### PR TITLE
Add AgentToolResult event for tool call results

### DIFF
--- a/agent_service/local_python_anthropic/README.md
+++ b/agent_service/local_python_anthropic/README.md
@@ -19,13 +19,13 @@ appends them to history.
 ## Text-only, for now
 
 This turn is text in, text out. It accepts the `Sandbox` from the request but
-does not yet run anything in it. The `Event` proto now has an `AgentToolUse`
-event for the agent's tool calls, but the loop doesn't emit one yet, and there is
-still no tool-result event to feed a call's output back into the conversation.
-Once tool use is wired — the `AgentService ..> SandboxRuntime : exec` edge from
-the architecture — this is where the agent gains a tool, runs commands in the
-sandbox through a `SandboxRuntime` client, and emits `AgentToolUse` (and, later,
-tool-result) events. The sandbox is accepted today so this stays that seam (the
+does not yet run anything in it. The `Event` proto now has the `AgentToolUse` and
+`AgentToolResult` events that tool calls need, but the loop doesn't emit them —
+it has no tools and never reaches the sandbox. Once tool use is wired — the
+`AgentService ..> SandboxRuntime : exec` edge from the architecture — this is
+where the agent gains a tool, runs commands in the sandbox through a
+`SandboxRuntime` client, and emits an `AgentToolUse` followed by its
+`AgentToolResult`. The sandbox is accepted today so this stays that seam (the
 same way the Docker runtime accepts an agent whose skills it can't load yet).
 
 ## Requirements

--- a/proto/funky/type/v1/event.proto
+++ b/proto/funky/type/v1/event.proto
@@ -31,6 +31,9 @@ message Event {
 
     // A built-in tool call the agent made during its turn.
     AgentToolUse agent_tool_use = 6;
+
+    // The result of one such tool call.
+    AgentToolResult agent_tool_result = 7;
   }
 }
 
@@ -64,10 +67,10 @@ message TextBlock {
 // Like UserMessage and AgentMessage, it is a payload of an Event, so the call's
 // identity and timing live on the Event envelope (id, processed_at), not here. A
 // tool call and its result are separate events — the result comes back as its
-// own payload (a tool-result kind, added when the first backend needs it), the
-// same way the agent's text and its tool calls arrive as distinct events rather
-// than nested in one message. How a call's permission was resolved (allow / ask /
-// deny) is a later addition, once a backend gates tools; field 3 is left for it.
+// own payload (an AgentToolResult), the same way the agent's text and its tool
+// calls arrive as distinct events rather than nested in one message. How a call's
+// permission was resolved (allow / ask / deny) is a later addition, once a backend
+// gates tools; field 3 is left for it.
 message AgentToolUse {
   // Name of the tool being invoked.
   string name = 1;
@@ -75,4 +78,23 @@ message AgentToolUse {
   // Input arguments for the call, an arbitrary JSON object. Struct is proto's
   // JSON-object type, so this round-trips through proto3 JSON unchanged.
   google.protobuf.Struct input = 2;
+}
+
+// AgentToolResult is the outcome of one AgentToolUse: what the tool returned, and
+// whether it failed.
+//
+// Like the other payloads, it is carried by an Event, so its own id and timing
+// live on the Event envelope. It points back to the call it answers by that
+// call's Event id (tool_use_id), pairing a result with its tool use. The content
+// reuses ContentBlock, so a result is text today and grows image/document/...
+// blocks exactly as ContentBlock does.
+message AgentToolResult {
+  // Event id of the AgentToolUse this result answers.
+  string tool_use_id = 1;
+
+  // What the tool returned, in order.
+  repeated ContentBlock content = 2;
+
+  // Whether the tool execution failed. False (the default) means success.
+  bool is_error = 3;
 }


### PR DESCRIPTION
Adds an `AgentToolResult` payload to the `Event` oneof so the protocol can represent the outcome of an `AgentToolUse`. It links back to the call by that call's `Event` id (`tool_use_id`), carries what the tool returned as `repeated ContentBlock` — reusing the existing extensible content type, so text works today and image/document blocks grow on `ContentBlock` later — and flags failure with `is_error`. Its own id and timing come from the `Event` envelope, the same as the other payloads. This also refreshes two now-stale doc notes: the `AgentToolUse` comment (its result kind now exists) and the Anthropic backend README (the proto now has both tool events, though the loop still emits neither).

🤖 Generated with [Claude Code](https://claude.com/claude-code)