### PR TITLE
Scaffold buf toolchain and AgentConfig proto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Generated protobuf code — the .proto files are the source of truth.
+# Regenerate with `buf generate`.
+/gen/

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,0 +1,19 @@
+# buf.gen.yaml — code generation config.
+# Docs: https://buf.build/docs/configuration/v2/buf-gen-yaml
+#
+# Targets Python via Buf's remote plugins (no local protoc plugins to install):
+#   - protocolbuffers/python -> *_pb2.py   (message classes)
+#   - protocolbuffers/pyi     -> *_pb2.pyi  (type stubs for IDEs / mypy)
+#
+# No managed mode: that mainly fixes Go's go_package / Java's java_package, which
+# Python doesn't have, so the .proto files stay language-neutral on their own.
+#
+# No RPC plugin yet — these are messages only. When the first service lands we
+# add the RPC stub plugin (buf.build/grpc/python or a Connect plugin, depending
+# on the gRPC-vs-Connect decision).
+version: v2
+plugins:
+  - remote: buf.build/protocolbuffers/python
+    out: gen/python
+  - remote: buf.build/protocolbuffers/pyi
+    out: gen/python

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,0 +1,11 @@
+# buf.yaml — module + lint/breaking config for the Funky protobufs.
+# Docs: https://buf.build/docs/configuration/v2/buf-yaml
+version: v2
+modules:
+  - path: proto
+lint:
+  use:
+    - STANDARD
+breaking:
+  use:
+    - FILE

--- a/proto/funky/type/v1/agent.proto
+++ b/proto/funky/type/v1/agent.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package funky.type.v1;
+
+// AgentConfig is the specification of an agent: the model it runs on, the
+// system prompt that steers it, and a human-readable name.
+//
+// It is the unit a ConfigRegistry stores and hands back by id. AgentConfig is
+// intentionally a pure spec and carries no server-assigned id — the id is the
+// registry's handle, returned from create and supplied to get.
+message AgentConfig {
+  // Human-readable name for the agent. Not unique; for display and debugging.
+  string name = 1;
+
+  // Model identifier the agent runs on, e.g. "gemini-3.5-flash".
+  string model = 2;
+
+  // System prompt that defines the agent's behavior and persona.
+  string system_prompt = 3;
+}


### PR DESCRIPTION
Bootstraps the Funky protobufs with a buf v2 setup: a module rooted at `proto/` with `STANDARD` lint and `FILE` breaking-change checks (`buf.yaml`), plus Python codegen via buf remote plugins (`buf.gen.yaml`). Adds the first shared message, `funky.type.v1.AgentConfig` (`name`, `model`, `system_prompt`), as a pure spec with no server-assigned id. Gitignores the generated `gen/` tree so the `.proto` files stay the source of truth (regenerate with `buf generate`). Verified with `buf lint`, `buf build`, and `buf generate` all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)