### PR TITLE
Pull in requests so the client can mint Cloud Run ID tokens

### DIFF
--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -30,8 +30,10 @@ server = [
   # ASGI server, as the Postgres backends use; supports SSE streaming.
   "uvicorn>=0.30",
   # Mint Cloud Run ID tokens so the client can call private (auth-required)
-  # backends; see funky_client.client._IdTokenAuth.
-  "google-auth>=2.0",
+  # backends; see funky_client.client._IdTokenAuth. The [requests] extra pulls
+  # in `requests`, which google.auth.transport.requests needs but google-auth
+  # does not install on its own.
+  "google-auth[requests]>=2.0",
 ]
 
 # funky-chat: one command to start a conversation in the terminal.

--- a/uv.lock
+++ b/uv.lock
@@ -912,7 +912,7 @@ local = [
     { name = "funky-session-store-jsonl" },
 ]
 server = [
-    { name = "google-auth" },
+    { name = "google-auth", extra = ["requests"] },
     { name = "starlette" },
     { name = "uvicorn" },
 ]
@@ -924,7 +924,7 @@ requires-dist = [
     { name = "funky-protos", editable = "gen/python" },
     { name = "funky-sandbox-runtime-docker", marker = "extra == 'local'", editable = "sandbox_runtime/local_python_docker" },
     { name = "funky-session-store-jsonl", marker = "extra == 'local'", editable = "session_store/local_python_jsonl" },
-    { name = "google-auth", marker = "extra == 'server'", specifier = ">=2.0" },
+    { name = "google-auth", extras = ["requests"], marker = "extra == 'server'", specifier = ">=2.0" },
     { name = "starlette", marker = "extra == 'server'", specifier = ">=0.37" },
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.30" },
 ]
@@ -1054,6 +1054,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/1c/70b23fc52b2bb3c70b379f3bd05c4a60ab3a873e30c6bd21c57e0154848a/google_auth-2.55.0.tar.gz", hash = "sha256:fcd3a130f575fa36403d38774af1c64a4fbfbca09215f0589d2372b5119697cb", size = 349379, upload-time = "2026-06-15T22:33:16.466Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/71/c0321dc6d63d99946da45f7c06299b934e4f7f7da5c4f14d101bcb39adf1/google_auth-2.55.0-py3-none-any.whl", hash = "sha256:a17cef9dedf98c4ebae2fb0c48c8f75952c877cbc2efe09f329ef16c2783d88a", size = 252400, upload-time = "2026-06-15T22:33:14.992Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
 ]
 
 [[package]]


### PR DESCRIPTION
Follow-up to #31: the new ID-token interceptor imports `google.auth.transport.requests`, but `google-auth` does not install `requests` on its own, so the slim `server`-extra image crashed at startup with `ImportError: The requests library is not installed`. This changes the dependency to `google-auth[requests]>=2.0` so the requests transport is importable, and re-locks `uv.lock` (which now pulls in `requests==2.34.2`) so the `--frozen` Docker build installs it. Verified by importing `google.auth.transport.requests` in a clean isolated env, plus 14/14 client tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)