### PR TITLE
Add empty EnvironmentConfig proto

### DIFF
--- a/proto/funky/type/v1/environment.proto
+++ b/proto/funky/type/v1/environment.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package funky.type.v1;
+
+// EnvironmentConfig is the specification of where a session runs — the sandbox
+// it gets and how that sandbox is provisioned.
+//
+// Like AgentConfig, it is a pure spec stored by a ConfigRegistry and referenced
+// by id; it carries no server-assigned id of its own.
+//
+// It is intentionally empty for now: the default environment needs no
+// configuration, and a zero-field message is valid protobuf. Fields (sandbox
+// image, resource limits, vendor selection, ...) will be added as the
+// SandboxRuntime contract takes shape — adding fields to a proto message is a
+// backward-compatible change, so starting empty costs nothing.
+message EnvironmentConfig {}


### PR DESCRIPTION
Adds `funky.type.v1.EnvironmentConfig` as an intentionally empty message — the default environment needs no configuration, and a zero-field message is valid protobuf. Uses a named message rather than `google.protobuf.Empty` so fields (sandbox image, resource limits, vendor selection) can be added later as a backward-compatible change; the doc comment records why it's empty. Verified with `buf lint`, `buf build`, and `buf generate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)