### PR TITLE
Add Event proto for session history

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Funky factors a cloud agent into **four small interfaces**. Implement, or pick, 
 Funky is built from four small interfaces, plus a thin **Client** that wires them together:
 
 - **ConfigRegistry** stores and retrieves agent and environment configs.
-- **SessionStore** creates sessions and appends/reads their item history.
+- **SessionStore** creates sessions and appends/reads their event history.
 - **SandboxRuntime** creates, executes in, and destroys sandboxes.
 - **AgentService** runs a single turn of the agent loop against a sandbox.
 - **Client** is the orchestrator developers actually call; it resolves ids → configs and coordinates the four services.

--- a/proto/funky/type/v1/event.proto
+++ b/proto/funky/type/v1/event.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+package funky.type.v1;
+
+import "google/protobuf/timestamp.proto";
+
+// Event is one entry in a session's append-only history.
+//
+// The payload oneof is the envelope's discriminator; new kinds (tool uses, tool
+// results, status updates, ...) are added as new oneof fields without breaking
+// existing ones. The starting set is a user turn in and an agent turn out.
+message Event {
+  // Stable identifier, assigned on append. Addresses the event in history and
+  // de-duplicates it on stream reconnect.
+  string id = 1;
+
+  // When the event was recorded, set by the SessionStore on append. Unset while
+  // still queued. Serializes to an RFC 3339 string in proto3 JSON.
+  google.protobuf.Timestamp processed_at = 4;
+
+  oneof payload {
+    // A turn sent into the session on behalf of the user.
+    UserMessage user_message = 2;
+
+    // A turn produced by the agent.
+    AgentMessage agent_message = 3;
+  }
+}
+
+// UserMessage is a prompt from the end user.
+message UserMessage {
+  repeated ContentBlock content = 1;
+}
+
+// AgentMessage is a response from the agent.
+message AgentMessage {
+  repeated ContentBlock content = 1;
+}
+
+// ContentBlock is one piece of a message's content. The block oneof discriminates
+// the kind of content; new kinds (image, document, ...) are added as new oneof
+// fields, and each block being its own message lets it grow fields of its own.
+message ContentBlock {
+  oneof block {
+    TextBlock text = 1;
+  }
+}
+
+// TextBlock is a run of plain text.
+message TextBlock {
+  string text = 1;
+}


### PR DESCRIPTION
## What

Adds `funky.type.v1.Event` — the unit of a session's append-only history — to the type package, alongside the existing `AgentConfig` and `EnvironmentConfig`.

```proto
Event        { id; processed_at; oneof payload { UserMessage | AgentMessage } }
UserMessage  { repeated ContentBlock content }
AgentMessage { repeated ContentBlock content }
ContentBlock { oneof block { TextBlock text } }
TextBlock    { text }
```

A turn is two events: a `user_message` in, an `agent_message` out.

## Design notes

- **Two envelopes, two growth seams.** `Event.payload` admits new event *kinds* (tool use/result, status) later; `ContentBlock.block` admits new content *kinds* (image, document). Both are backward-compatible oneof additions, so nothing here is boxed in. Modeled on Claude's [managed-agents session events](https://platform.claude.com/docs/en/managed-agents/events-and-streaming).
- **Content as blocks, not a bare string** — for extensibility on two axes: new block types via the oneof, and new fields on a block (e.g. citations on text) by keeping `TextBlock` a message.
- **`processed_at` is `google.protobuf.Timestamp`** (first import in the repo; a bundled well-known type). Proto3 JSON serializes it to the RFC 3339 string the reference uses; unset = still queued.
- **`UserMessage` and `AgentMessage` share `ContentBlock`** — deliberately *not* enforcing "agent = text-only" at the type level. The producer (AgentService, server-side) upholds that invariant, and a single content type is simpler for everything that renders/logs/persists content. Revisit only if agent messages can come from untrusted sources.

Also updates the README to call the session log an **event** history (was "item").

`buf build` and `buf lint` pass.