### PR TITLE
Document gcloud ADC login in the Postgres backend README

### DIFF
--- a/session_store/gcp_python_postgres/README.md
+++ b/session_store/gcp_python_postgres/README.md
@@ -49,6 +49,8 @@ From the repository root:
 buf generate            # regenerate the protobuf/ConnectRPC stubs into gen/python
 uv sync                 # create the workspace venv and install the backend + deps
 
+gcloud auth application-default login   # credentials for the Cloud SQL connector
+
 export INSTANCE_CONNECTION_NAME="my-project:us-central1:my-instance"
 export DB_USER="funky" DB_NAME="funky" DB_PASS="..."
 uv run funky-session-store-postgres --port 8081


### PR DESCRIPTION
Follow-up to #20 (already merged). Adds a `gcloud auth application-default login` step to the **Run it** section of the `gcp_python_postgres` README, so the Cloud SQL connector has Application Default Credentials to authenticate with before the server starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)