### PR TITLE
Add Session proto and link Events to their session

### DIFF
--- a/proto/funky/type/v1/event.proto
+++ b/proto/funky/type/v1/event.proto
@@ -14,6 +14,9 @@ message Event {
   // de-duplicates it on stream reconnect.
   string id = 1;
 
+  // The session this event belongs to.
+  string session_id = 5;
+
   // When the event was recorded, set by the SessionStore on append. Unset while
   // still queued. Serializes to an RFC 3339 string in proto3 JSON.
   google.protobuf.Timestamp processed_at = 4;

--- a/proto/funky/type/v1/session.proto
+++ b/proto/funky/type/v1/session.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package funky.type.v1;
+
+import "funky/type/v1/agent.proto";
+
+// Session is a running agent instance: one agent in one environment, working a
+// task and accumulating an Event history.
+//
+// The agent is snapshotted into the session — a resolved AgentConfig frozen at
+// creation, so later registry edits don't reach a live session and session-local
+// changes don't propagate back. The environment stays a reference by id. The
+// Event history lives in the SessionStore and is read separately, not here.
+message Session {
+  // SessionStore-assigned identifier.
+  string id = 1;
+
+  // The agent this session runs, snapshotted at creation.
+  AgentConfig agent_config = 2;
+
+  // EnvironmentConfig this session runs in, by ConfigRegistry id.
+  string environment_config_id = 3;
+}


### PR DESCRIPTION
## What

Adds `funky.type.v1.Session` and links each `Event` to its session.

- **`session.proto`** — `Session`: a stored record with a SessionStore-assigned `id`, an **embedded `AgentConfig` snapshot** (frozen at creation), and an `environment_config_id` **reference**.
- **`event.proto`** — adds `session_id` to `Event` so each event names the session it belongs to.

## Design notes

- **Snapshot the agent, reference the environment.** Mirrors `BetaManagedAgentsSession`: the agent is denormalized into the session — a resolved copy pinned at creation — so later ConfigRegistry edits can't mutate a live session and session-local changes can't leak back; the environment stays a reference by id. This is also what makes future session-local config (e.g. mid-session tool updates) representable.
- **`session_id` is a plain string id**, not an import of `session.proto` — the two files stay independent.

Follows #5 (the `Event` envelope), now merged to `main`.

`buf build` and `buf lint` pass.