### PR TITLE
Add FunkyClient and a funky-chat CLI

### DIFF
--- a/client/python/README.md
+++ b/client/python/README.md
@@ -1,0 +1,132 @@
+# funky-client (python)
+
+The thin **Client** from the [architecture](../../docs/architecture.mmd) — the
+orchestrator developers actually call. It wires the four Funky services together
+over their generated ConnectRPC clients and resolves ids to configs so you never
+touch the services directly. It has no server and no backend of its own; point it
+at one of each service and go.
+
+```
+ConfigRegistry   SessionStore   SandboxRuntime   AgentService
+       \              |               |              /
+        \             |               |             /
+                      FunkyClient (this)
+```
+
+## The API
+
+Four calls, mirroring the architecture diagram:
+
+| Call | Does |
+|---|---|
+| `client.agents.create(agent_config)` → `agent_id` | store an agent spec in the ConfigRegistry |
+| `client.environments.create(env_config=None)` → `environment_id` | store an environment spec (empty config is fine) |
+| `client.sessions.create(agent_id, environment_id)` → `session_id` | resolve the agent and open a session for it |
+| `client.sessions.send(session_id, prompt)` → `events` | run one agent turn and return the agent's events |
+
+`sessions.send` is where the coordination happens. For one prompt it: resolves
+the session and its environment config, reads the prior history and persists the
+new user message, provisions a sandbox from the session's agent + environment,
+runs the turn against the history through the `AgentService`, persists every event
+the agent produces, and tears the sandbox down afterwards (even if the turn
+fails). The agent config is **snapshotted into the session** at `create`, so the
+turn runs the agent as it was then, regardless of later registry edits.
+
+## Use it
+
+```python
+from funky_client import FunkyClient
+from funky.type.v1 import agent_pb2
+
+client = FunkyClient.from_urls(
+    config_registry_url="http://127.0.0.1:8080",
+    session_store_url="http://127.0.0.1:8081",
+    sandbox_runtime_url="http://127.0.0.1:8082",
+    agent_service_url="http://127.0.0.1:8083",
+)
+
+agent_id = client.agents.create(
+    agent_pb2.AgentConfig(
+        name="coder",
+        model="claude-sonnet-4-6",
+        system_prompt="You are a careful coding assistant.",
+    )
+)
+environment_id = client.environments.create()
+session_id = client.sessions.create(agent_id, environment_id)
+
+for event in client.sessions.send(session_id, "Use bash to print the Python version."):
+    if event.HasField("agent_message"):
+        print(event.agent_message.content[0].text.text)
+```
+
+This assumes one of each service is running on the ports above — see each
+backend's README ([ConfigRegistry](../../config_registry/local_python_jsonl),
+[SessionStore](../../session_store/local_python_jsonl),
+[SandboxRuntime](../../sandbox_runtime/local_python_docker),
+[AgentService](../../agent_service/local_python_anthropic)). The constructor also
+takes the four clients directly (`FunkyClient(registry, store, runtime, agent)`),
+which is how the tests inject fakes.
+
+## Chat from the command line
+
+`funky-chat` is one command that starts a conversation: it creates an agent, an
+environment, and a session, then loops — read a line, run it as a turn, print what
+the agent does and says.
+
+```bash
+# The agent calls Anthropic, so export your API key first:
+export ANTHROPIC_API_KEY=sk-ant-...
+
+# Bring up all four services in-process and chat — nothing else to start.
+# Also needs a Docker daemon for the SandboxRuntime.
+uv run funky-chat --local
+
+# Or point at services you're already running on their default ports (8080–8083):
+uv run funky-chat
+
+# Override the model, system prompt, or any service URL:
+uv run funky-chat --model claude-sonnet-4-6 --system "You are a terse shell wizard."
+
+# Resume an existing session instead of starting fresh:
+uv run funky-chat --session-id ses_...
+```
+
+`--local` starts the four backends on ephemeral ports backed by a throwaway data
+directory and tears them down when you exit — handy for a quick session without
+opening four terminals. It needs the backends installed (they ship as the
+`funky-client[local]` extra; in this workspace they're already present). Without
+`--local`, run one of each service yourself (see the backend READMEs) and the
+default `--*-url` flags will find them.
+
+```
+Funky chat — session ses_1a2b…
+Type a message; Ctrl-D or 'exit' to quit.
+
+you> what python version is in the sandbox?
+  · bash: python3 --version
+    Python 3.12.13
+agent> The sandbox has Python 3.12.13.
+you> exit
+```
+
+Tool calls the agent makes are shown as `· <tool>: <command>` with the result
+indented beneath; a failed command is marked `(error)`. The defaults point at the
+local backends, so `funky-chat` alone is enough once they're up (the AgentService
+needs `ANTHROPIC_API_KEY` and a reachable SandboxRuntime, as its README covers).
+`--help` lists every flag.
+
+## Test
+
+```bash
+uv run pytest client/python
+```
+
+The client tests drive `FunkyClient` against in-memory fakes of the four services
+and assert the orchestration: the agent config is snapshotted into the session, a
+turn runs against the prior history with the new prompt, the whole exchange is
+persisted in order, history accumulates across turns, and the sandbox is always
+torn down — even when the turn fails. The CLI tests script `input` and a fake
+client to check the chat loop and how events render. Each service's own wire path
+is covered by its backend's tests, so these focus on coordination and need no
+servers.

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -1,0 +1,42 @@
+# funky-client — the thin orchestrator developers call. It wires the four Funky
+# services together over their generated ConnectRPC clients; it has no server and
+# no backend of its own. See README.md.
+[project]
+name = "funky-client"
+version = "0.0.0"
+description = "FunkyClient — the orchestrator that ties the four Funky services together."
+requires-python = ">=3.10"
+dependencies = [
+  "funky-protos",
+]
+
+# `funky-chat --local` boots the four backends in-process. They're optional: the
+# client only needs them for --local, so they live behind a `local` extra
+# (`pip install "funky-client[local]"`). In this uv workspace they're already
+# present, so --local works out of the box.
+[project.optional-dependencies]
+local = [
+  "funky-config-registry-jsonl",
+  "funky-session-store-jsonl",
+  "funky-sandbox-runtime-docker",
+  "funky-agent-service-anthropic",
+]
+
+# funky-chat: one command to start a conversation in the terminal.
+[project.scripts]
+funky-chat = "funky_client.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/funky_client"]
+
+# Resolve the funky packages from the workspace rather than PyPI.
+[tool.uv.sources]
+funky-protos = { workspace = true }
+funky-config-registry-jsonl = { workspace = true }
+funky-session-store-jsonl = { workspace = true }
+funky-sandbox-runtime-docker = { workspace = true }
+funky-agent-service-anthropic = { workspace = true }

--- a/client/python/src/funky_client/__init__.py
+++ b/client/python/src/funky_client/__init__.py
@@ -1,0 +1,5 @@
+"""FunkyClient — the orchestrator that ties the four Funky services together."""
+
+from .client import FunkyClient
+
+__all__ = ["FunkyClient"]

--- a/client/python/src/funky_client/cli.py
+++ b/client/python/src/funky_client/cli.py
@@ -1,0 +1,219 @@
+"""funky-chat: one command to talk to a Funky agent from the terminal.
+
+A small REPL over a ``FunkyClient``. It creates an agent, an environment, and a
+session (or resumes one with ``--session-id``), then loops: read a line, run it as
+one turn, print what the agent does and says. Each turn's tool calls run in a
+sandbox via the services the client points at, so the four services must be up
+(see the client README); the CLI itself only needs their URLs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from connectrpc.errors import ConnectError
+from google.protobuf import json_format
+
+from funky.type.v1 import agent_pb2, event_pb2
+
+from .client import FunkyClient
+
+DEFAULT_MODEL = "claude-sonnet-4-6"
+DEFAULT_SYSTEM = (
+    "You are a helpful assistant working in a sandbox. "
+    "Use the bash tool to run commands when it helps."
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Start a chat with a Funky agent from the command line."
+    )
+    parser.add_argument("--config-registry-url", default="http://127.0.0.1:8080")
+    parser.add_argument("--session-store-url", default="http://127.0.0.1:8081")
+    parser.add_argument("--sandbox-runtime-url", default="http://127.0.0.1:8082")
+    parser.add_argument("--agent-service-url", default="http://127.0.0.1:8083")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="model the agent runs on")
+    parser.add_argument("--system", default=DEFAULT_SYSTEM, help="agent system prompt")
+    parser.add_argument("--name", default="cli", help="agent name (display only)")
+    parser.add_argument(
+        "--session-id",
+        help="resume this session instead of creating a fresh agent/env/session",
+    )
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        help="also start the four services in-process (needs Docker + "
+        "ANTHROPIC_API_KEY); ignores the --*-url flags",
+    )
+    args = parser.parse_args()
+
+    if args.local:
+        urls = _serve_local()
+    else:
+        urls = {
+            "config_registry_url": args.config_registry_url,
+            "session_store_url": args.session_store_url,
+            "sandbox_runtime_url": args.sandbox_runtime_url,
+            "agent_service_url": args.agent_service_url,
+        }
+
+    client = FunkyClient.from_urls(**urls)
+
+    try:
+        session_id = args.session_id or _start_session(client, args)
+    except ConnectError as err:
+        print(f"could not reach a service: {err}", file=sys.stderr)
+        return 1
+
+    print(f"Funky chat — session {session_id}")
+    print("Type a message; Ctrl-D or 'exit' to quit.\n")
+    _chat(client, session_id)
+    return 0
+
+
+def _serve_local() -> dict[str, str]:
+    """Boot the four backends in-process on ephemeral ports; return their URLs.
+
+    Lets ``--local`` bring up the whole stack from one command. It needs the
+    service backends installed (``funky-client[local]``), a Docker daemon for the
+    SandboxRuntime, and ANTHROPIC_API_KEY for the AgentService — the same
+    requirements as starting the four servers by hand. The servers run in daemon
+    threads on a throwaway data dir, so they shut down when the chat exits.
+    """
+    try:
+        from waitress.server import create_server
+
+        from funky.agent.v1.agent_service_connect import AgentServiceWSGIApplication
+        from funky.registry.v1.config_registry_connect import (
+            ConfigRegistryWSGIApplication,
+        )
+        from funky.sandbox.v1.sandbox_runtime_connect import (
+            SandboxRuntimeClientSync,
+            SandboxRuntimeWSGIApplication,
+        )
+        from funky.session.v1.session_store_connect import SessionStoreWSGIApplication
+        from funky_agent_service_anthropic.service import AgentServiceAnthropic
+        from funky_config_registry_jsonl.service import ConfigRegistryService
+        from funky_sandbox_runtime_docker.service import SandboxRuntimeService
+        from funky_session_store_jsonl.service import SessionStoreService
+    except ImportError as err:
+        raise SystemExit(
+            f"--local needs the service backends (missing {err.name!r}); "
+            "install them with: pip install 'funky-client[local]'"
+        )
+
+    import tempfile
+    import threading
+    from pathlib import Path
+
+    data_dir = Path(tempfile.mkdtemp(prefix="funky-chat-"))
+
+    def serve(app) -> str:
+        server = create_server(app, host="127.0.0.1", port=0)
+        threading.Thread(target=server.run, daemon=True).start()
+        return f"http://127.0.0.1:{server.socket.getsockname()[1]}"
+
+    config_registry_url = serve(
+        ConfigRegistryWSGIApplication(ConfigRegistryService(data_dir / "config"))
+    )
+    session_store_url = serve(
+        SessionStoreWSGIApplication(SessionStoreService(data_dir / "sessions"))
+    )
+    try:
+        # SandboxRuntimeService() connects to the Docker daemon up front.
+        sandbox_runtime_url = serve(
+            SandboxRuntimeWSGIApplication(SandboxRuntimeService())
+        )
+    except Exception as err:
+        raise SystemExit(
+            f"--local could not start the SandboxRuntime (is Docker running?): {err}"
+        )
+    try:
+        # The AgentService execs its tools in the local SandboxRuntime above.
+        agent = AgentServiceAnthropic(SandboxRuntimeClientSync(sandbox_runtime_url))
+    except Exception as err:
+        raise SystemExit(
+            f"--local could not start the AgentService (is ANTHROPIC_API_KEY set?): {err}"
+        )
+    agent_service_url = serve(AgentServiceWSGIApplication(agent))
+
+    print(f"Started local services (data in {data_dir}):")
+    print(f"  config registry  {config_registry_url}")
+    print(f"  session store    {session_store_url}")
+    print(f"  sandbox runtime  {sandbox_runtime_url}")
+    print(f"  agent service    {agent_service_url}\n")
+    return {
+        "config_registry_url": config_registry_url,
+        "session_store_url": session_store_url,
+        "sandbox_runtime_url": sandbox_runtime_url,
+        "agent_service_url": agent_service_url,
+    }
+
+
+def _start_session(client: FunkyClient, args: argparse.Namespace) -> str:
+    """Create an agent, an environment, and a session; return the session id."""
+    agent_id = client.agents.create(
+        agent_pb2.AgentConfig(
+            name=args.name, model=args.model, system_prompt=args.system
+        )
+    )
+    environment_id = client.environments.create()
+    return client.sessions.create(agent_id, environment_id)
+
+
+def _chat(client: FunkyClient, session_id: str) -> None:
+    """Read–run–print loop until EOF, Ctrl-C, or 'exit'/'quit'."""
+    while True:
+        try:
+            line = input("you> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+        if not line:
+            continue
+        if line in {"exit", "quit"}:
+            return
+        try:
+            events = client.sessions.send(session_id, line)
+        except KeyboardInterrupt:
+            print("\n  [interrupted]")
+            continue
+        except ConnectError as err:
+            print(f"  [error] {err}", file=sys.stderr)
+            continue
+        for event in events:
+            _render(event)
+
+
+def _render(event: event_pb2.Event) -> None:
+    """Print one event the agent produced: its text, or a tool call/result."""
+    kind = event.WhichOneof("payload")
+    if kind == "agent_message":
+        text = _text(event.agent_message.content)
+        if text:
+            print(f"agent> {text}")
+    elif kind == "agent_tool_use":
+        args = json_format.MessageToDict(event.agent_tool_use.input)
+        detail = args.get("command", args)
+        print(f"  · {event.agent_tool_use.name}: {detail}")
+    elif kind == "agent_tool_result":
+        text = _truncate(_text(event.agent_tool_result.content).strip())
+        flag = " (error)" if event.agent_tool_result.is_error else ""
+        if text or flag:
+            print(f"    {text}{flag}")
+
+
+def _text(blocks) -> str:
+    return "".join(
+        block.text.text for block in blocks if block.WhichOneof("block") == "text"
+    )
+
+
+def _truncate(text: str, limit: int = 500) -> str:
+    return text if len(text) <= limit else text[:limit] + " …"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/client/python/src/funky_client/client.py
+++ b/client/python/src/funky_client/client.py
@@ -1,0 +1,193 @@
+"""FunkyClient: the orchestrator that ties the four Funky services together.
+
+Developers talk to this, not to the services directly. It is a thin layer over
+the four generated ConnectRPC clients — ConfigRegistry, SessionStore,
+SandboxRuntime, AgentService — that resolves ids to configs and coordinates a
+turn across all of them:
+
+    client = FunkyClient.from_urls(
+        config_registry_url="http://127.0.0.1:8080",
+        session_store_url="http://127.0.0.1:8081",
+        sandbox_runtime_url="http://127.0.0.1:8082",
+        agent_service_url="http://127.0.0.1:8083",
+    )
+    agent_id = client.agents.create(AgentConfig(name="coder", model="...", system_prompt="..."))
+    env_id = client.environments.create()
+    session_id = client.sessions.create(agent_id, env_id)
+    events = client.sessions.send(session_id, "List the files in the repo.")
+
+The constructor takes the four clients directly, so tests can pass fakes;
+``from_urls`` is the convenience that builds the real ConnectRPC clients.
+"""
+
+from __future__ import annotations
+
+from funky.agent.v1 import agent_service_pb2 as agent_service_pb
+from funky.agent.v1.agent_service_connect import AgentServiceClientSync
+from funky.registry.v1 import config_registry_pb2 as registry_pb
+from funky.registry.v1.config_registry_connect import ConfigRegistryClientSync
+from funky.sandbox.v1 import sandbox_runtime_pb2 as sandbox_pb
+from funky.sandbox.v1.sandbox_runtime_connect import SandboxRuntimeClientSync
+from funky.session.v1 import session_store_pb2 as session_pb
+from funky.session.v1.session_store_connect import SessionStoreClientSync
+from funky.type.v1 import agent_pb2, environment_pb2, event_pb2
+
+
+class FunkyClient:
+    """Coordinates the ConfigRegistry, SessionStore, SandboxRuntime, and
+    AgentService behind one small API (``agents``, ``environments``, ``sessions``)."""
+
+    def __init__(
+        self, config_registry, session_store, sandbox_runtime, agent_service
+    ) -> None:
+        self._config_registry = config_registry
+        self._session_store = session_store
+        self._sandbox_runtime = sandbox_runtime
+        self._agent_service = agent_service
+        self.agents = _Agents(self)
+        self.environments = _Environments(self)
+        self.sessions = _Sessions(self)
+
+    @classmethod
+    def from_urls(
+        cls,
+        *,
+        config_registry_url: str,
+        session_store_url: str,
+        sandbox_runtime_url: str,
+        agent_service_url: str,
+    ) -> "FunkyClient":
+        """Build a client from the four service base URLs."""
+        return cls(
+            ConfigRegistryClientSync(config_registry_url),
+            SessionStoreClientSync(session_store_url),
+            SandboxRuntimeClientSync(sandbox_runtime_url),
+            AgentServiceClientSync(agent_service_url),
+        )
+
+
+class _Agents:
+    """``client.agents`` — agent configs in the ConfigRegistry."""
+
+    def __init__(self, client: FunkyClient) -> None:
+        self._client = client
+
+    def create(self, config: agent_pb2.AgentConfig) -> str:
+        """Store an agent config and return its registry id."""
+        response = self._client._config_registry.create_agent(
+            registry_pb.CreateAgentRequest(config=config)
+        )
+        return response.id
+
+
+class _Environments:
+    """``client.environments`` — environment configs in the ConfigRegistry."""
+
+    def __init__(self, client: FunkyClient) -> None:
+        self._client = client
+
+    def create(self, config: environment_pb2.EnvironmentConfig | None = None) -> str:
+        """Store an environment config and return its registry id.
+
+        EnvironmentConfig is empty today, so this is callable with no argument.
+        """
+        response = self._client._config_registry.create_environment(
+            registry_pb.CreateEnvironmentRequest(
+                config=config or environment_pb2.EnvironmentConfig()
+            )
+        )
+        return response.id
+
+
+class _Sessions:
+    """``client.sessions`` — sessions and the turns run in them."""
+
+    def __init__(self, client: FunkyClient) -> None:
+        self._client = client
+
+    def create(self, agent_id: str, environment_id: str) -> str:
+        """Open a session for an agent in an environment; return its id.
+
+        Resolves the agent id to its config and snapshots it into the session; the
+        environment stays a reference by id, resolved per turn in ``send``.
+        """
+        agent_config = self._client._config_registry.get_agent(
+            registry_pb.GetAgentRequest(id=agent_id)
+        ).config
+        session = self._client._session_store.create_session(
+            session_pb.CreateSessionRequest(
+                agent_config=agent_config, environment_config_id=environment_id
+            )
+        ).session
+        return session.id
+
+    def send(
+        self, session_id: str, prompt: str | event_pb2.UserMessage
+    ) -> list[event_pb2.Event]:
+        """Send a user prompt, run one agent turn, and return the agent's events.
+
+        This is the orchestration the other three methods build up to. It:
+          1. resolves the session and its environment config,
+          2. reads the prior history and persists the new user prompt,
+          3. provisions a sandbox from the session's agent + the environment,
+          4. runs the turn against the prior history, and
+          5. persists every event the agent produces, tearing the sandbox down
+             afterwards even if the turn fails.
+
+        Returns the agent's events as stored (with their assigned ids).
+        """
+        client = self._client
+        session = client._session_store.get_session(
+            session_pb.GetSessionRequest(id=session_id)
+        ).session
+        environment = client._config_registry.get_environment(
+            registry_pb.GetEnvironmentRequest(id=session.environment_config_id)
+        ).config
+        # History is the conversation *before* this prompt; the prompt is passed to
+        # the turn separately, so it is not double-counted.
+        history = client._session_store.list_events(
+            session_pb.ListEventsRequest(session_id=session_id)
+        ).events
+
+        user_message = _user_message(prompt)
+        client._session_store.append_event(
+            session_pb.AppendEventRequest(
+                session_id=session_id,
+                event=event_pb2.Event(user_message=user_message),
+            )
+        )
+
+        sandbox = client._sandbox_runtime.create_sandbox(
+            sandbox_pb.CreateSandboxRequest(
+                agent_config=session.agent_config, environment_config=environment
+            )
+        ).sandbox
+        try:
+            response = client._agent_service.run_turn(
+                agent_service_pb.RunTurnRequest(
+                    agent_config=session.agent_config,
+                    events=history,
+                    prompt=user_message,
+                    sandbox=sandbox,
+                )
+            )
+            produced = []
+            for event in response.events:
+                stored = client._session_store.append_event(
+                    session_pb.AppendEventRequest(session_id=session_id, event=event)
+                ).event
+                produced.append(stored)
+            return produced
+        finally:
+            client._sandbox_runtime.destroy_sandbox(
+                sandbox_pb.DestroySandboxRequest(sandbox_id=sandbox.id)
+            )
+
+
+def _user_message(prompt: str | event_pb2.UserMessage) -> event_pb2.UserMessage:
+    """A prompt as a UserMessage: a bare string becomes one text block."""
+    if isinstance(prompt, event_pb2.UserMessage):
+        return prompt
+    return event_pb2.UserMessage(
+        content=[event_pb2.ContentBlock(text=event_pb2.TextBlock(text=prompt))]
+    )

--- a/client/python/tests/test_cli.py
+++ b/client/python/tests/test_cli.py
@@ -1,0 +1,108 @@
+"""Exercise the funky-chat REPL without a terminal: a fake client whose
+``sessions.send`` returns canned events, and ``input`` scripted with a list of
+lines. Captures stdout to check what the user would see."""
+
+from __future__ import annotations
+
+import builtins
+
+from funky.type.v1 import event_pb2
+
+from funky_client import cli
+
+
+def _agent_message(text: str) -> event_pb2.Event:
+    return event_pb2.Event(
+        agent_message=event_pb2.AgentMessage(
+            content=[event_pb2.ContentBlock(text=event_pb2.TextBlock(text=text))]
+        )
+    )
+
+
+def _tool_use(name: str, command: str) -> event_pb2.Event:
+    use = event_pb2.AgentToolUse(id="toolu_1", name=name)
+    use.input.update({"command": command})
+    return event_pb2.Event(agent_tool_use=use)
+
+
+def _tool_result(text: str, is_error: bool = False) -> event_pb2.Event:
+    return event_pb2.Event(
+        agent_tool_result=event_pb2.AgentToolResult(
+            tool_use_id="toolu_1",
+            content=[event_pb2.ContentBlock(text=event_pb2.TextBlock(text=text))],
+            is_error=is_error,
+        )
+    )
+
+
+class _Sessions:
+    def __init__(self, responses: list[list[event_pb2.Event]]) -> None:
+        self._responses = list(responses)
+        self.sent: list[tuple[str, str]] = []
+
+    def send(self, session_id: str, prompt: str) -> list[event_pb2.Event]:
+        self.sent.append((session_id, prompt))
+        return self._responses.pop(0)
+
+
+class FakeClient:
+    def __init__(self, responses: list[list[event_pb2.Event]]) -> None:
+        self.sessions = _Sessions(responses)
+
+
+def _script_input(monkeypatch, lines: list[str]) -> None:
+    it = iter(lines)
+    monkeypatch.setattr(builtins, "input", lambda prompt="": next(it))
+
+
+def test_chat_sends_each_line_and_prints_replies(capsys, monkeypatch):
+    _script_input(monkeypatch, ["what is 2+2?", "exit"])
+    client = FakeClient([[_agent_message("4")]])
+
+    cli._chat(client, "ses_1")
+
+    # The line was sent as a turn; 'exit' ended the loop before being sent.
+    assert client.sessions.sent == [("ses_1", "what is 2+2?")]
+    assert "agent> 4" in capsys.readouterr().out
+
+
+def test_chat_renders_tool_activity(capsys, monkeypatch):
+    _script_input(monkeypatch, ["run uname", "exit"])
+    client = FakeClient(
+        [[_tool_use("bash", "uname"), _tool_result("Linux\n"), _agent_message("You're on Linux.")]]
+    )
+
+    cli._chat(client, "ses_1")
+
+    out = capsys.readouterr().out
+    assert "· bash: uname" in out
+    assert "Linux" in out
+    assert "agent> You're on Linux." in out
+
+
+def test_blank_lines_are_skipped(capsys, monkeypatch):
+    _script_input(monkeypatch, ["", "  ", "hi", "exit"])
+    client = FakeClient([[_agent_message("hello")]])
+
+    cli._chat(client, "ses_1")
+
+    # Only the non-blank line was sent.
+    assert client.sessions.sent == [("ses_1", "hi")]
+
+
+def test_eof_ends_the_loop(monkeypatch):
+    def _eof(prompt=""):
+        raise EOFError
+
+    monkeypatch.setattr(builtins, "input", _eof)
+    client = FakeClient([])
+
+    cli._chat(client, "ses_1")  # returns without sending anything
+
+    assert client.sessions.sent == []
+
+
+def test_render_marks_failed_tool_results(capsys):
+    cli._render(_tool_result("boom\n[exit code 1]", is_error=True))
+
+    assert "(error)" in capsys.readouterr().out

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -1,0 +1,232 @@
+"""Drive FunkyClient against in-memory fakes of the four services, asserting the
+orchestration: which service is called, with what, in what order. Each service's
+own wire path is covered by its backend's tests; here the Client's coordination is
+the thing under test, so the fakes are injected directly (no servers needed)."""
+
+from __future__ import annotations
+
+from funky.agent.v1 import agent_service_pb2 as agent_service_pb
+from funky.registry.v1 import config_registry_pb2 as registry_pb
+from funky.sandbox.v1 import sandbox_runtime_pb2 as sandbox_pb
+from funky.session.v1 import session_store_pb2 as session_pb
+from funky.type.v1 import (
+    agent_pb2,
+    event_pb2,
+    sandbox_pb2,
+    session_pb2,
+)
+
+from funky_client import FunkyClient
+
+
+class FakeConfigRegistry:
+    """In-memory ConfigRegistry: mints ids and stores configs."""
+
+    def __init__(self) -> None:
+        self.agents: dict[str, agent_pb2.AgentConfig] = {}
+        self.environments: dict[str, object] = {}
+        self._n = 0
+
+    def create_agent(self, request):
+        self._n += 1
+        agent_id = f"agt_{self._n}"
+        self.agents[agent_id] = request.config
+        return registry_pb.CreateAgentResponse(id=agent_id)
+
+    def get_agent(self, request):
+        return registry_pb.GetAgentResponse(config=self.agents[request.id])
+
+    def create_environment(self, request):
+        self._n += 1
+        env_id = f"env_{self._n}"
+        self.environments[env_id] = request.config
+        return registry_pb.CreateEnvironmentResponse(id=env_id)
+
+    def get_environment(self, request):
+        return registry_pb.GetEnvironmentResponse(config=self.environments[request.id])
+
+
+class FakeSessionStore:
+    """In-memory SessionStore: mints ids and keeps an append-only event log."""
+
+    def __init__(self) -> None:
+        self.sessions: dict[str, session_pb2.Session] = {}
+        self.events: dict[str, list[event_pb2.Event]] = {}
+        self._n = 0
+
+    def create_session(self, request):
+        self._n += 1
+        session = session_pb2.Session(
+            id=f"ses_{self._n}",
+            agent_config=request.agent_config,
+            environment_config_id=request.environment_config_id,
+        )
+        self.sessions[session.id] = session
+        self.events[session.id] = []
+        return session_pb.CreateSessionResponse(session=session)
+
+    def get_session(self, request):
+        return session_pb.GetSessionResponse(session=self.sessions[request.id])
+
+    def append_event(self, request):
+        self._n += 1
+        stored = event_pb2.Event()
+        stored.CopyFrom(request.event)
+        stored.id = f"evt_{self._n}"
+        stored.session_id = request.session_id
+        stored.processed_at.GetCurrentTime()
+        self.events[request.session_id].append(stored)
+        return session_pb.AppendEventResponse(event=stored)
+
+    def list_events(self, request):
+        return session_pb.ListEventsResponse(events=self.events[request.session_id])
+
+
+class FakeSandboxRuntime:
+    """In-memory SandboxRuntime: records create/destroy and hands out sandbox ids."""
+
+    def __init__(self) -> None:
+        self.created: list = []
+        self.destroyed: list[str] = []
+        self._n = 0
+
+    def create_sandbox(self, request):
+        self._n += 1
+        self.created.append(request)
+        return sandbox_pb.CreateSandboxResponse(
+            sandbox=sandbox_pb2.Sandbox(id=f"sbx_{self._n}")
+        )
+
+    def destroy_sandbox(self, request):
+        self.destroyed.append(request.sandbox_id)
+        return sandbox_pb.DestroySandboxResponse()
+
+
+class FakeAgentService:
+    """In-memory AgentService: records each run_turn and replies with canned
+    events, one response (a list of events) per call."""
+
+    def __init__(self, responses: list[list[event_pb2.Event]]) -> None:
+        self._responses = list(responses)
+        self.requests: list = []
+
+    def run_turn(self, request):
+        self.requests.append(request)
+        return agent_service_pb.RunTurnResponse(events=self._responses.pop(0))
+
+
+def _agent_event(text: str) -> event_pb2.Event:
+    return event_pb2.Event(
+        agent_message=event_pb2.AgentMessage(
+            content=[event_pb2.ContentBlock(text=event_pb2.TextBlock(text=text))]
+        )
+    )
+
+
+def _client(agent_responses):
+    registry = FakeConfigRegistry()
+    store = FakeSessionStore()
+    runtime = FakeSandboxRuntime()
+    agent = FakeAgentService(agent_responses)
+    return FunkyClient(registry, store, runtime, agent), registry, store, runtime, agent
+
+
+def test_create_resolves_the_agent_and_snapshots_it_into_the_session():
+    client, registry, store, _, _ = _client([])
+
+    agent_id = client.agents.create(
+        agent_pb2.AgentConfig(name="coder", model="claude-sonnet-4-6", system_prompt="be brief")
+    )
+    env_id = client.environments.create()
+    session_id = client.sessions.create(agent_id, env_id)
+
+    # Ids come back from the registry/store.
+    assert agent_id in registry.agents
+    assert env_id in registry.environments
+    # The session snapshots the resolved agent config and references the env by id.
+    session = store.sessions[session_id]
+    assert session.agent_config.model == "claude-sonnet-4-6"
+    assert session.environment_config_id == env_id
+
+
+def test_send_runs_a_turn_and_persists_the_whole_exchange():
+    client, _, store, runtime, agent = _client([[_agent_event("hi there")]])
+
+    agent_id = client.agents.create(
+        agent_pb2.AgentConfig(name="coder", model="m", system_prompt="s")
+    )
+    session_id = client.sessions.create(agent_id, client.environments.create())
+
+    produced = client.sessions.send(session_id, "hello")
+
+    # The AgentService got the snapshot config, the (empty) prior history, the
+    # prompt, and the sandbox that was provisioned for the turn.
+    [run] = agent.requests
+    assert run.agent_config.model == "m"
+    assert list(run.events) == []
+    assert run.prompt.content[0].text.text == "hello"
+    assert len(runtime.created) == 1
+    assert run.sandbox.id.startswith("sbx_")
+
+    # The sandbox was created from the session's agent + env, then torn down.
+    assert runtime.destroyed == [run.sandbox.id]
+
+    # The user prompt and the agent's reply were persisted, in order.
+    history = store.events[session_id]
+    assert [e.WhichOneof("payload") for e in history] == ["user_message", "agent_message"]
+    assert history[0].user_message.content[0].text.text == "hello"
+    assert history[1].agent_message.content[0].text.text == "hi there"
+
+    # send returns the agent's events as stored (with assigned ids).
+    assert [e.agent_message.content[0].text.text for e in produced] == ["hi there"]
+    assert all(e.id for e in produced)
+
+
+def test_history_accumulates_across_turns():
+    client, _, store, _, agent = _client(
+        [[_agent_event("first reply")], [_agent_event("second reply")]]
+    )
+    agent_id = client.agents.create(
+        agent_pb2.AgentConfig(name="coder", model="m", system_prompt="s")
+    )
+    session_id = client.sessions.create(agent_id, client.environments.create())
+
+    client.sessions.send(session_id, "first")
+    client.sessions.send(session_id, "second")
+
+    # The second turn is run against the first turn's persisted history (the first
+    # user prompt and the first agent reply), with the new prompt passed separately.
+    first_run, second_run = agent.requests
+    assert list(first_run.events) == []
+    assert [e.WhichOneof("payload") for e in second_run.events] == [
+        "user_message",
+        "agent_message",
+    ]
+    assert second_run.events[0].user_message.content[0].text.text == "first"
+    assert second_run.events[1].agent_message.content[0].text.text == "first reply"
+
+    # The full exchange is in the store, in order.
+    assert [
+        e.WhichOneof("payload") for e in store.events[session_id]
+    ] == ["user_message", "agent_message", "user_message", "agent_message"]
+
+
+def test_sandbox_is_destroyed_even_when_the_turn_fails():
+    client, _, store, runtime, _ = _client([])
+    agent_id = client.agents.create(
+        agent_pb2.AgentConfig(name="coder", model="m", system_prompt="s")
+    )
+    session_id = client.sessions.create(agent_id, client.environments.create())
+
+    # FakeAgentService was given no responses, so run_turn raises (pop from empty).
+    raised = False
+    try:
+        client.sessions.send(session_id, "hello")
+    except IndexError:
+        raised = True
+
+    assert raised
+    # The sandbox was still torn down, and the user prompt was still persisted.
+    assert len(runtime.created) == 1
+    assert runtime.destroyed == ["sbx_1"]
+    assert [e.WhichOneof("payload") for e in store.events[session_id]] == ["user_message"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ members = [
   "session_store/local_python_jsonl",
   "sandbox_runtime/local_python_docker",
   "agent_service/local_python_anthropic",
+  "client/python",
 ]
 
 # Test tooling, shared across all backends. Installed by `uv sync`.

--- a/uv.lock
+++ b/uv.lock
@@ -5,6 +5,7 @@ requires-python = ">=3.10"
 [manifest]
 members = [
     "funky-agent-service-anthropic",
+    "funky-client",
     "funky-config-registry-jsonl",
     "funky-protos",
     "funky-sandbox-runtime-docker",
@@ -252,6 +253,32 @@ requires-dist = [
     { name = "funky-protos", editable = "gen/python" },
     { name = "waitress", specifier = ">=3" },
 ]
+
+[[package]]
+name = "funky-client"
+version = "0.0.0"
+source = { editable = "client/python" }
+dependencies = [
+    { name = "funky-protos" },
+]
+
+[package.optional-dependencies]
+local = [
+    { name = "funky-agent-service-anthropic" },
+    { name = "funky-config-registry-jsonl" },
+    { name = "funky-sandbox-runtime-docker" },
+    { name = "funky-session-store-jsonl" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "funky-agent-service-anthropic", marker = "extra == 'local'", editable = "agent_service/local_python_anthropic" },
+    { name = "funky-config-registry-jsonl", marker = "extra == 'local'", editable = "config_registry/local_python_jsonl" },
+    { name = "funky-protos", editable = "gen/python" },
+    { name = "funky-sandbox-runtime-docker", marker = "extra == 'local'", editable = "sandbox_runtime/local_python_docker" },
+    { name = "funky-session-store-jsonl", marker = "extra == 'local'", editable = "session_store/local_python_jsonl" },
+]
+provides-extras = ["local"]
 
 [[package]]
 name = "funky-config-registry-jsonl"


### PR DESCRIPTION
Adds the **Client** from the architecture — a thin orchestrator (`client/python`, package `funky_client`) over the four services' ConnectRPC clients, exposing `agents.create`, `environments.create`, `sessions.create`, and `sessions.send`, where `send` resolves the session's environment, provisions a sandbox, runs one turn against the prior history through the AgentService, persists the prompt and every produced event, and tears the sandbox down even on failure. It also adds a **`funky-chat`** command: one command that starts a terminal conversation, rendering the agent's text and its sandbox tool calls/results, with a `--local` flag that boots all four backends in-process (behind an optional `funky-client[local]` extra) so a chat needs nothing else started. Hermetic tests cover the orchestration and the chat loop; the real four-service wire path and the `--local` boot were also verified end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)