### PR TITLE
Add AgentToolUse event for agent tool calls

### DIFF
--- a/agent_service/local_python_anthropic/README.md
+++ b/agent_service/local_python_anthropic/README.md
@@ -19,14 +19,14 @@ appends them to history.
 ## Text-only, for now
 
 This turn is text in, text out. It accepts the `Sandbox` from the request but
-does not yet run anything in it, because tools need event kinds the protocol does
-not have yet: the `Event` proto carries only user and agent text messages, with
-no tool-use or tool-result blocks to stream. Once those land, this is the place
-the `AgentService ..> SandboxRuntime : exec` edge from the architecture gets
-wired — the agent gains a tool, runs commands in the sandbox through a
-`SandboxRuntime` client, and emits the tool events the proto can finally express.
-The sandbox is accepted today so this stays that seam (the same way the Docker
-runtime accepts an agent whose skills it can't load yet).
+does not yet run anything in it. The `Event` proto now has an `AgentToolUse`
+event for the agent's tool calls, but the loop doesn't emit one yet, and there is
+still no tool-result event to feed a call's output back into the conversation.
+Once tool use is wired — the `AgentService ..> SandboxRuntime : exec` edge from
+the architecture — this is where the agent gains a tool, runs commands in the
+sandbox through a `SandboxRuntime` client, and emits `AgentToolUse` (and, later,
+tool-result) events. The sandbox is accepted today so this stays that seam (the
+same way the Docker runtime accepts an agent whose skills it can't load yet).
 
 ## Requirements
 

--- a/proto/funky/type/v1/event.proto
+++ b/proto/funky/type/v1/event.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package funky.type.v1;
 
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
 // Event is one entry in a session's append-only history.
@@ -27,6 +28,9 @@ message Event {
 
     // A turn produced by the agent.
     AgentMessage agent_message = 3;
+
+    // A built-in tool call the agent made during its turn.
+    AgentToolUse agent_tool_use = 6;
   }
 }
 
@@ -52,4 +56,23 @@ message ContentBlock {
 // TextBlock is a run of plain text.
 message TextBlock {
   string text = 1;
+}
+
+// AgentToolUse is one built-in tool call the agent made during a turn: which
+// tool, and with what input.
+//
+// Like UserMessage and AgentMessage, it is a payload of an Event, so the call's
+// identity and timing live on the Event envelope (id, processed_at), not here. A
+// tool call and its result are separate events — the result comes back as its
+// own payload (a tool-result kind, added when the first backend needs it), the
+// same way the agent's text and its tool calls arrive as distinct events rather
+// than nested in one message. How a call's permission was resolved (allow / ask /
+// deny) is a later addition, once a backend gates tools; field 3 is left for it.
+message AgentToolUse {
+  // Name of the tool being invoked.
+  string name = 1;
+
+  // Input arguments for the call, an arbitrary JSON object. Struct is proto's
+  // JSON-object type, so this round-trips through proto3 JSON unchanged.
+  google.protobuf.Struct input = 2;
 }


### PR DESCRIPTION
Adds an `AgentToolUse` payload to the `Event` oneof so the protocol can represent a built-in tool call the agent makes during a turn, carrying the tool `name` and its `input` arguments as a `google.protobuf.Struct` — proto's arbitrary-JSON-object type, matching the open `string → value` shape tool arguments have. The call's id and timing come from the `Event` envelope, the same as the existing message payloads. Permission evaluation (allow/ask/deny) is intentionally deferred, with field 3 left free for it. This also updates the Anthropic backend README note to reflect that the proto now has a tool-use event (the loop still doesn't emit one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)