### PR TITLE
Add ConfigRegistry gRPC service

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -2,18 +2,17 @@
 # Docs: https://buf.build/docs/configuration/v2/buf-gen-yaml
 #
 # Targets Python via Buf's remote plugins (no local protoc plugins to install):
-#   - protocolbuffers/python -> *_pb2.py   (message classes)
-#   - protocolbuffers/pyi     -> *_pb2.pyi  (type stubs for IDEs / mypy)
+#   - protocolbuffers/python  -> *_pb2.py        (message classes)
+#   - protocolbuffers/pyi     -> *_pb2.pyi       (type stubs for IDEs / mypy)
+#   - grpc/python             -> *_pb2_grpc.py   (gRPC service stubs)
 #
-# No managed mode: that mainly fixes Go's go_package / Java's java_package, which
-# Python doesn't have, so the .proto files stay language-neutral on their own.
-#
-# No RPC plugin yet — these are messages only. When the first service lands we
-# add the RPC stub plugin (buf.build/grpc/python or a Connect plugin, depending
-# on the gRPC-vs-Connect decision).
+# RPC stubs are gRPC. The .proto service definitions are protocol-neutral,
+# so a Connect plugin could be swapped in later without touching them.
 version: v2
 plugins:
   - remote: buf.build/protocolbuffers/python
     out: gen/python
   - remote: buf.build/protocolbuffers/pyi
+    out: gen/python
+  - remote: buf.build/grpc/python
     out: gen/python

--- a/buf.yaml
+++ b/buf.yaml
@@ -6,6 +6,11 @@ modules:
 lint:
   use:
     - STANDARD
+  except:
+    # Services are named for the interfaces in the README (ConfigRegistry,
+    # SessionStore, SandboxRuntime, AgentService), not all of which end in
+    # "Service". Drop the suffix requirement to keep the proto names aligned.
+    - SERVICE_SUFFIX
 breaking:
   use:
     - FILE

--- a/proto/funky/registry/v1/config_registry.proto
+++ b/proto/funky/registry/v1/config_registry.proto
@@ -1,0 +1,57 @@
+syntax = "proto3";
+
+package funky.registry.v1;
+
+import "funky/type/v1/agent.proto";
+import "funky/type/v1/environment.proto";
+
+// ConfigRegistry stores agent and environment configs and hands them back by
+// id. Configs are write-once specs: create stores one and returns its id, get
+// resolves an id back to the stored config.
+service ConfigRegistry {
+  // Store an AgentConfig and return its id.
+  rpc CreateAgent(CreateAgentRequest) returns (CreateAgentResponse);
+
+  // Resolve an AgentConfig by id.
+  rpc GetAgent(GetAgentRequest) returns (GetAgentResponse);
+
+  // Store an EnvironmentConfig and return its id.
+  rpc CreateEnvironment(CreateEnvironmentRequest) returns (CreateEnvironmentResponse);
+
+  // Resolve an EnvironmentConfig by id.
+  rpc GetEnvironment(GetEnvironmentRequest) returns (GetEnvironmentResponse);
+}
+
+message CreateAgentRequest {
+  funky.type.v1.AgentConfig config = 1;
+}
+
+message CreateAgentResponse {
+  // Registry-assigned id for the stored config.
+  string id = 1;
+}
+
+message GetAgentRequest {
+  string id = 1;
+}
+
+message GetAgentResponse {
+  funky.type.v1.AgentConfig config = 1;
+}
+
+message CreateEnvironmentRequest {
+  funky.type.v1.EnvironmentConfig config = 1;
+}
+
+message CreateEnvironmentResponse {
+  // Registry-assigned id for the stored config.
+  string id = 1;
+}
+
+message GetEnvironmentRequest {
+  string id = 1;
+}
+
+message GetEnvironmentResponse {
+  funky.type.v1.EnvironmentConfig config = 1;
+}


### PR DESCRIPTION
Adds `funky.registry.v1.ConfigRegistry`, a gRPC service that stores and resolves agent and environment configs by id — `CreateAgent`/`GetAgent` and `CreateEnvironment`/`GetEnvironment`, each with a dedicated request/response message in a new `funky.registry.v1` package (one package per interface). Wires up the `buf.build/grpc/python` codegen plugin in `buf.gen.yaml` so gRPC service stubs (`*_pb2_grpc.py`) are generated. Relaxes `SERVICE_SUFFIX` in `buf.yaml` so the service is named `ConfigRegistry`, matching the interface name in the README. `buf build`, `buf lint`, and `buf generate` all pass.