### PR TITLE
Add client/local_python: a minimal REST client for local/Compose use

### DIFF
--- a/client/local_python/README.md
+++ b/client/local_python/README.md
@@ -1,0 +1,83 @@
+# funky-client-local
+
+The thin **Client** from the [architecture](../../docs/architecture.mmd) behind a
+small REST API, for local and Docker Compose use. It wires the four Funky services
+together over their generated ConnectRPC clients and exposes them as one JSON/REST
+endpoint, so another service can run a whole agent turn without talking to the four
+backends directly.
+
+This is the local sibling of [`gcp_python`](../gcp_python): the same orchestration,
+but it calls the backends over plain HTTP with no auth (the Cloud Run variant adds
+OIDC ID tokens so the backends can be deployed private) and ships no deploy
+artifacts.
+
+```
+ConfigRegistry   SessionStore   SandboxRuntime   AgentService
+       \              |               |              /
+        \             |               |             /
+                 funky-client-local (this) ── REST ──> your service
+```
+
+## The REST API
+
+JSON in, JSON out, snake_case throughout:
+
+| Method & path | Body | Returns |
+|---|---|---|
+| `GET /health` | — | `{"status": "ok"}` |
+| `POST /v1/agents` | `{"name", "model", "system_prompt"}` | `{"id": "agt_..."}` |
+| `POST /v1/environments` | `{}` (optional) | `{"id": "env_..."}` |
+| `POST /v1/sessions` | `{"agent_id", "environment_id"}` | `{"id": "ses_..."}` |
+| `POST /v1/sessions/{id}/messages` | `{"prompt"}` | `{"events": [...]}` |
+
+`messages` runs one agent turn and returns the events it produced.
+
+## Run it
+
+From the repository root:
+
+```bash
+buf generate            # regenerate the protobuf/ConnectRPC stubs into gen/python
+uv sync                 # create the workspace venv and install the client + deps
+uv run funky-client-local-server --host 127.0.0.1 --port 8000
+```
+
+It reads the four backend URLs from the environment, each with a localhost default
+matching the backends' own ports — `CONFIG_REGISTRY_URL` (`:8080`),
+`SESSION_STORE_URL` (`:8081`), `SANDBOX_RUNTIME_URL` (`:8082`),
+`AGENT_SERVICE_URL` (`:8083`) — so in Docker Compose you point it at the sibling
+services by name:
+
+```bash
+CONFIG_REGISTRY_URL=http://config-registry:8080 \
+SESSION_STORE_URL=http://session-store:8081 \
+SANDBOX_RUNTIME_URL=http://sandbox-runtime:8082 \
+AGENT_SERVICE_URL=http://agent-service:8083 \
+  funky-client-local-server --host 0.0.0.0 --port 8000
+```
+
+Then drive a turn with `curl`:
+
+```bash
+# Create an agent -> {"id":"agt_..."}
+curl -s -X POST http://127.0.0.1:8000/v1/agents \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"coder","model":"claude-sonnet-4-6","system_prompt":"Be brief."}'
+
+# Open an environment and a session, then send a message
+curl -s -X POST http://127.0.0.1:8000/v1/environments -d '{}'
+curl -s -X POST http://127.0.0.1:8000/v1/sessions \
+  -H 'Content-Type: application/json' \
+  -d '{"agent_id":"agt_...","environment_id":"env_..."}'
+curl -s -X POST http://127.0.0.1:8000/v1/sessions/ses_.../messages \
+  -H 'Content-Type: application/json' -d '{"prompt":"List the files in the repo."}'
+```
+
+## Test
+
+```bash
+uv run pytest client/local_python
+```
+
+The tests drive the REST app and the orchestrator against in-memory fakes of the
+four services — no backends needed.

--- a/client/local_python/pyproject.toml
+++ b/client/local_python/pyproject.toml
@@ -1,0 +1,33 @@
+# funky-client-local — the FunkyClient orchestrator behind a small REST API, for
+# local and Docker Compose use. It wires the four Funky services together over
+# plain HTTP ConnectRPC (no auth) and exposes them as one JSON/REST endpoint. The
+# Cloud Run variant, which adds OIDC ID tokens, lives in client/gcp_python. See
+# README.md.
+[project]
+name = "funky-client-local"
+version = "0.0.0"
+description = "FunkyClient over a local REST API — the orchestrator for the four Funky services."
+requires-python = ">=3.10"
+dependencies = [
+  "funky-protos",
+  # The REST front door: a small ASGI framework and an ASGI server. The server is
+  # the whole point of this package, so unlike the gcp variant these aren't behind
+  # an extra.
+  "starlette>=0.37",
+  "uvicorn>=0.30",
+]
+
+# funky-client-local-server: the orchestrator over a REST API, for Compose.
+[project.scripts]
+funky-client-local-server = "funky_client_local.server:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/funky_client_local"]
+
+# Resolve funky-protos from the workspace rather than PyPI.
+[tool.uv.sources]
+funky-protos = { workspace = true }

--- a/client/local_python/src/funky_client_local/__init__.py
+++ b/client/local_python/src/funky_client_local/__init__.py
@@ -1,0 +1,5 @@
+"""FunkyClient (local) — the orchestrator that ties the four Funky services together."""
+
+from .client import FunkyClient
+
+__all__ = ["FunkyClient"]

--- a/client/local_python/src/funky_client_local/client.py
+++ b/client/local_python/src/funky_client_local/client.py
@@ -1,0 +1,194 @@
+"""FunkyClient — the orchestrator that ties the four Funky services together.
+
+Local variant: it talks to the four backends over plain HTTP ConnectRPC with no
+auth, which is all a local or Docker Compose deployment needs. (The Cloud Run
+variant, client/gcp_python, additionally signs each call with a Google OIDC ID
+token so the backends can be deployed private.) The orchestration is otherwise
+identical.
+
+    client = FunkyClient.from_urls(
+        config_registry_url="http://127.0.0.1:8080",
+        session_store_url="http://127.0.0.1:8081",
+        sandbox_runtime_url="http://127.0.0.1:8082",
+        agent_service_url="http://127.0.0.1:8083",
+    )
+    agent_id = client.agents.create(AgentConfig(name="coder", model="...", system_prompt="..."))
+    env_id = client.environments.create()
+    session_id = client.sessions.create(agent_id, env_id)
+    events = client.sessions.send(session_id, "List the files in the repo.")
+
+The constructor takes the four clients directly, so tests can pass fakes;
+``from_urls`` is the convenience that builds the real ConnectRPC clients.
+"""
+
+from __future__ import annotations
+
+from funky.agent.v1 import agent_service_pb2 as agent_service_pb
+from funky.agent.v1.agent_service_connect import AgentServiceClientSync
+from funky.registry.v1 import config_registry_pb2 as registry_pb
+from funky.registry.v1.config_registry_connect import ConfigRegistryClientSync
+from funky.sandbox.v1 import sandbox_runtime_pb2 as sandbox_pb
+from funky.sandbox.v1.sandbox_runtime_connect import SandboxRuntimeClientSync
+from funky.session.v1 import session_store_pb2 as session_pb
+from funky.session.v1.session_store_connect import SessionStoreClientSync
+from funky.type.v1 import agent_pb2, environment_pb2, event_pb2
+
+
+class FunkyClient:
+    """Coordinates the ConfigRegistry, SessionStore, SandboxRuntime, and
+    AgentService behind one small API (``agents``, ``environments``, ``sessions``)."""
+
+    def __init__(
+        self, config_registry, session_store, sandbox_runtime, agent_service
+    ) -> None:
+        self._config_registry = config_registry
+        self._session_store = session_store
+        self._sandbox_runtime = sandbox_runtime
+        self._agent_service = agent_service
+        self.agents = _Agents(self)
+        self.environments = _Environments(self)
+        self.sessions = _Sessions(self)
+
+    @classmethod
+    def from_urls(
+        cls,
+        *,
+        config_registry_url: str,
+        session_store_url: str,
+        sandbox_runtime_url: str,
+        agent_service_url: str,
+    ) -> "FunkyClient":
+        """Build a client from the four service base URLs (plain HTTP, no auth)."""
+        return cls(
+            ConfigRegistryClientSync(config_registry_url),
+            SessionStoreClientSync(session_store_url),
+            SandboxRuntimeClientSync(sandbox_runtime_url),
+            AgentServiceClientSync(agent_service_url),
+        )
+
+
+class _Agents:
+    """``client.agents`` — agent configs in the ConfigRegistry."""
+
+    def __init__(self, client: FunkyClient) -> None:
+        self._client = client
+
+    def create(self, config: agent_pb2.AgentConfig) -> str:
+        """Store an agent config and return its registry id."""
+        response = self._client._config_registry.create_agent(
+            registry_pb.CreateAgentRequest(config=config)
+        )
+        return response.id
+
+
+class _Environments:
+    """``client.environments`` — environment configs in the ConfigRegistry."""
+
+    def __init__(self, client: FunkyClient) -> None:
+        self._client = client
+
+    def create(self, config: environment_pb2.EnvironmentConfig | None = None) -> str:
+        """Store an environment config and return its registry id.
+
+        EnvironmentConfig is empty today, so this is callable with no argument.
+        """
+        response = self._client._config_registry.create_environment(
+            registry_pb.CreateEnvironmentRequest(
+                config=config or environment_pb2.EnvironmentConfig()
+            )
+        )
+        return response.id
+
+
+class _Sessions:
+    """``client.sessions`` — sessions and the turns run in them."""
+
+    def __init__(self, client: FunkyClient) -> None:
+        self._client = client
+
+    def create(self, agent_id: str, environment_id: str) -> str:
+        """Open a session for an agent in an environment; return its id.
+
+        Resolves the agent id to its config and snapshots it into the session; the
+        environment stays a reference by id, resolved per turn in ``send``.
+        """
+        agent_config = self._client._config_registry.get_agent(
+            registry_pb.GetAgentRequest(id=agent_id)
+        ).config
+        session = self._client._session_store.create_session(
+            session_pb.CreateSessionRequest(
+                agent_config=agent_config, environment_config_id=environment_id
+            )
+        ).session
+        return session.id
+
+    def send(
+        self, session_id: str, prompt: str | event_pb2.UserMessage
+    ) -> list[event_pb2.Event]:
+        """Send a user prompt, run one agent turn, and return the agent's events.
+
+        This is the orchestration the other methods build up to. It:
+          1. resolves the session and its environment config,
+          2. reads the prior history and persists the new user prompt,
+          3. provisions a sandbox from the session's agent + the environment,
+          4. runs the turn against the prior history, and
+          5. persists every event the agent produces, tearing the sandbox down
+             afterwards even if the turn fails.
+
+        Returns the agent's events as stored (with their assigned ids).
+        """
+        client = self._client
+        session = client._session_store.get_session(
+            session_pb.GetSessionRequest(id=session_id)
+        ).session
+        environment = client._config_registry.get_environment(
+            registry_pb.GetEnvironmentRequest(id=session.environment_config_id)
+        ).config
+        # History is the conversation *before* this prompt; the prompt is passed to
+        # the turn separately, so it is not double-counted.
+        history = client._session_store.list_events(
+            session_pb.ListEventsRequest(session_id=session_id)
+        ).events
+
+        user_message = _user_message(prompt)
+        client._session_store.append_event(
+            session_pb.AppendEventRequest(
+                session_id=session_id,
+                event=event_pb2.Event(user_message=user_message),
+            )
+        )
+
+        sandbox = client._sandbox_runtime.create_sandbox(
+            sandbox_pb.CreateSandboxRequest(
+                agent_config=session.agent_config, environment_config=environment
+            )
+        ).sandbox
+        try:
+            response = client._agent_service.run_turn(
+                agent_service_pb.RunTurnRequest(
+                    agent_config=session.agent_config,
+                    events=history,
+                    prompt=user_message,
+                    sandbox=sandbox,
+                )
+            )
+            produced = []
+            for event in response.events:
+                stored = client._session_store.append_event(
+                    session_pb.AppendEventRequest(session_id=session_id, event=event)
+                ).event
+                produced.append(stored)
+            return produced
+        finally:
+            client._sandbox_runtime.destroy_sandbox(
+                sandbox_pb.DestroySandboxRequest(sandbox_id=sandbox.id)
+            )
+
+
+def _user_message(prompt: str | event_pb2.UserMessage) -> event_pb2.UserMessage:
+    """A prompt as a UserMessage: a bare string becomes one text block."""
+    if isinstance(prompt, event_pb2.UserMessage):
+        return prompt
+    return event_pb2.UserMessage(
+        content=[event_pb2.ContentBlock(text=event_pb2.TextBlock(text=prompt))]
+    )

--- a/client/local_python/src/funky_client_local/server.py
+++ b/client/local_python/src/funky_client_local/server.py
@@ -1,0 +1,204 @@
+"""funky-client-local-server: a small REST front door for the FunkyClient orchestrator.
+
+Wraps the local :class:`~funky_client_local.client.FunkyClient` in a JSON/REST HTTP
+service so other services — or a Docker Compose stack — can drive the four Funky
+backends through one endpoint instead of wiring up four. It is stateless: every
+request resolves ids against the backends.
+
+The four backend URLs come from the environment (``CONFIG_REGISTRY_URL``,
+``SESSION_STORE_URL``, ``SANDBOX_RUNTIME_URL``, ``AGENT_SERVICE_URL``), each with a
+localhost default, so it runs locally with no config and is pointed at sibling
+containers in Compose by setting those vars. Backends are called over plain HTTP
+with no auth (the Cloud Run variant, client/gcp_python, adds OIDC ID tokens).
+
+Endpoints (JSON in, JSON out, snake_case throughout):
+
+    GET  /health                              -> {"status": "ok"}
+    POST /v1/agents                           -> {"id": "agt_..."}
+    POST /v1/environments                     -> {"id": "env_..."}
+    POST /v1/sessions                         -> {"id": "ses_..."}
+    POST /v1/sessions/{session_id}/messages   -> {"events": [...]}
+
+``messages`` runs one agent turn and returns the events it produced, as JSON, once
+the turn completes. ``create_app`` takes a FunkyClient so tests can inject fakes;
+``main`` builds the real client from the environment / flags and serves it with
+uvicorn.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+from connectrpc.errors import ConnectError
+from google.protobuf import json_format
+from starlette.applications import Starlette
+from starlette.concurrency import run_in_threadpool
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+
+from funky.type.v1 import agent_pb2, event_pb2
+
+from .client import FunkyClient
+
+# Local defaults match the backends' own default ports, so the server runs with no
+# env set; Compose overrides each via an env var to point at the sibling services.
+_URL_ENV = {
+    "config_registry_url": ("CONFIG_REGISTRY_URL", "http://127.0.0.1:8080"),
+    "session_store_url": ("SESSION_STORE_URL", "http://127.0.0.1:8081"),
+    "sandbox_runtime_url": ("SANDBOX_RUNTIME_URL", "http://127.0.0.1:8082"),
+    "agent_service_url": ("AGENT_SERVICE_URL", "http://127.0.0.1:8083"),
+}
+
+
+def default_urls() -> dict[str, str]:
+    """The four backend URLs from the environment, each with a local fallback."""
+    return {key: os.environ.get(env, default) for key, (env, default) in _URL_ENV.items()}
+
+
+def create_app(client: FunkyClient) -> Starlette:
+    """Build the ASGI app over a FunkyClient (injected, so tests pass fakes).
+
+    The ConnectRPC clients are synchronous, so each handler offloads its backend
+    calls to a worker thread to keep the event loop free.
+    """
+
+    async def health(_: Request) -> Response:
+        return JSONResponse({"status": "ok"})
+
+    async def create_agent(request: Request) -> Response:
+        body = await _json_body(request)
+        config = agent_pb2.AgentConfig(
+            name=body.get("name", ""),
+            model=body.get("model", ""),
+            system_prompt=body.get("system_prompt", ""),
+        )
+        agent_id = await run_in_threadpool(client.agents.create, config)
+        return JSONResponse({"id": agent_id}, status_code=201)
+
+    async def create_environment(request: Request) -> Response:
+        # EnvironmentConfig is empty today, so the body is ignored (but tolerated).
+        await _json_body(request, optional=True)
+        env_id = await run_in_threadpool(client.environments.create)
+        return JSONResponse({"id": env_id}, status_code=201)
+
+    async def create_session(request: Request) -> Response:
+        body = await _json_body(request)
+        agent_id = _require(body, "agent_id")
+        environment_id = _require(body, "environment_id")
+        session_id = await run_in_threadpool(
+            client.sessions.create, agent_id, environment_id
+        )
+        return JSONResponse({"id": session_id}, status_code=201)
+
+    async def send_message(request: Request) -> Response:
+        session_id = request.path_params["session_id"]
+        body = await _json_body(request)
+        prompt = _require(body, "prompt")
+        events = await run_in_threadpool(client.sessions.send, session_id, prompt)
+        return JSONResponse({"events": [_event_dict(e) for e in events]})
+
+    routes = [
+        # NB: not "/healthz" — keep parity with the gcp variant, whose health route
+        # avoids the path Google's frontend reserves.
+        Route("/health", health, methods=["GET"]),
+        Route("/v1/agents", create_agent, methods=["POST"]),
+        Route("/v1/environments", create_environment, methods=["POST"]),
+        Route("/v1/sessions", create_session, methods=["POST"]),
+        Route("/v1/sessions/{session_id}/messages", send_message, methods=["POST"]),
+    ]
+    return Starlette(
+        routes=routes,
+        exception_handlers={
+            _BadRequest: _bad_request_handler,
+            ConnectError: _connect_error_handler,
+        },
+    )
+
+
+def _event_dict(event: event_pb2.Event) -> dict:
+    """An Event as JSON, snake_case to match this API's REST convention."""
+    return json_format.MessageToDict(event, preserving_proto_field_name=True)
+
+
+class _BadRequest(Exception):
+    """A malformed request body or a missing required field (-> HTTP 400)."""
+
+
+async def _json_body(request: Request, *, optional: bool = False) -> dict:
+    """Parse the JSON body into a dict; raise _BadRequest on anything else.
+
+    With ``optional``, an empty body becomes ``{}`` (for endpoints whose body is
+    not required, like creating an environment).
+    """
+    raw = await request.body()
+    if not raw:
+        if optional:
+            return {}
+        raise _BadRequest("request body must be a JSON object")
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as err:
+        raise _BadRequest(f"invalid JSON: {err}") from err
+    if not isinstance(body, dict):
+        raise _BadRequest("request body must be a JSON object")
+    return body
+
+
+def _require(body: dict, field: str) -> str:
+    value = body.get(field)
+    if not isinstance(value, str) or not value:
+        raise _BadRequest(f"missing required field: {field!r}")
+    return value
+
+
+def _bad_request_handler(_: Request, exc: _BadRequest) -> Response:
+    return JSONResponse({"error": str(exc)}, status_code=400)
+
+
+def _connect_error_handler(_: Request, exc: ConnectError) -> Response:
+    # Map the backend's Connect status onto an HTTP status: not-found -> 404,
+    # invalid argument -> 400, everything else -> 502 (a backend call failed).
+    status = {"not_found": 404, "invalid_argument": 400}.get(exc.code.name, 502)
+    return JSONResponse({"error": str(exc), "code": exc.code.name}, status_code=status)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    # Off the backends' 8080–8083 so the whole stack can run locally at once.
+    parser.add_argument("--port", type=int, default=8000)
+    urls = default_urls()
+    for key, (env, _default) in _URL_ENV.items():
+        parser.add_argument(
+            f"--{key.replace('_', '-')}",
+            default=urls[key],
+            help=f"base URL of the {key[:-4].replace('_', ' ')} (defaults to ${env})",
+        )
+    args = parser.parse_args()
+
+    client = FunkyClient.from_urls(
+        config_registry_url=args.config_registry_url,
+        session_store_url=args.session_store_url,
+        sandbox_runtime_url=args.sandbox_runtime_url,
+        agent_service_url=args.agent_service_url,
+    )
+    app = create_app(client)
+
+    import uvicorn
+
+    print(
+        f"FunkyClient (local) REST API on http://{args.host}:{args.port}\n"
+        f"  config registry  {args.config_registry_url}\n"
+        f"  session store    {args.session_store_url}\n"
+        f"  sandbox runtime  {args.sandbox_runtime_url}\n"
+        f"  agent service    {args.agent_service_url}",
+        flush=True,
+    )
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/client/local_python/tests/test_local_client.py
+++ b/client/local_python/tests/test_local_client.py
@@ -1,0 +1,196 @@
+"""Drive FunkyClient against in-memory fakes of the four services, asserting the
+orchestration: which service is called, with what, in what order. Each service's
+own wire path is covered by its backend's tests; here the Client's coordination is
+the thing under test, so the fakes are injected directly (no servers needed). The
+fakes are also reused by test_local_server."""
+
+from __future__ import annotations
+
+from funky.agent.v1 import agent_service_pb2 as agent_service_pb
+from funky.registry.v1 import config_registry_pb2 as registry_pb
+from funky.sandbox.v1 import sandbox_runtime_pb2 as sandbox_pb
+from funky.session.v1 import session_store_pb2 as session_pb
+from funky.type.v1 import agent_pb2, event_pb2, sandbox_pb2, session_pb2
+
+from funky_client_local import FunkyClient
+
+
+class FakeConfigRegistry:
+    """In-memory ConfigRegistry: mints ids and stores configs."""
+
+    def __init__(self) -> None:
+        self.agents: dict[str, agent_pb2.AgentConfig] = {}
+        self.environments: dict[str, object] = {}
+        self._n = 0
+
+    def create_agent(self, request):
+        self._n += 1
+        agent_id = f"agt_{self._n}"
+        self.agents[agent_id] = request.config
+        return registry_pb.CreateAgentResponse(id=agent_id)
+
+    def get_agent(self, request):
+        return registry_pb.GetAgentResponse(config=self.agents[request.id])
+
+    def create_environment(self, request):
+        self._n += 1
+        env_id = f"env_{self._n}"
+        self.environments[env_id] = request.config
+        return registry_pb.CreateEnvironmentResponse(id=env_id)
+
+    def get_environment(self, request):
+        return registry_pb.GetEnvironmentResponse(config=self.environments[request.id])
+
+
+class FakeSessionStore:
+    """In-memory SessionStore: mints ids and keeps an append-only event log."""
+
+    def __init__(self) -> None:
+        self.sessions: dict[str, session_pb2.Session] = {}
+        self.events: dict[str, list[event_pb2.Event]] = {}
+        self._n = 0
+
+    def create_session(self, request):
+        self._n += 1
+        session = session_pb2.Session(
+            id=f"ses_{self._n}",
+            agent_config=request.agent_config,
+            environment_config_id=request.environment_config_id,
+        )
+        self.sessions[session.id] = session
+        self.events[session.id] = []
+        return session_pb.CreateSessionResponse(session=session)
+
+    def get_session(self, request):
+        return session_pb.GetSessionResponse(session=self.sessions[request.id])
+
+    def append_event(self, request):
+        self._n += 1
+        stored = event_pb2.Event()
+        stored.CopyFrom(request.event)
+        stored.id = f"evt_{self._n}"
+        stored.session_id = request.session_id
+        stored.processed_at.GetCurrentTime()
+        self.events[request.session_id].append(stored)
+        return session_pb.AppendEventResponse(event=stored)
+
+    def list_events(self, request):
+        return session_pb.ListEventsResponse(events=self.events[request.session_id])
+
+
+class FakeSandboxRuntime:
+    """In-memory SandboxRuntime: records create/destroy and hands out sandbox ids."""
+
+    def __init__(self) -> None:
+        self.created: list = []
+        self.destroyed: list[str] = []
+        self._n = 0
+
+    def create_sandbox(self, request):
+        self._n += 1
+        self.created.append(request)
+        return sandbox_pb.CreateSandboxResponse(
+            sandbox=sandbox_pb2.Sandbox(id=f"sbx_{self._n}")
+        )
+
+    def destroy_sandbox(self, request):
+        self.destroyed.append(request.sandbox_id)
+        return sandbox_pb.DestroySandboxResponse()
+
+
+class FakeAgentService:
+    """In-memory AgentService: records each run_turn and replies with canned
+    events, one response (a list of events) per call."""
+
+    def __init__(self, responses: list[list[event_pb2.Event]]) -> None:
+        self._responses = list(responses)
+        self.requests: list = []
+
+    def run_turn(self, request):
+        self.requests.append(request)
+        return agent_service_pb.RunTurnResponse(events=self._responses.pop(0))
+
+
+def _agent_event(text: str) -> event_pb2.Event:
+    return event_pb2.Event(
+        agent_message=event_pb2.AgentMessage(
+            content=[event_pb2.ContentBlock(text=event_pb2.TextBlock(text=text))]
+        )
+    )
+
+
+def _client(agent_responses):
+    registry = FakeConfigRegistry()
+    store = FakeSessionStore()
+    runtime = FakeSandboxRuntime()
+    agent = FakeAgentService(agent_responses)
+    return FunkyClient(registry, store, runtime, agent), registry, store, runtime, agent
+
+
+def test_create_resolves_the_agent_and_snapshots_it_into_the_session():
+    client, registry, store, _, _ = _client([])
+
+    agent_id = client.agents.create(
+        agent_pb2.AgentConfig(name="coder", model="claude-sonnet-4-6", system_prompt="be brief")
+    )
+    env_id = client.environments.create()
+    session_id = client.sessions.create(agent_id, env_id)
+
+    assert agent_id in registry.agents
+    assert env_id in registry.environments
+    # The session snapshots the resolved agent config and references the env by id.
+    session = store.sessions[session_id]
+    assert session.agent_config.model == "claude-sonnet-4-6"
+    assert session.environment_config_id == env_id
+
+
+def test_send_runs_a_turn_and_persists_the_whole_exchange():
+    client, _, store, runtime, agent = _client([[_agent_event("hi there")]])
+
+    agent_id = client.agents.create(
+        agent_pb2.AgentConfig(name="coder", model="m", system_prompt="s")
+    )
+    session_id = client.sessions.create(agent_id, client.environments.create())
+
+    produced = client.sessions.send(session_id, "hello")
+
+    # The AgentService got the snapshot config, the (empty) prior history, the
+    # prompt, and the sandbox that was provisioned for the turn.
+    [run] = agent.requests
+    assert run.agent_config.model == "m"
+    assert list(run.events) == []
+    assert run.prompt.content[0].text.text == "hello"
+    assert len(runtime.created) == 1
+    # The sandbox was created for the turn, then torn down.
+    assert runtime.destroyed == [run.sandbox.id]
+
+    # The user prompt and the agent's reply were persisted, in order.
+    history = store.events[session_id]
+    assert [e.WhichOneof("payload") for e in history] == ["user_message", "agent_message"]
+    assert history[0].user_message.content[0].text.text == "hello"
+    assert history[1].agent_message.content[0].text.text == "hi there"
+
+    # send returns the agent's events as stored (with assigned ids).
+    assert [e.agent_message.content[0].text.text for e in produced] == ["hi there"]
+    assert all(e.id for e in produced)
+
+
+def test_sandbox_is_destroyed_even_when_the_turn_fails():
+    client, _, store, runtime, _ = _client([])
+    agent_id = client.agents.create(
+        agent_pb2.AgentConfig(name="coder", model="m", system_prompt="s")
+    )
+    session_id = client.sessions.create(agent_id, client.environments.create())
+
+    # FakeAgentService was given no responses, so run_turn raises (pop from empty).
+    raised = False
+    try:
+        client.sessions.send(session_id, "hello")
+    except IndexError:
+        raised = True
+
+    assert raised
+    # The sandbox was still torn down, and the user prompt was still persisted.
+    assert len(runtime.created) == 1
+    assert runtime.destroyed == ["sbx_1"]
+    assert [e.WhichOneof("payload") for e in store.events[session_id]] == ["user_message"]

--- a/client/local_python/tests/test_local_server.py
+++ b/client/local_python/tests/test_local_server.py
@@ -1,0 +1,91 @@
+"""Drive the REST server against a FunkyClient over the in-memory fakes, asserting
+the JSON surface: the four endpoints round-trip ids, a turn returns the agent's
+events as JSON, and bad input maps to 400. The orchestration itself is covered by
+test_local_client; here the HTTP layer on top of it is the thing under test, so the
+same fakes are reused."""
+
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from funky_client_local import FunkyClient
+from funky_client_local.server import create_app
+
+# Reuse the four in-memory fakes (and the event helper) from the client tests.
+from test_local_client import (
+    FakeAgentService,
+    FakeConfigRegistry,
+    FakeSandboxRuntime,
+    FakeSessionStore,
+    _agent_event,
+)
+
+
+def _app(agent_responses):
+    agent = FakeAgentService(agent_responses)
+    client = FunkyClient(
+        FakeConfigRegistry(), FakeSessionStore(), FakeSandboxRuntime(), agent
+    )
+    return TestClient(create_app(client)), agent
+
+
+def test_health():
+    client, _ = _app([])
+    assert client.get("/health").json() == {"status": "ok"}
+
+
+def test_create_agent_environment_session_round_trip():
+    client, _ = _app([])
+
+    agent = client.post(
+        "/v1/agents", json={"name": "coder", "model": "m", "system_prompt": "s"}
+    )
+    assert agent.status_code == 201
+    agent_id = agent.json()["id"]
+    assert agent_id.startswith("agt_")
+
+    env = client.post("/v1/environments", json={})
+    assert env.status_code == 201
+    env_id = env.json()["id"]
+    assert env_id.startswith("env_")
+
+    # Environment body is optional — no body works too.
+    assert client.post("/v1/environments").status_code == 201
+
+    session = client.post(
+        "/v1/sessions", json={"agent_id": agent_id, "environment_id": env_id}
+    )
+    assert session.status_code == 201
+    assert session.json()["id"].startswith("ses_")
+
+
+def test_send_message_returns_events_as_json():
+    client, agent = _app([[_agent_event("hi there")]])
+    session_id = _start_session(client)
+
+    resp = client.post(f"/v1/sessions/{session_id}/messages", json={"prompt": "hello"})
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+    # The agent's reply comes back, snake_case, with its assigned id.
+    assert events[0]["agent_message"]["content"][0]["text"]["text"] == "hi there"
+    assert events[0]["id"]
+    # The turn saw the prompt.
+    assert agent.requests[0].prompt.content[0].text.text == "hello"
+
+
+def test_missing_required_field_is_400():
+    client, _ = _app([])
+    assert client.post("/v1/sessions", json={"agent_id": "agt_1"}).status_code == 400
+    assert client.post("/v1/agents", content=b"not json").status_code == 400
+    session_id = _start_session(client)
+    assert client.post(f"/v1/sessions/{session_id}/messages", json={}).status_code == 400
+
+
+def _start_session(client: TestClient) -> str:
+    agent_id = client.post(
+        "/v1/agents", json={"name": "c", "model": "m", "system_prompt": "s"}
+    ).json()["id"]
+    env_id = client.post("/v1/environments", json={}).json()["id"]
+    return client.post(
+        "/v1/sessions", json={"agent_id": agent_id, "environment_id": env_id}
+    ).json()["id"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ members = [
   "agent_service/local_python_anthropic",
   "agent_service/gcp_python_openrouter",
   "client/gcp_python",
+  "client/local_python",
 ]
 
 # The Modal SDK (sandbox_runtime/gcp_python_modal) declares a conservative

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,7 @@ members = [
     "funky-agent-service-anthropic",
     "funky-agent-service-openrouter",
     "funky-client",
+    "funky-client-local",
     "funky-config-registry-jsonl",
     "funky-config-registry-postgres",
     "funky-protos",
@@ -929,6 +930,23 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.30" },
 ]
 provides-extras = ["local", "server"]
+
+[[package]]
+name = "funky-client-local"
+version = "0.0.0"
+source = { editable = "client/local_python" }
+dependencies = [
+    { name = "funky-protos" },
+    { name = "starlette" },
+    { name = "uvicorn" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "funky-protos", editable = "gen/python" },
+    { name = "starlette", specifier = ">=0.37" },
+    { name = "uvicorn", specifier = ">=0.30" },
+]
 
 [[package]]
 name = "funky-config-registry-jsonl"


### PR DESCRIPTION
Adds `client/local_python`, the local sibling of `client/gcp_python`: the same `FunkyClient` orchestrator, but stripped to the essentials for a local or Docker Compose stack — it calls the four backends over plain HTTP with no auth (no Cloud Run OIDC), and drops SSE, the CLI, and the deploy artifacts. A small Starlette JSON/REST server (`funky-client-local-server`) exposes the orchestrator as one endpoint so other services can run a whole agent turn without wiring up the four backends, with the backend URLs read from the `CONFIG_REGISTRY_URL` / `SESSION_STORE_URL` / `SANDBOX_RUNTIME_URL` / `AGENT_SERVICE_URL` env vars so it points at sibling containers in Compose. The package is registered as a uv workspace member; its deps are just `funky-protos`, `starlette`, and `uvicorn`. Tests drive both the orchestrator and the REST surface against in-memory fakes (distinct test basenames avoid colliding with the gcp client) — `uv run pytest client/local_python` passes 7, and the full suite stays green at 57 passed / 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)