### PR TITLE
Add cloudbuild.yaml and document the repo-root build context

### DIFF
--- a/session_store/gcp_python_postgres/README.md
+++ b/session_store/gcp_python_postgres/README.md
@@ -102,16 +102,35 @@ FUNKY_SESSION_STORE_TEST_DATABASE_URL="postgresql+asyncpg://user:pass@localhost/
 
 The [`Dockerfile`](./Dockerfile) builds a self-contained image: it runs
 `buf generate` and installs this backend from the committed lockfile, then serves
-on `$PORT` bound to all interfaces (Cloud Run's contract). **Build with the
-repository root as the context** — the backend resolves `funky-protos` from the
-uv workspace.
+on `$PORT` bound to all interfaces (Cloud Run's contract).
+
+> **The build context must be the repository root, not this directory.** The
+> backend resolves `funky-protos` from the uv workspace, and `buf generate` reads
+> `buf.gen.yaml`, `buf.yaml`, and `proto/` — all at the repo root. Building with
+> the package directory as the context fails with
+> `read buf.gen.yaml: file does not exist`.
+
+**Cloud Build** — use [`cloudbuild.yaml`](./cloudbuild.yaml), and submit from the
+repository root so the workspace is uploaded as the context:
 
 ```bash
-# From the repository root. Cloud Run is linux/amd64.
+gcloud builds submit \
+  --config session_store/gcp_python_postgres/cloudbuild.yaml \
+  --substitutions=_IMAGE=REGION-docker.pkg.dev/PROJECT/REPO/funky-session-store-postgres
+```
+
+**Or build locally** and push (Cloud Run is linux/amd64):
+
+```bash
+# From the repository root.
 IMAGE="REGION-docker.pkg.dev/PROJECT/REPO/funky-session-store-postgres"
 docker build -f session_store/gcp_python_postgres/Dockerfile --platform linux/amd64 -t "$IMAGE" .
 docker push "$IMAGE"
+```
 
+Then deploy the image:
+
+```bash
 gcloud run deploy funky-session-store-postgres \
   --image "$IMAGE" --region REGION \
   --service-account funky-runtime@PROJECT.iam.gserviceaccount.com \

--- a/session_store/gcp_python_postgres/cloudbuild.yaml
+++ b/session_store/gcp_python_postgres/cloudbuild.yaml
@@ -1,0 +1,21 @@
+# Cloud Build config for the GCP Cloud SQL (Postgres) SessionStore image.
+#
+# Submit from the REPOSITORY ROOT so the whole uv workspace — proto/, buf.gen.yaml,
+# buf.yaml, gen/python — is uploaded as the build context. The Dockerfile's
+# `COPY . .` and `buf generate` need those files; building with a subdirectory as
+# the context is what produces "read buf.gen.yaml: file does not exist".
+#
+#   gcloud builds submit \
+#     --config session_store/gcp_python_postgres/cloudbuild.yaml \
+#     --substitutions=_IMAGE=REGION-docker.pkg.dev/PROJECT/REPO/funky-session-store-postgres
+#
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - --file=session_store/gcp_python_postgres/Dockerfile
+      - --tag=${_IMAGE}
+      - .   # build context = the uploaded source root (the repository root)
+
+images:
+  - ${_IMAGE}


### PR DESCRIPTION
The Cloud Run image must be built with the repository root as the Docker context — `buf generate` reads `buf.gen.yaml`/`buf.yaml`/`proto/` and the backend resolves `funky-protos` from the uv workspace, all at the repo root — so a package-directory context fails with `read buf.gen.yaml: file does not exist`. Adds `session_store/gcp_python_postgres/cloudbuild.yaml`, which pins `--file` to the Dockerfile with `.` (the repo root, the uploaded source) as the context. The README gains a prominent callout about the context requirement (naming the exact error) plus a Cloud Build path alongside the local docker-build path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)