### PR TITLE
Wire the agent to run tools in the sandbox

### DIFF
--- a/agent_service/local_python_anthropic/README.md
+++ b/agent_service/local_python_anthropic/README.md
@@ -5,34 +5,43 @@ that runs one agent turn against the [Anthropic](https://docs.anthropic.com/)
 Messages API — no agent platform, no managed loop, just a direct call to the
 model from your machine.
 
-`RunTurn` takes the agent, the conversation so far, and a new prompt; converts
-the prior events plus the prompt into Anthropic messages (with the agent's `model`
-and `system_prompt`); calls the Messages API; and returns the reply as one
-`AgentMessage` event per text block the model produces. It is unary — one request,
-one response holding all of the turn's events.
+`RunTurn` takes the agent, the conversation so far, and a new prompt, and runs one
+turn of an agentic loop: it converts the prior events plus the prompt into
+Anthropic messages (with the agent's `model` and `system_prompt`), gives the model
+a `bash` tool, and calls the Messages API. Every command the model runs is
+executed in the request's `Sandbox` and fed back, looping until the model stops
+calling tools. It is unary — one request, one response holding all of the turn's
+events: an `AgentMessage` per text block, and an `AgentToolUse` + `AgentToolResult`
+pair per command.
 
 The turn is stateless, exactly as the contract requires — the prior events are
 passed in, never stored — and the events it emits are payload-only: the
-`SessionStore` assigns their id, session_id, and processed_at when the Client
-appends them to history.
+`SessionStore` assigns their Event id, session_id, and processed_at when the
+Client appends them to history. (A result is matched to its call by the call's own
+`AgentToolUse.id`, which the loop sets — distinct from the Event id.)
 
-## Text-only, for now
+## Tools: running in the sandbox
 
-This turn is text in, text out. It accepts the `Sandbox` from the request but
-does not yet run anything in it. The `Event` proto now has the `AgentToolUse` and
-`AgentToolResult` events that tool calls need, but the loop doesn't emit them —
-it has no tools and never reaches the sandbox. Once tool use is wired — the
-`AgentService ..> SandboxRuntime : exec` edge from the architecture — this is
-where the agent gains a tool, runs commands in the sandbox through a
-`SandboxRuntime` client, and emits an `AgentToolUse` followed by its
-`AgentToolResult`. The sandbox is accepted today so this stays that seam (the
-same way the Docker runtime accepts an agent whose skills it can't load yet).
+The agent gets one tool, `bash`: run a shell command in the sandbox. When the
+model calls it, the loop execs `bash -c <command>` in the request's sandbox
+through a `SandboxRuntime` client (`--sandbox-runtime-url`), packages the combined
+stdout/stderr as an `AgentToolResult` (`is_error` set on a non-zero exit or a
+failed exec), and feeds it back to the model — this is the
+`AgentService ..> SandboxRuntime : exec` edge from the architecture. The loop caps
+the number of tool rounds per turn so a model can't loop forever. The sandbox
+image must have `bash`; the Docker runtime's default `python:3.12-slim` does.
 
 ## Requirements
 
-An Anthropic API key. The default client reads `ANTHROPIC_API_KEY` from the
-environment; the model named in each request's `AgentConfig.model` must be one
-your key can call. Everything else runs locally.
+- An Anthropic API key. The default client reads `ANTHROPIC_API_KEY` from the
+  environment; the model named in each request's `AgentConfig.model` must be one
+  your key can call.
+- A reachable [`SandboxRuntime`](../../proto/funky/sandbox/v1/sandbox_runtime.proto)
+  for the agent to exec its tools in. Point at it with `--sandbox-runtime-url`,
+  which defaults to the [local Docker backend](../../sandbox_runtime/local_python_docker)'s
+  `http://127.0.0.1:8082`.
+
+Otherwise everything runs locally.
 
 ## Run it
 
@@ -42,7 +51,12 @@ From the repository root:
 buf generate            # regenerate the protobuf/ConnectRPC stubs into gen/python
 uv sync                 # create the workspace venv and install the backend + deps
 export ANTHROPIC_API_KEY=sk-ant-...
-uv run funky-agent-service-anthropic --port 8083
+
+# In one shell: a SandboxRuntime for the agent to exec tools in.
+uv run funky-sandbox-runtime-docker --port 8082
+
+# In another: the AgentService, pointed at it.
+uv run funky-agent-service-anthropic --port 8083 --sandbox-runtime-url http://127.0.0.1:8082
 ```
 
 The server runs on [waitress](https://github.com/Pylons/waitress) (pure Python)
@@ -56,12 +70,16 @@ makes a real, billed request to Anthropic:
 curl -X POST http://127.0.0.1:8083/funky.agent.v1.AgentService/RunTurn \
   -H 'Content-Type: application/json' \
   -d '{
-        "agentConfig": {"name":"researcher","model":"claude-sonnet-4-6","systemPrompt":"You are a careful research assistant."},
-        "prompt": {"content":[{"text":{"text":"In one sentence, what is a protobuf?"}}]},
-        "sandbox": {"id":"sbx_unused"}
+        "agentConfig": {"name":"coder","model":"claude-sonnet-4-6","systemPrompt":"You are a careful coding assistant."},
+        "prompt": {"content":[{"text":{"text":"Use bash to print the Python version, then tell me what it is."}}]},
+        "sandbox": {"id":"sbx_..."}
       }'
-# -> {"events":[{"agentMessage":{"content":[{"text":{"text":"..."}}]}}]}
+# -> {"events":[{"agentToolUse":{...}},{"agentToolResult":{...}},{"agentMessage":{...}}]}
 ```
+
+The `sandbox.id` must be a live sandbox from the same `SandboxRuntime` — create one
+first with its `CreateSandbox` (see that backend's README). A prompt the agent can
+answer without a tool never touches the sandbox.
 
 ## Test
 
@@ -70,8 +88,10 @@ uv run pytest agent_service/local_python_anthropic
 ```
 
 The test boots the server on an ephemeral port and drives `RunTurn` through the
-generated ConnectRPC client, covering the response holding every event the turn
-produced, the payload-only invariant on those events, the history → Anthropic
-messages translation (model, system prompt, role order, prompt appended last), and
-the empty-system-prompt-omitted case. A fake Anthropic client stands in for the
-model, so it needs no API key and makes no network calls.
+generated ConnectRPC client, covering a text-only turn, a tool-use turn (the bash
+command reaching the sandbox with the right argv, the `AgentToolUse`/
+`AgentToolResult` events, and the result fed back to the model), a failed command
+flagged with `is_error`, prior tool events round-tripping back into a valid
+Anthropic exchange, the history translation, and the empty-system-prompt case. A
+fake Anthropic client and a fake SandboxRuntime stand in for the model and the
+sandbox, so it needs no API key, no Docker, and no network.

--- a/agent_service/local_python_anthropic/src/funky_agent_service_anthropic/loop.py
+++ b/agent_service/local_python_anthropic/src/funky_agent_service_anthropic/loop.py
@@ -1,38 +1,80 @@
 """The agent turn itself: prior history + a new prompt -> the agent's events.
 
-Stateless by construction, exactly as the AgentService contract requires — the
-turn holds nothing across calls. Each ``run_turn`` converts the Events passed in
-into Anthropic Messages, asks the model for one response, and yields it back as
-``AgentMessage`` Events (the service collects them into the RunTurn response).
+This is a real tool-use loop. The agent is given a single ``bash`` tool; each
+round it calls the model, and for every tool call the model makes it runs the
+command in the sandbox through a SandboxRuntime client and feeds the result back,
+looping until the model stops calling tools. This is the
+``AgentService ..> SandboxRuntime : exec`` edge from the architecture.
 
-The Anthropic client is injected rather than constructed here, so the turn can be
-driven by the real Messages API in production and a fake in tests — the same seam
-the Docker runtime uses for its Docker client. This module never imports
-``anthropic``: it only speaks the Messages API's data shapes (a ``messages.create``
-call and a response whose ``.content`` is a list of typed blocks), which keeps it
-trivially fakeable.
+The turn is stateless, as the AgentService contract requires — prior events are
+passed in, never stored — and the Events it yields are payload-only: their Event
+id, session_id, and processed_at are the SessionStore's to assign on append.
+(``AgentToolUse.id`` is a different thing — the tool call's own handle, used to
+pair a result with its call within the turn.)
+
+Both clients are injected so the turn can run against the real Anthropic API and a
+real SandboxRuntime in production, and against fakes in tests. The module speaks
+the Anthropic Messages API's data shapes (a ``messages.create`` call, a response
+whose ``.content`` is a list of typed blocks) rather than importing ``anthropic``,
+which keeps it trivially fakeable.
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
 
+from connectrpc.errors import ConnectError
+from google.protobuf import json_format
+
+from funky.sandbox.v1 import sandbox_runtime_pb2
 from funky.type.v1 import agent_pb2, event_pb2, sandbox_pb2
 
 # Anthropic requires an explicit output cap on every request. 4096 is generous
 # for a single chat turn and well under every current Claude model's ceiling; a
 # `max_tokens` field on AgentConfig is the natural place to make this per-agent
-# later, the same way an `image` field on EnvironmentConfig would override the
-# sandbox base image.
+# later.
 DEFAULT_MAX_TOKENS = 4096
+
+# Safety cap on tool-use rounds in one turn, so a model that keeps calling tools
+# can't loop forever. Each round is one model call plus the tool calls it makes.
+DEFAULT_MAX_ITERATIONS = 50
+
+# The one tool the agent gets: run a shell command in the sandbox. Its input is
+# an arbitrary JSON object per the schema; the model fills in `command`.
+BASH_TOOL = {
+    "name": "bash",
+    "description": (
+        "Run a shell command inside the sandbox and return its combined "
+        "stdout and stderr."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "command": {
+                "type": "string",
+                "description": "The shell command to run.",
+            },
+        },
+        "required": ["command"],
+    },
+}
 
 
 class AnthropicAgentLoop:
-    """One agent turn backed by the Anthropic Messages API."""
+    """One agent turn backed by the Anthropic Messages API and a sandbox."""
 
-    def __init__(self, client, *, max_tokens: int = DEFAULT_MAX_TOKENS) -> None:
+    def __init__(
+        self,
+        client,
+        sandbox_client,
+        *,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+        max_iterations: int = DEFAULT_MAX_ITERATIONS,
+    ) -> None:
         self._client = client
+        self._sandbox = sandbox_client
         self._max_tokens = max_tokens
+        self._max_iterations = max_iterations
 
     def run_turn(
         self,
@@ -41,64 +83,159 @@ class AnthropicAgentLoop:
         prompt: event_pb2.UserMessage,
         sandbox: sandbox_pb2.Sandbox,
     ) -> Iterator[event_pb2.Event]:
-        """Run one turn and yield the agent's reply as ``AgentMessage`` Events.
+        """Run one turn and yield the Events the agent produces, in order.
 
-        ``sandbox`` is accepted but not yet acted in: the agent has no tools to
-        run there. Tool use — the ``AgentService ..> SandboxRuntime : exec`` edge
-        in the architecture — lands once the Event proto grows tool-use and
-        tool-result blocks to carry it; until then this is a text-only turn and
-        the sandbox is the documented seam for that next step. (The Docker runtime
-        accepts an agent whose skills it can't load yet for the same reason.)
-
-        The yielded Events carry only their payload. id, session_id, and
-        processed_at are the SessionStore's to assign when the Client appends the
-        events to history, so they are deliberately left unset here.
+        Text the model writes becomes an AgentMessage; every tool call becomes an
+        AgentToolUse followed by the AgentToolResult from running it in the
+        sandbox. The loop ends when the model finishes a response without calling
+        a tool (or the iteration cap is hit).
         """
-        messages: list[dict] = []
-        for event in events:
-            message = _to_message(event)
-            if message is not None:
-                messages.append(message)
-        messages.append(_user_message(prompt))
-
-        request: dict = {
+        messages = _to_messages(events, prompt)
+        request = {
             "model": agent_config.model,
             "max_tokens": self._max_tokens,
-            "messages": messages,
+            "tools": [BASH_TOOL],
         }
         # Omit `system` when empty rather than sending "": a blank system prompt
         # is a no-op, and leaving it off keeps the request minimal.
         if agent_config.system_prompt:
             request["system"] = agent_config.system_prompt
 
-        response = self._client.messages.create(**request)
-        for block in response.content:
-            if getattr(block, "type", None) == "text":
-                yield _agent_text_event(block.text)
+        for _ in range(self._max_iterations):
+            response = self._client.messages.create(messages=messages, **request)
+
+            assistant_content: list[dict] = []
+            tool_results: list[dict] = []
+            for block in response.content:
+                if getattr(block, "type", None) == "text":
+                    yield _agent_text_event(block.text)
+                    assistant_content.append({"type": "text", "text": block.text})
+                elif getattr(block, "type", None) == "tool_use":
+                    yield _agent_tool_use_event(block)
+                    assistant_content.append(
+                        {
+                            "type": "tool_use",
+                            "id": block.id,
+                            "name": block.name,
+                            "input": block.input,
+                        }
+                    )
+                    output, is_error = self._run_tool(sandbox.id, block)
+                    yield _agent_tool_result_event(block.id, output, is_error)
+                    tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": block.id,
+                            "content": output,
+                            "is_error": is_error,
+                        }
+                    )
+
+            messages.append({"role": "assistant", "content": assistant_content})
+            # No tool calls this round -> the turn is done.
+            if getattr(response, "stop_reason", None) != "tool_use":
+                return
+            messages.append({"role": "user", "content": tool_results})
+
+    def _run_tool(self, sandbox_id: str, block) -> tuple[str, bool]:
+        """Run a tool call in the sandbox; return (output, is_error).
+
+        Only ``bash`` exists today. A failed RPC or a non-zero exit is surfaced as
+        an errored result so the model can react, rather than aborting the turn.
+        """
+        command = block.input.get("command", "") if isinstance(block.input, dict) else ""
+        argv = ["bash", "-c", command]
+        try:
+            result = self._sandbox.exec_command(
+                sandbox_runtime_pb2.ExecCommandRequest(
+                    sandbox_id=sandbox_id, command=argv
+                )
+            )
+        except ConnectError as err:
+            return f"sandbox exec failed: {err}", True
+        return _format_output(result), result.exit_code != 0
 
 
-def _to_message(event: event_pb2.Event) -> dict | None:
-    """An Event as an Anthropic message, or ``None`` if it carries no known turn."""
+def _to_messages(
+    events: Sequence[event_pb2.Event], prompt: event_pb2.UserMessage
+) -> list[dict]:
+    """Build the Anthropic message list from prior events and the new prompt.
+
+    Each event maps to a role and some content blocks; consecutive events of the
+    same role are merged into one message so the result alternates user/assistant,
+    as the Messages API requires, with tool_use blocks landing in assistant
+    messages and tool_result blocks in user messages.
+    """
+    messages: list[dict] = []
+    for event in events:
+        converted = _event_to_message(event)
+        if converted is not None:
+            _append(messages, *converted)
+    _append(messages, "user", _text_content(prompt.content))
+    return messages
+
+
+def _append(messages: list[dict], role: str, blocks: list[dict]) -> None:
+    if messages and messages[-1]["role"] == role:
+        messages[-1]["content"].extend(blocks)
+    else:
+        messages.append({"role": role, "content": list(blocks)})
+
+
+def _event_to_message(event: event_pb2.Event) -> tuple[str, list[dict]] | None:
+    """An event as (role, content blocks), or None if it carries no known turn."""
     kind = event.WhichOneof("payload")
     if kind == "user_message":
-        return {"role": "user", "content": _content(event.user_message.content)}
+        return "user", _text_content(event.user_message.content)
     if kind == "agent_message":
-        return {"role": "assistant", "content": _content(event.agent_message.content)}
+        return "assistant", _text_content(event.agent_message.content)
+    if kind == "agent_tool_use":
+        use = event.agent_tool_use
+        return "assistant", [
+            {
+                "type": "tool_use",
+                "id": use.id,
+                "name": use.name,
+                "input": json_format.MessageToDict(use.input),
+            }
+        ]
+    if kind == "agent_tool_result":
+        res = event.agent_tool_result
+        return "user", [
+            {
+                "type": "tool_result",
+                "tool_use_id": res.tool_use_id,
+                "content": _blocks_text(res.content),
+                "is_error": res.is_error,
+            }
+        ]
     return None
 
 
-def _user_message(prompt: event_pb2.UserMessage) -> dict:
-    """The new prompt as the turn's final user message."""
-    return {"role": "user", "content": _content(prompt.content)}
+def _text_content(blocks: Sequence[event_pb2.ContentBlock]) -> list[dict]:
+    """Funky content blocks as Anthropic text content blocks (text only, today)."""
+    return [
+        {"type": "text", "text": block.text.text}
+        for block in blocks
+        if block.WhichOneof("block") == "text"
+    ]
 
 
-def _content(blocks: Sequence[event_pb2.ContentBlock]) -> list[dict]:
-    """Funky content blocks as Anthropic content blocks (text only, for now)."""
-    out: list[dict] = []
-    for block in blocks:
-        if block.WhichOneof("block") == "text":
-            out.append({"type": "text", "text": block.text.text})
-    return out
+def _blocks_text(blocks: Sequence[event_pb2.ContentBlock]) -> str:
+    """Flatten content blocks to a string, for a tool_result's content."""
+    return "".join(
+        block.text.text for block in blocks if block.WhichOneof("block") == "text"
+    )
+
+
+def _format_output(result: sandbox_runtime_pb2.ExecCommandResponse) -> str:
+    """Combine a command's stdout/stderr, noting a non-zero exit code."""
+    parts = [stream for stream in (result.stdout, result.stderr) if stream]
+    text = "\n".join(parts)
+    if result.exit_code != 0:
+        note = f"[exit code {result.exit_code}]"
+        text = f"{text}\n{note}" if text else note
+    return text
 
 
 def _agent_text_event(text: str) -> event_pb2.Event:
@@ -106,5 +243,26 @@ def _agent_text_event(text: str) -> event_pb2.Event:
     return event_pb2.Event(
         agent_message=event_pb2.AgentMessage(
             content=[event_pb2.ContentBlock(text=event_pb2.TextBlock(text=text))]
+        )
+    )
+
+
+def _agent_tool_use_event(block) -> event_pb2.Event:
+    """A payload-only AgentToolUse Event for a model tool_use block."""
+    use = event_pb2.AgentToolUse(id=block.id, name=block.name)
+    if isinstance(block.input, dict):
+        use.input.update(block.input)
+    return event_pb2.Event(agent_tool_use=use)
+
+
+def _agent_tool_result_event(
+    tool_use_id: str, output: str, is_error: bool
+) -> event_pb2.Event:
+    """A payload-only AgentToolResult Event for a tool call's outcome."""
+    return event_pb2.Event(
+        agent_tool_result=event_pb2.AgentToolResult(
+            tool_use_id=tool_use_id,
+            content=[event_pb2.ContentBlock(text=event_pb2.TextBlock(text=output))],
+            is_error=is_error,
         )
     )

--- a/agent_service/local_python_anthropic/src/funky_agent_service_anthropic/server.py
+++ b/agent_service/local_python_anthropic/src/funky_agent_service_anthropic/server.py
@@ -8,7 +8,9 @@ ConnectRPC over HTTP/1.1 + JSON and is reachable with plain ``curl`` (see
 README.md).
 
 The agent calls the Anthropic Messages API, so ANTHROPIC_API_KEY must be set in
-the environment; the server itself is fully local.
+the environment, and it execs its tools in a SandboxRuntime, so one must be
+reachable at --sandbox-runtime-url (the local Docker backend's default port). The
+server itself is fully local.
 """
 
 from __future__ import annotations
@@ -18,6 +20,7 @@ import argparse
 from waitress.server import create_server
 
 from funky.agent.v1.agent_service_connect import AgentServiceWSGIApplication
+from funky.sandbox.v1.sandbox_runtime_connect import SandboxRuntimeClientSync
 
 from .loop import DEFAULT_MAX_TOKENS
 from .service import AgentServiceAnthropic
@@ -30,6 +33,11 @@ def main() -> None:
     # 8082 so every backend can run locally at once.
     parser.add_argument("--port", type=int, default=8083)
     parser.add_argument(
+        "--sandbox-runtime-url",
+        default="http://127.0.0.1:8082",
+        help="base URL of the SandboxRuntime the agent execs its tools in",
+    )
+    parser.add_argument(
         "--max-tokens",
         type=int,
         default=DEFAULT_MAX_TOKENS,
@@ -37,13 +45,15 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    service = AgentServiceAnthropic(max_tokens=args.max_tokens)
+    sandbox_client = SandboxRuntimeClientSync(args.sandbox_runtime_url)
+    service = AgentServiceAnthropic(sandbox_client, max_tokens=args.max_tokens)
     app = AgentServiceWSGIApplication(service)
 
     server = create_server(app, host=args.host, port=args.port)
     host, port = server.socket.getsockname()[:2]
     print(
         f"AgentService (anthropic) listening on http://{host}:{port}\n"
+        f"  sandbox runtime: {args.sandbox_runtime_url}\n"
         f"  max_tokens: {args.max_tokens}",
         flush=True,
     )

--- a/agent_service/local_python_anthropic/src/funky_agent_service_anthropic/service.py
+++ b/agent_service/local_python_anthropic/src/funky_agent_service_anthropic/service.py
@@ -2,9 +2,9 @@
 
 Structurally satisfies the generated ``AgentServiceSync`` protocol: ``run_turn``
 takes its request plus a ``RequestContext`` and returns a ``RunTurnResponse``. The
-loop owns the model call and produces the Events; this layer unpacks the request,
-collects the events into the response, and builds the default Anthropic client
-when one isn't injected.
+loop owns the model call and the sandbox tool calls and produces the Events; this
+layer unpacks the request, collects the events into the response, and builds the
+default Anthropic client when one isn't injected.
 """
 
 from __future__ import annotations
@@ -22,13 +22,18 @@ class AgentServiceAnthropic:
     """Anthropic-backed ``funky.agent.v1.AgentService``."""
 
     def __init__(
-        self, client: anthropic.Anthropic | None = None, *, max_tokens: int = DEFAULT_MAX_TOKENS
+        self,
+        sandbox_client,
+        *,
+        client: anthropic.Anthropic | None = None,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
     ) -> None:
-        # anthropic.Anthropic() reads ANTHROPIC_API_KEY from the environment. The
-        # client is injectable so tests can drive the turn with a fake model
-        # instead of the real API (see tests/test_agent_service.py).
+        # sandbox_client is a SandboxRuntime client the agent execs its tools in.
+        # anthropic.Anthropic() reads ANTHROPIC_API_KEY from the environment. Both
+        # clients are injectable so tests can drive the turn with a fake model and
+        # a fake sandbox instead of the real services (see tests/).
         self._loop = AnthropicAgentLoop(
-            client or anthropic.Anthropic(), max_tokens=max_tokens
+            client or anthropic.Anthropic(), sandbox_client, max_tokens=max_tokens
         )
 
     def run_turn(

--- a/agent_service/local_python_anthropic/tests/test_agent_service.py
+++ b/agent_service/local_python_anthropic/tests/test_agent_service.py
@@ -1,9 +1,11 @@
 """End-to-end test: boot the WSGI server on an ephemeral port and drive RunTurn
-through the generated ConnectRPC client, with a fake Anthropic client standing in
-for the model so the test stays hermetic — no API key, no network."""
+through the generated ConnectRPC client, with a fake Anthropic client and a fake
+SandboxRuntime standing in for the model and the sandbox so the test stays
+hermetic — no API key, no Docker, no network."""
 
 from __future__ import annotations
 
+import copy
 import threading
 from dataclasses import dataclass, field
 
@@ -20,54 +22,102 @@ from funky.type.v1 import agent_pb2, event_pb2, sandbox_pb2
 from funky_agent_service_anthropic.service import AgentServiceAnthropic
 
 
+# --- fake Anthropic model -------------------------------------------------
+
+
 @dataclass
-class _Block:
-    """A content block of an Anthropic response, shaped like the SDK's TextBlock."""
+class _Text:
+    """A text content block, shaped like the SDK's TextBlock."""
 
     text: str
     type: str = "text"
 
 
 @dataclass
-class _Message:
-    """An Anthropic Messages response: a list of content blocks."""
+class _ToolUse:
+    """A tool_use content block, shaped like the SDK's ToolUseBlock."""
+
+    id: str
+    name: str
+    input: dict
+    type: str = "tool_use"
+
+
+@dataclass
+class _Response:
+    """An Anthropic Messages response: content blocks plus a stop reason."""
 
     content: list
+    stop_reason: str = "end_turn"
 
 
 class _Messages:
-    """The ``client.messages`` namespace: records each create() and replies canned."""
+    """The ``client.messages`` namespace: returns the canned responses in order,
+    one per create() call, and records each call's kwargs for inspection."""
 
-    def __init__(self, blocks: list, calls: list) -> None:
-        self._blocks = blocks
+    def __init__(self, responses: list, calls: list) -> None:
+        self._responses = list(responses)
         self._calls = calls
 
-    def create(self, **kwargs) -> _Message:
-        self._calls.append(kwargs)
-        return _Message(content=list(self._blocks))
+    def create(self, **kwargs) -> _Response:
+        # Snapshot the kwargs: the loop keeps mutating the messages list in place
+        # after the call, and the real SDK serializes the request, so a live
+        # reference would not reflect what was actually sent.
+        self._calls.append(copy.deepcopy(kwargs))
+        return self._responses.pop(0)
 
 
 @dataclass
 class FakeAnthropic:
-    """Stands in for ``anthropic.Anthropic``: ``messages.create`` returns the given
-    blocks and stashes its kwargs in ``calls`` for the test to inspect."""
+    """Stands in for ``anthropic.Anthropic``: ``messages.create`` returns the next
+    canned response and stashes its kwargs in ``calls``."""
 
-    blocks: list
+    responses: list
     calls: list = field(default_factory=list)
 
     def __post_init__(self) -> None:
-        self.messages = _Messages(self.blocks, self.calls)
+        self.messages = _Messages(self.responses, self.calls)
+
+
+# --- fake SandboxRuntime --------------------------------------------------
+
+
+@dataclass
+class _ExecResult:
+    """An ExecCommandResponse stand-in."""
+
+    exit_code: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+
+class FakeSandbox:
+    """Stands in for the SandboxRuntime client: ``exec_command`` returns a canned
+    result and records each request."""
+
+    def __init__(self, result: _ExecResult | None = None) -> None:
+        self._result = result or _ExecResult()
+        self.calls: list = []
+
+    def exec_command(self, request) -> _ExecResult:
+        self.calls.append(request)
+        return self._result
+
+
+# --- harness --------------------------------------------------------------
 
 
 @pytest.fixture
 def serve():
-    """Yields ``start(fake) -> client``: boots a server wired to the fake model and
-    returns a ConnectRPC client for it. All servers are torn down at teardown."""
+    """Yields ``start(model, sandbox) -> client``: boots a server wired to the fake
+    model and sandbox, returns a ConnectRPC client. Servers torn down at teardown."""
     started: list = []
 
-    def start(fake: FakeAnthropic) -> AgentServiceClientSync:
-        app = AgentServiceWSGIApplication(AgentServiceAnthropic(client=fake))
-        server = create_server(app, host="127.0.0.1", port=0)
+    def start(model: FakeAnthropic, sandbox: FakeSandbox) -> AgentServiceClientSync:
+        service = AgentServiceAnthropic(sandbox, client=model)
+        server = create_server(
+            AgentServiceWSGIApplication(service), host="127.0.0.1", port=0
+        )
         port = server.socket.getsockname()[1]
         stopping = threading.Event()
 
@@ -112,50 +162,152 @@ def _agent_config(system_prompt: str = "You are a careful research assistant.") 
     )
 
 
-def test_run_turn_returns_all_events_at_once(serve):
-    client = serve(FakeAnthropic([_Block("Hello"), _Block(" world")]))
-
-    response = client.run_turn(
-        pb.RunTurnRequest(
-            agent_config=_agent_config(),
-            prompt=_user("hi"),
-            sandbox=sandbox_pb2.Sandbox(id="sbx_1"),
-        )
+def _request(events=(), prompt="hi", sandbox_id="sbx_1", system="You are a careful research assistant.") -> pb.RunTurnRequest:
+    return pb.RunTurnRequest(
+        agent_config=_agent_config(system),
+        events=list(events),
+        prompt=_user(prompt),
+        sandbox=sandbox_pb2.Sandbox(id=sandbox_id),
     )
 
-    # The unary RPC returns one response holding every event the turn produced —
-    # one AgentMessage per text block the model returned.
+
+# --- tests ----------------------------------------------------------------
+
+
+def test_text_only_turn_returns_agent_messages(serve):
+    sandbox = FakeSandbox()
+    client = serve(FakeAnthropic([_Response([_Text("Hello"), _Text(" world")])]), sandbox)
+
+    response = client.run_turn(_request())
+
     assert [
         e.agent_message.content[0].text.text for e in response.events
     ] == ["Hello", " world"]
-    # The events are payload-only: id/session_id/processed_at are the
-    # SessionStore's to assign when the Client appends them to history.
+    # No tool calls -> the sandbox is never touched.
+    assert sandbox.calls == []
+    # Events are payload-only: id/session_id/processed_at are the SessionStore's.
     assert all(
         e.id == "" and e.session_id == "" and not e.HasField("processed_at")
         for e in response.events
     )
 
 
+def test_agent_runs_a_tool_in_the_sandbox(serve):
+    model = FakeAnthropic(
+        [
+            _Response(
+                [_ToolUse(id="toolu_1", name="bash", input={"command": "echo hi"})],
+                stop_reason="tool_use",
+            ),
+            _Response([_Text("It printed hi.")]),
+        ]
+    )
+    sandbox = FakeSandbox(_ExecResult(exit_code=0, stdout="hi\n"))
+    client = serve(model, sandbox)
+
+    response = client.run_turn(_request(prompt="run echo hi", sandbox_id="sbx_42"))
+
+    # The command ran in the right sandbox, wrapped for a shell.
+    [exec_call] = sandbox.calls
+    assert exec_call.sandbox_id == "sbx_42"
+    assert list(exec_call.command) == ["bash", "-c", "echo hi"]
+
+    # The turn's events: the tool call, its result, then the agent's reply.
+    use, result, message = response.events
+    assert use.agent_tool_use.id == "toolu_1"
+    assert use.agent_tool_use.name == "bash"
+    assert use.agent_tool_use.input["command"] == "echo hi"
+    assert result.agent_tool_result.tool_use_id == "toolu_1"
+    assert result.agent_tool_result.content[0].text.text == "hi\n"
+    assert result.agent_tool_result.is_error is False
+    assert message.agent_message.content[0].text.text == "It printed hi."
+
+    # The second model call carried the tool_use back and the tool_result in.
+    second = model.calls[1]["messages"]
+    assert second[-2] == {
+        "role": "assistant",
+        "content": [
+            {"type": "tool_use", "id": "toolu_1", "name": "bash", "input": {"command": "echo hi"}}
+        ],
+    }
+    assert second[-1] == {
+        "role": "user",
+        "content": [
+            {"type": "tool_result", "tool_use_id": "toolu_1", "content": "hi\n", "is_error": False}
+        ],
+    }
+
+
+def test_failed_command_is_flagged_as_an_error(serve):
+    model = FakeAnthropic(
+        [
+            _Response(
+                [_ToolUse(id="toolu_x", name="bash", input={"command": "false"})],
+                stop_reason="tool_use",
+            ),
+            _Response([_Text("That failed.")]),
+        ]
+    )
+    sandbox = FakeSandbox(_ExecResult(exit_code=1, stderr="boom"))
+    client = serve(model, sandbox)
+
+    response = client.run_turn(_request())
+
+    result = response.events[1].agent_tool_result
+    assert result.is_error is True
+    assert "boom" in result.content[0].text.text
+    assert "[exit code 1]" in result.content[0].text.text
+    # The error flag is carried back to the model too.
+    assert model.calls[1]["messages"][-1]["content"][0]["is_error"] is True
+
+
+def test_history_with_tool_events_round_trips_to_the_model(serve):
+    model = FakeAnthropic([_Response([_Text("ok")])])
+    sandbox = FakeSandbox()
+    client = serve(model, sandbox)
+
+    use = event_pb2.AgentToolUse(id="toolu_h", name="bash")
+    use.input.update({"command": "ls"})
+    result = event_pb2.AgentToolResult(
+        tool_use_id="toolu_h",
+        content=[event_pb2.ContentBlock(text=event_pb2.TextBlock(text="a\nb"))],
+    )
+    history = [
+        event_pb2.Event(user_message=_user("list files")),
+        event_pb2.Event(agent_tool_use=use),
+        event_pb2.Event(agent_tool_result=result),
+    ]
+    client.run_turn(_request(events=history, prompt="thanks"))
+
+    # The prior tool call and its result reconstruct into a valid Anthropic
+    # exchange: tool_use in an assistant message, tool_result in a user message,
+    # paired by id.
+    messages = model.calls[0]["messages"]
+    assert messages[0] == {"role": "user", "content": [{"type": "text", "text": "list files"}]}
+    assert messages[1] == {
+        "role": "assistant",
+        "content": [{"type": "tool_use", "id": "toolu_h", "name": "bash", "input": {"command": "ls"}}],
+    }
+    assert messages[2] == {
+        "role": "user",
+        "content": [
+            {"type": "tool_result", "tool_use_id": "toolu_h", "content": "a\nb", "is_error": False},
+            {"type": "text", "text": "thanks"},
+        ],
+    }
+
+
 def test_history_and_prompt_become_anthropic_messages(serve):
-    fake = FakeAnthropic([_Block("ok")])
-    client = serve(fake)
+    model = FakeAnthropic([_Response([_Text("ok")])])
+    client = serve(model, FakeSandbox())
 
     history = [
         event_pb2.Event(user_message=_user("first question")),
         event_pb2.Event(agent_message=_agent_message("first answer")),
     ]
-    client.run_turn(
-        pb.RunTurnRequest(
-            agent_config=_agent_config(),
-            events=history,
-            prompt=_user("second question"),
-            sandbox=sandbox_pb2.Sandbox(id="sbx_1"),
-        )
-    )
+    client.run_turn(_request(events=history, prompt="second question"))
 
-    # The model is asked with the agent's model + system prompt, and the history
-    # in order with the new prompt appended as the trailing user turn.
-    [call] = fake.calls
+    [call] = model.calls
     assert call["model"] == "claude-sonnet-4-6"
     assert call["system"] == "You are a careful research assistant."
     assert call["messages"] == [
@@ -166,17 +318,10 @@ def test_history_and_prompt_become_anthropic_messages(serve):
 
 
 def test_empty_system_prompt_is_omitted(serve):
-    fake = FakeAnthropic([_Block("ok")])
-    client = serve(fake)
+    model = FakeAnthropic([_Response([_Text("ok")])])
+    client = serve(model, FakeSandbox())
 
-    client.run_turn(
-        pb.RunTurnRequest(
-            agent_config=_agent_config(system_prompt=""),
-            prompt=_user("hi"),
-            sandbox=sandbox_pb2.Sandbox(id="sbx_1"),
-        )
-    )
+    client.run_turn(_request(system=""))
 
-    # A blank system prompt is left off the request rather than sent as "".
-    [call] = fake.calls
+    [call] = model.calls
     assert "system" not in call

--- a/proto/funky/type/v1/event.proto
+++ b/proto/funky/type/v1/event.proto
@@ -62,15 +62,18 @@ message TextBlock {
 }
 
 // AgentToolUse is one built-in tool call the agent made during a turn: which
-// tool, and with what input.
+// tool, with what input, and an id that pairs it with its result.
 //
-// Like UserMessage and AgentMessage, it is a payload of an Event, so the call's
-// identity and timing live on the Event envelope (id, processed_at), not here. A
-// tool call and its result are separate events — the result comes back as its
-// own payload (an AgentToolResult), the same way the agent's text and its tool
-// calls arrive as distinct events rather than nested in one message. How a call's
-// permission was resolved (allow / ask / deny) is a later addition, once a backend
-// gates tools; field 3 is left for it.
+// Like UserMessage and AgentMessage, it is a payload of an Event, so the event's
+// place in history — its Event id and processed_at — lives on the envelope. The
+// id field here is a different handle: the tool call's own id, set when the agent
+// makes the call, that the matching AgentToolResult references as tool_use_id. It
+// exists because Event ids are assigned later (by the SessionStore on append), so
+// a result can't point at its call by Event id when the call is made. A tool call
+// and its result are separate events — the result is its own AgentToolResult —
+// just as the agent's text and its tool calls arrive as distinct events rather
+// than nested in one message. How a call's permission was resolved (allow / ask /
+// deny) is a later addition, once a backend gates tools.
 message AgentToolUse {
   // Name of the tool being invoked.
   string name = 1;
@@ -78,18 +81,22 @@ message AgentToolUse {
   // Input arguments for the call, an arbitrary JSON object. Struct is proto's
   // JSON-object type, so this round-trips through proto3 JSON unchanged.
   google.protobuf.Struct input = 2;
+
+  // The tool call's own id, unique within the turn. The AgentToolResult that
+  // answers this call carries it as tool_use_id.
+  string id = 3;
 }
 
 // AgentToolResult is the outcome of one AgentToolUse: what the tool returned, and
 // whether it failed.
 //
-// Like the other payloads, it is carried by an Event, so its own id and timing
-// live on the Event envelope. It points back to the call it answers by that
-// call's Event id (tool_use_id), pairing a result with its tool use. The content
-// reuses ContentBlock, so a result is text today and grows image/document/...
-// blocks exactly as ContentBlock does.
+// Like the other payloads, it is carried by an Event, so its own Event id and
+// timing live on the envelope. It points back to the call it answers by that
+// call's id (tool_use_id = AgentToolUse.id), pairing a result with its tool use.
+// The content reuses ContentBlock, so a result is text today and grows
+// image/document/... blocks exactly as ContentBlock does.
 message AgentToolResult {
-  // Event id of the AgentToolUse this result answers.
+  // The AgentToolUse.id this result answers.
   string tool_use_id = 1;
 
   // What the tool returned, in order.


### PR DESCRIPTION
Turns the Anthropic backend's text-only turn into a real tool-use loop: the agent gets a `bash` tool, and every command the model calls is executed in the request's `Sandbox` through a `SandboxRuntime` client and fed back, looping until the model stops calling tools (with an iteration cap). The turn now emits an `AgentMessage` per text block and an `AgentToolUse` + `AgentToolResult` pair per command, and reconstructs prior tool events in history into a valid Anthropic exchange; the server gains a `--sandbox-runtime-url` flag (default `http://127.0.0.1:8082`). It also adds `AgentToolUse.id` (field 3) — the tool call's own handle that `AgentToolResult.tool_use_id` references, needed because Event ids are assigned later by the SessionStore (so a result can't reference its call by Event id at emit time) and Anthropic requires `tool_result` to match a `tool_use` id to round-trip. Hermetic tests fake the model and the sandbox; the real `AgentService → SandboxRuntime → Docker` path was also verified end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)