### PR TITLE
Add cloudbuild.yaml and document the repo-root build context

### DIFF
--- a/session_store/gcp_python_postgres/cloudbuild.yaml
+++ b/session_store/gcp_python_postgres/cloudbuild.yaml
@@ -19,3 +19,9 @@ steps:
 
 images:
   - ${_IMAGE}
+
+options:
+  # A user-specified build service account (set on a Cloud Run deploy trigger)
+  # has no default logs bucket, so a logging destination must be chosen here or
+  # the build fails to start with "if 'build.service_account' is specified ...".
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
The Cloud Run image must be built with the repository root as the Docker context — `buf generate` reads `buf.gen.yaml`/`buf.yaml`/`proto/` and the backend resolves `funky-protos` from the uv workspace, all at the repo root — so a package-directory context fails with `read buf.gen.yaml: file does not exist`. Adds `session_store/gcp_python_postgres/cloudbuild.yaml`, which pins `--file` to the Dockerfile with `.` (the repo root, the uploaded source) as the context. The README gains a prominent callout about the context requirement (naming the exact error) plus a Cloud Build path alongside the local docker-build path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)