### PR TITLE
Add AgentService streaming service and Sandbox type

### DIFF
--- a/proto/funky/agent/v1/agent_service.proto
+++ b/proto/funky/agent/v1/agent_service.proto
@@ -1,0 +1,36 @@
+syntax = "proto3";
+
+package funky.agent.v1;
+
+import "funky/type/v1/agent.proto";
+import "funky/type/v1/event.proto";
+import "funky/type/v1/sandbox.proto";
+
+// AgentService runs a single turn of the agent loop. Given an agent, the
+// conversation so far, a new prompt, and a sandbox to act in, it streams back
+// the events the agent produces. It holds no state across turns — the prior
+// events are passed in, not stored — and reaches the sandbox through the
+// SandboxRuntime.
+service AgentService {
+  // Run one turn against a sandbox, streaming the events the agent produces.
+  rpc RunTurn(RunTurnRequest) returns (stream RunTurnResponse);
+}
+
+message RunTurnRequest {
+  // The agent to run.
+  funky.type.v1.AgentConfig agent_config = 1;
+
+  // The conversation so far, in order.
+  repeated funky.type.v1.Event events = 2;
+
+  // The new user input that starts this turn.
+  funky.type.v1.UserMessage prompt = 3;
+
+  // The sandbox the turn acts in.
+  funky.type.v1.Sandbox sandbox = 4;
+}
+
+message RunTurnResponse {
+  // One event produced during the turn.
+  funky.type.v1.Event event = 1;
+}

--- a/proto/funky/type/v1/sandbox.proto
+++ b/proto/funky/type/v1/sandbox.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package funky.type.v1;
+
+// Sandbox is a handle to the isolated environment a session's turns run in. The
+// SandboxRuntime creates it from an EnvironmentConfig, runs commands in it, and
+// destroys it; the AgentService runs a turn against it.
+//
+// A handle for now — just the id the SandboxRuntime addresses it by. Connection
+// and status details are added as the SandboxRuntime contract takes shape.
+message Sandbox {
+  // Runtime-assigned identifier for the sandbox.
+  string id = 1;
+}


### PR DESCRIPTION
Adds `funky.agent.v1.AgentService`, whose server-streaming `RunTurn` rpc runs one turn of the agent loop — given the agent, the prior `events`, a `prompt`, and a `sandbox` — and streams back the events the agent produces, holding no state across turns. Introduces a minimal shared `funky.type.v1.Sandbox` handle (id only) that `RunTurn` references; the SandboxRuntime (the remaining interface) will flesh it out and own its lifecycle. `buf build`, `buf lint`, and `buf generate` (Connect codegen) all pass.