### PR TITLE
Add SandboxRuntime gRPC service

### DIFF
--- a/proto/funky/sandbox/v1/sandbox_runtime.proto
+++ b/proto/funky/sandbox/v1/sandbox_runtime.proto
@@ -1,0 +1,69 @@
+syntax = "proto3";
+
+package funky.sandbox.v1;
+
+import "funky/type/v1/agent.proto";
+import "funky/type/v1/environment.proto";
+import "funky/type/v1/sandbox.proto";
+
+// SandboxRuntime creates, executes in, and destroys sandboxes. It owns the
+// lifecycle of the isolated environments an agent's commands run in.
+//
+// It works in resolved specs, not stored ids: create takes an EnvironmentConfig
+// inline, so the runtime never talks to a ConfigRegistry and knows nothing about
+// sessions. What backs it — Docker, Firecracker, gVisor, Kubernetes Jobs, or a
+// remote provider — is an implementation detail behind this contract.
+service SandboxRuntime {
+  // Create a sandbox from a resolved environment config.
+  rpc CreateSandbox(CreateSandboxRequest) returns (CreateSandboxResponse);
+
+  // Run a command inside a sandbox and return its result.
+  rpc ExecCommand(ExecCommandRequest) returns (ExecCommandResponse);
+
+  // Destroy a sandbox and release its resources.
+  rpc DestroySandbox(DestroySandboxRequest) returns (DestroySandboxResponse);
+}
+
+message CreateSandboxRequest {
+  // Resolved agent to provision into the sandbox. At creation the runtime loads
+  // the agent's skills onto the sandbox's local disk, so they are in place
+  // before any command runs.
+  funky.type.v1.AgentConfig agent_config = 1;
+
+  // Resolved environment the sandbox is provisioned from.
+  funky.type.v1.EnvironmentConfig environment_config = 2;
+}
+
+message CreateSandboxResponse {
+  // The created sandbox, with its runtime-assigned id.
+  funky.type.v1.Sandbox sandbox = 1;
+}
+
+message ExecCommandRequest {
+  // Sandbox to run the command in.
+  string sandbox_id = 1;
+
+  // Command to run, argv-style: the program followed by each argument as its
+  // own element. Executed directly, not through a shell, so there is no quoting
+  // or word-splitting to reason about.
+  repeated string command = 2;
+}
+
+message ExecCommandResponse {
+  // Process exit code. 0 conventionally means success.
+  int32 exit_code = 1;
+
+  // Raw bytes the command wrote to standard output. Bytes, not a string, since
+  // command output is not guaranteed to be valid UTF-8.
+  bytes stdout = 2;
+
+  // Raw bytes the command wrote to standard error.
+  bytes stderr = 3;
+}
+
+message DestroySandboxRequest {
+  // Sandbox to destroy.
+  string sandbox_id = 1;
+}
+
+message DestroySandboxResponse {}

--- a/proto/funky/type/v1/sandbox.proto
+++ b/proto/funky/type/v1/sandbox.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package funky.type.v1;
+
+// Sandbox is a live, isolated execution environment a SandboxRuntime hands out:
+// the place an agent's commands actually run.
+//
+// Unlike EnvironmentConfig — a pure spec stored in a ConfigRegistry — a Sandbox
+// is a running resource. The runtime returns one from create, addresses it by
+// id for exec, and tears it down on destroy. It carries no spec of its own; the
+// EnvironmentConfig it was provisioned from stays the caller's concern.
+//
+// It holds only an id for now. Runtime-observable state (status, a connection
+// endpoint, ...) will be added as backends need it — appending fields is a
+// backward-compatible change.
+message Sandbox {
+  // SandboxRuntime-assigned identifier. Addresses the sandbox for exec and
+  // destroy.
+  string id = 1;
+}


### PR DESCRIPTION
Adds the `SandboxRuntime` service — the third of Funky's four interfaces — which creates, executes in, and destroys sandboxes. `CreateSandbox` takes resolved agent and environment configs inline (the agent so the runtime can load its skills onto the sandbox's local disk), `ExecCommand` runs an argv command and returns the exit code plus stdout/stderr, and `DestroySandbox` releases it. Also adds a `Sandbox` live-resource type in `funky.type.v1`, alongside `Session`. Follows the existing proto conventions and passes `buf lint`, `build`, `breaking`, and `generate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)