### PR TITLE
Rename client health route /healthz -> /health (Cloud Run reserves /healthz)

### DIFF
--- a/client/python/README.md
+++ b/client/python/README.md
@@ -140,7 +140,7 @@ The endpoints mirror the four client calls (JSON in, JSON out, snake_case):
 
 | Method & path | Body | Returns |
 |---|---|---|
-| `GET /healthz` | — | `{"status":"ok"}` |
+| `GET /health` | — | `{"status":"ok"}` (not `/healthz` — Google's frontend reserves that path) |
 | `POST /v1/agents` | `{"name","model","system_prompt"}` | `{"id":"agt_…"}` |
 | `POST /v1/environments` | `{}` (optional) | `{"id":"env_…"}` |
 | `POST /v1/sessions` | `{"agent_id","environment_id"}` | `{"id":"ses_…"}` |

--- a/client/python/src/funky_client/server.py
+++ b/client/python/src/funky_client/server.py
@@ -14,7 +14,7 @@ handled yet — deploy the backends ``--allow-unauthenticated`` for now.
 
 Endpoints (JSON in, JSON out, snake_case throughout):
 
-    GET  /healthz                          -> {"status": "ok"}
+    GET  /health                           -> {"status": "ok"}
     POST /v1/agents                        -> {"id": "agt_..."}
     POST /v1/environments                  -> {"id": "env_..."}
     POST /v1/sessions                      -> {"id": "ses_..."}
@@ -70,7 +70,7 @@ def default_urls() -> dict[str, str]:
 def create_app(client: FunkyClient) -> Starlette:
     """Build the ASGI app over a FunkyClient (injected, so tests pass fakes)."""
 
-    async def healthz(_: Request) -> Response:
+    async def health(_: Request) -> Response:
         return JSONResponse({"status": "ok"})
 
     async def create_agent(request: Request) -> Response:
@@ -115,7 +115,10 @@ def create_app(client: FunkyClient) -> Starlette:
         return JSONResponse({"events": [_event_dict(e) for e in events]})
 
     routes = [
-        Route("/healthz", healthz, methods=["GET"]),
+        # NB: not "/healthz" — Google's frontend reserves that path and answers
+        # it with its own 404 before the request reaches a Cloud Run container,
+        # so the health route would be unreachable exactly where it's needed.
+        Route("/health", health, methods=["GET"]),
         Route("/v1/agents", create_agent, methods=["POST"]),
         Route("/v1/environments", create_environment, methods=["POST"]),
         Route("/v1/sessions", create_session, methods=["POST"]),

--- a/client/python/tests/test_server.py
+++ b/client/python/tests/test_server.py
@@ -45,9 +45,9 @@ def _parse_sse(text: str) -> list[tuple[str, dict]]:
     return frames
 
 
-def test_healthz():
+def test_health():
     client, _ = _app([])
-    assert client.get("/healthz").json() == {"status": "ok"}
+    assert client.get("/health").json() == {"status": "ok"}
 
 
 def test_create_agent_environment_session_round_trip():


### PR DESCRIPTION
Google's frontend reserves `/healthz` and answers it with its own 404 before the request reaches the Cloud Run container, so the client server's health route was unreachable on the very platform it ships to (verified against the deployed `agent-client` service: `/healthz` returned a Google Frontend 404 while every other route reached the app). Renames the route to `/health` and updates the test and README. All four real endpoints already work end-to-end on Cloud Run; this only fixes the health check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)