### PR TITLE
Add Docker Compose for the whole local stack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,7 @@ gen/python/funky/
 # Example runtime data and workspace scratch.
 data/
 .context/
+
+# Local Compose secrets — never bake ANTHROPIC_API_KEY into an image layer. It's
+# passed to the agent-service at run time via the environment, not the build.
+.env

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy to .env (gitignored) before `docker compose up`. Compose reads .env
+# automatically from the repo root.
+
+# Required: the agent-service makes a real, billed call to the Anthropic Messages
+# API on each turn. The model named in a request's AgentConfig.model must be one
+# your key can call.
+ANTHROPIC_API_KEY=sk-ant-...

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ __pycache__/
 
 # Example runtime data (the JSONL config stores).
 data/
+
+# Local Docker Compose secrets (ANTHROPIC_API_KEY); .env.example is committed.
+.env

--- a/README.md
+++ b/README.md
@@ -48,6 +48,42 @@ Each is an interface. Funky doesn't care whether your `SandboxRuntime` is backed
 3. **Start a session.** Launch a session that references your agent and environment configuration.
 4. **Send events and stream responses.** Send user messages as events. The agent autonomously executes tools and streams back results through server-sent events (SSE). Event history is persisted server-side and can be fetched in full.
 
+## Run the whole stack locally with Docker Compose
+
+The repo ships a fully local implementation of each of the four contracts plus the
+REST client, wired together in [`docker-compose.yml`](./docker-compose.yml): a
+JSONL [`ConfigRegistry`](./config_registry/local_python_jsonl) and
+[`SessionStore`](./session_store/local_python_jsonl), a Docker-backed
+[`SandboxRuntime`](./sandbox_runtime/local_python_docker), an Anthropic
+[`AgentService`](./agent_service/local_python_anthropic), and the
+[`Client`](./client/local_python) as the one published front door (`:8000`).
+
+```bash
+cp .env.example .env        # then put your ANTHROPIC_API_KEY in it
+docker compose up --build
+```
+
+Then drive a turn against the client (see [its README](./client/local_python)):
+
+```bash
+curl -s -X POST http://127.0.0.1:8000/v1/agents \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"coder","model":"claude-sonnet-4-6","system_prompt":"Be brief."}'
+curl -s -X POST http://127.0.0.1:8000/v1/environments -d '{}'
+curl -s -X POST http://127.0.0.1:8000/v1/sessions \
+  -H 'Content-Type: application/json' \
+  -d '{"agent_id":"agt_...","environment_id":"env_..."}'
+curl -s -X POST http://127.0.0.1:8000/v1/sessions/ses_.../messages \
+  -H 'Content-Type: application/json' -d '{"prompt":"List the files in the repo."}'
+```
+
+The `sandbox-runtime` service bind-mounts the host Docker socket and runs each
+sandbox as a *sibling* container on the host daemon (Docker-out-of-Docker). The
+config and session stores persist to named volumes, so they survive
+`docker compose down`; add `-v` to wipe them. A sandbox left behind by a crash is
+labelled and reapable with
+`docker rm -f $(docker ps -aq --filter label=funky.sandbox)`.
+
 ## Pluggable by design
 
 Every contract is an interface, so each layer is independently swappable. These are *examples of the kinds of backends that fit each contract*, not a list of shipped integrations.

--- a/agent_service/local_python_anthropic/Dockerfile
+++ b/agent_service/local_python_anthropic/Dockerfile
@@ -1,0 +1,50 @@
+# Container image for the local Anthropic AgentService, for Docker Compose.
+#
+# IMPORTANT: build with the REPOSITORY ROOT as the context, not this directory —
+# the backend resolves `funky-protos` from the uv workspace (gen/python) and the
+# ConnectRPC stubs are generated from proto/ at build time. From the repo root:
+#
+#   docker build -f agent_service/local_python_anthropic/Dockerfile \
+#     -t funky-agent-service-anthropic .
+#
+# `buf generate` reaches Buf's remote plugins, so the build needs network access.
+#
+# A turn makes a real, billed call to the Anthropic Messages API, so
+# ANTHROPIC_API_KEY must be in the environment, and it execs its tools in a
+# SandboxRuntime, reached over HTTP at --sandbox-runtime-url (so this service
+# never needs the Docker socket — only the sandbox-runtime does). Both are wired
+# up by the agent-service entry in docker-compose.yml.
+
+FROM python:3.12-slim
+
+# uv for locked, reproducible dependency installation.
+COPY --from=ghcr.io/astral-sh/uv:0.10.9 /uv /uvx /bin/
+
+# buf, to generate the *_pb2 / *_connect stubs from proto/ at build time (they're
+# gitignored — the .proto files are the source of truth).
+ARG BUF_VERSION=1.70.0
+ARG TARGETARCH=amd64
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && buf_arch="$(case "$TARGETARCH" in arm64) echo aarch64 ;; *) echo x86_64 ;; esac)" \
+ && curl -fsSL "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-Linux-${buf_arch}" \
+      -o /usr/local/bin/buf \
+ && chmod +x /usr/local/bin/buf \
+ && apt-get purge -y --auto-remove curl \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . .
+
+# Generate the stubs, then install just this backend (plus funky-protos) from the
+# committed lockfile into /app/.venv. --no-dev drops the test-only deps.
+RUN buf generate \
+ && uv sync --frozen --no-dev --package funky-agent-service-anthropic
+
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Bind all interfaces so sibling Compose services can reach it. The sandbox URL is
+# a CLI flag (no env-var fallback in the server), so Compose passes it through
+# SANDBOX_RUNTIME_URL here; ANTHROPIC_API_KEY is read from the environment.
+EXPOSE 8083
+CMD ["sh", "-c", "funky-agent-service-anthropic --host 0.0.0.0 --port ${PORT:-8083} --sandbox-runtime-url ${SANDBOX_RUNTIME_URL:-http://127.0.0.1:8082}"]

--- a/client/local_python/Dockerfile
+++ b/client/local_python/Dockerfile
@@ -1,0 +1,47 @@
+# Container image for the local FunkyClient REST front door, for Docker Compose.
+#
+# IMPORTANT: build with the REPOSITORY ROOT as the context, not this directory —
+# the client resolves `funky-protos` from the uv workspace (gen/python) and the
+# ConnectRPC stubs are generated from proto/ at build time. From the repo root:
+#
+#   docker build -f client/local_python/Dockerfile -t funky-client-local .
+#
+# `buf generate` reaches Buf's remote plugins, so the build needs network access.
+# This is the only service that needs publishing to the host; it fans out to the
+# four backends, whose URLs it reads from the environment (see docker-compose.yml).
+
+FROM python:3.12-slim
+
+# uv for locked, reproducible dependency installation.
+COPY --from=ghcr.io/astral-sh/uv:0.10.9 /uv /uvx /bin/
+
+# buf, to generate the *_pb2 / *_connect stubs from proto/ at build time (they're
+# gitignored — the .proto files are the source of truth).
+ARG BUF_VERSION=1.70.0
+ARG TARGETARCH=amd64
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && buf_arch="$(case "$TARGETARCH" in arm64) echo aarch64 ;; *) echo x86_64 ;; esac)" \
+ && curl -fsSL "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-Linux-${buf_arch}" \
+      -o /usr/local/bin/buf \
+ && chmod +x /usr/local/bin/buf \
+ && apt-get purge -y --auto-remove curl \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . .
+
+# Generate the stubs, then install just the client (plus funky-protos) from the
+# committed lockfile into /app/.venv. --no-dev drops the test-only deps. Unlike
+# the gcp variant, the REST stack (starlette + uvicorn) is a hard dependency, so
+# there is no `server` extra to select.
+RUN buf generate \
+ && uv sync --frozen --no-dev --package funky-client-local
+
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Bind all interfaces so the published port reaches it. The four backend URLs come
+# from the environment (CONFIG_REGISTRY_URL / SESSION_STORE_URL /
+# SANDBOX_RUNTIME_URL / AGENT_SERVICE_URL); each falls back to a localhost default.
+EXPOSE 8000
+CMD ["sh", "-c", "funky-client-local-server --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/config_registry/local_python_jsonl/Dockerfile
+++ b/config_registry/local_python_jsonl/Dockerfile
@@ -1,0 +1,44 @@
+# Container image for the local JSONL ConfigRegistry, for Docker Compose.
+#
+# IMPORTANT: build with the REPOSITORY ROOT as the context, not this directory —
+# the backend resolves `funky-protos` from the uv workspace (gen/python) and the
+# ConnectRPC stubs are generated from proto/ at build time. From the repo root:
+#
+#   docker build -f config_registry/local_python_jsonl/Dockerfile \
+#     -t funky-config-registry-jsonl .
+#
+# `buf generate` reaches Buf's remote plugins, so the build needs network access.
+# The whole local stack is wired together in docker-compose.yml at the repo root.
+
+FROM python:3.12-slim
+
+# uv for locked, reproducible dependency installation.
+COPY --from=ghcr.io/astral-sh/uv:0.10.9 /uv /uvx /bin/
+
+# buf, to generate the *_pb2 / *_connect stubs from proto/ at build time (they're
+# gitignored — the .proto files are the source of truth).
+ARG BUF_VERSION=1.70.0
+ARG TARGETARCH=amd64
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && buf_arch="$(case "$TARGETARCH" in arm64) echo aarch64 ;; *) echo x86_64 ;; esac)" \
+ && curl -fsSL "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-Linux-${buf_arch}" \
+      -o /usr/local/bin/buf \
+ && chmod +x /usr/local/bin/buf \
+ && apt-get purge -y --auto-remove curl \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . .
+
+# Generate the stubs, then install just this backend (plus funky-protos) from the
+# committed lockfile into /app/.venv. --no-dev drops the test-only deps.
+RUN buf generate \
+ && uv sync --frozen --no-dev --package funky-config-registry-jsonl
+
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Bind all interfaces so sibling Compose services can reach it; --data-dir is a
+# mounted volume in Compose so the JSONL stores survive `docker compose down`.
+EXPOSE 8080
+CMD ["sh", "-c", "funky-config-registry-jsonl --host 0.0.0.0 --port ${PORT:-8080} --data-dir ${DATA_DIR:-/data}"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,92 @@
+# The whole local Funky stack in one file: the four backends plus the REST client,
+# all built from the repo as the build context (each Dockerfile generates the proto
+# stubs and installs just its own package). Bring it up from the repo root:
+#
+#   cp .env.example .env        # then put your ANTHROPIC_API_KEY in it
+#   docker compose up --build
+#
+# Then drive a turn against the client on http://127.0.0.1:8000 (see
+# client/local_python/README.md). Only the client is published to the host; the
+# four backends talk to each other over the compose network by service name.
+#
+# Ports mirror each backend's own default: config-registry 8080, session-store
+# 8081, sandbox-runtime 8082, agent-service 8083, client 8000. Every server is
+# launched with --host 0.0.0.0 (their default is loopback-only, which siblings
+# can't reach) via each image's CMD.
+
+services:
+  config-registry:
+    build:
+      context: .
+      dockerfile: config_registry/local_python_jsonl/Dockerfile
+    # JSONL configs persist in a named volume so they survive `compose down`.
+    volumes:
+      - config-data:/data
+    restart: unless-stopped
+
+  session-store:
+    build:
+      context: .
+      dockerfile: session_store/local_python_jsonl/Dockerfile
+    # JSONL sessions + events persist in a named volume.
+    volumes:
+      - session-data:/data
+    restart: unless-stopped
+
+  sandbox-runtime:
+    build:
+      context: .
+      dockerfile: sandbox_runtime/local_python_docker/Dockerfile
+    # Option 1 — Docker-out-of-Docker: bind-mount the host daemon's socket so the
+    # runtime can spawn each sandbox as a *sibling* container on the host. Simple
+    # and shares the host image cache, at the cost of giving this one service
+    # effective root on the host daemon. Sandboxes self-clean per turn (the client
+    # destroys them in a finally) and carry a funky.sandbox=true label, so any left
+    # by a crash are reapable:
+    #   docker rm -f $(docker ps -aq --filter label=funky.sandbox)
+    #
+    # To harden without code changes (the runtime honours DOCKER_HOST via
+    # docker.from_env()), drop the socket mount and put a docker-socket-proxy in
+    # front instead, then set `environment: DOCKER_HOST: tcp://docker-proxy:2375`.
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: unless-stopped
+
+  agent-service:
+    build:
+      context: .
+      dockerfile: agent_service/local_python_anthropic/Dockerfile
+    environment:
+      # A turn makes a real, billed Anthropic call; taken from .env (or the shell).
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:?set ANTHROPIC_API_KEY in .env}
+      # The sandbox URL is a CLI flag on the server (no env fallback); the image's
+      # CMD forwards this var into --sandbox-runtime-url.
+      SANDBOX_RUNTIME_URL: http://sandbox-runtime:8082
+    depends_on:
+      - sandbox-runtime
+    restart: unless-stopped
+
+  client:
+    build:
+      context: .
+      dockerfile: client/local_python/Dockerfile
+    # The one service published to the host.
+    ports:
+      - "8000:8000"
+    # The client reads each backend's base URL from the environment.
+    environment:
+      CONFIG_REGISTRY_URL: http://config-registry:8080
+      SESSION_STORE_URL: http://session-store:8081
+      SANDBOX_RUNTIME_URL: http://sandbox-runtime:8082
+      AGENT_SERVICE_URL: http://agent-service:8083
+    depends_on:
+      - config-registry
+      - session-store
+      - sandbox-runtime
+      - agent-service
+    restart: unless-stopped
+
+# Persist the JSONL stores across `compose down`. Remove with `compose down -v`.
+volumes:
+  config-data:
+  session-data:

--- a/sandbox_runtime/local_python_docker/Dockerfile
+++ b/sandbox_runtime/local_python_docker/Dockerfile
@@ -1,0 +1,50 @@
+# Container image for the local Docker SandboxRuntime, for Docker Compose.
+#
+# IMPORTANT: build with the REPOSITORY ROOT as the context, not this directory —
+# the backend resolves `funky-protos` from the uv workspace (gen/python) and the
+# ConnectRPC stubs are generated from proto/ at build time. From the repo root:
+#
+#   docker build -f sandbox_runtime/local_python_docker/Dockerfile \
+#     -t funky-sandbox-runtime-docker .
+#
+# `buf generate` reaches Buf's remote plugins, so the build needs network access.
+#
+# This backend talks to a Docker daemon (via the SDK's docker.from_env(), which
+# honours DOCKER_HOST) and spawns each sandbox as a sibling container. In Compose
+# it gets the host daemon's socket bind-mounted (Docker-out-of-Docker) — see the
+# sandbox-runtime service in docker-compose.yml. The image ships no docker CLI;
+# the Python SDK speaks to the daemon over the socket directly.
+
+FROM python:3.12-slim
+
+# uv for locked, reproducible dependency installation.
+COPY --from=ghcr.io/astral-sh/uv:0.10.9 /uv /uvx /bin/
+
+# buf, to generate the *_pb2 / *_connect stubs from proto/ at build time (they're
+# gitignored — the .proto files are the source of truth).
+ARG BUF_VERSION=1.70.0
+ARG TARGETARCH=amd64
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && buf_arch="$(case "$TARGETARCH" in arm64) echo aarch64 ;; *) echo x86_64 ;; esac)" \
+ && curl -fsSL "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-Linux-${buf_arch}" \
+      -o /usr/local/bin/buf \
+ && chmod +x /usr/local/bin/buf \
+ && apt-get purge -y --auto-remove curl \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . .
+
+# Generate the stubs, then install just this backend (plus funky-protos) from the
+# committed lockfile into /app/.venv. --no-dev drops the test-only deps.
+RUN buf generate \
+ && uv sync --frozen --no-dev --package funky-sandbox-runtime-docker
+
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Bind all interfaces so sibling Compose services can reach it. --image is the
+# base image sandboxes are created from (must contain bash for the agent's tool);
+# the default python:3.12-slim does.
+EXPOSE 8082
+CMD ["sh", "-c", "funky-sandbox-runtime-docker --host 0.0.0.0 --port ${PORT:-8082} --image ${SANDBOX_IMAGE:-python:3.12-slim}"]

--- a/session_store/local_python_jsonl/Dockerfile
+++ b/session_store/local_python_jsonl/Dockerfile
@@ -1,0 +1,44 @@
+# Container image for the local JSONL SessionStore, for Docker Compose.
+#
+# IMPORTANT: build with the REPOSITORY ROOT as the context, not this directory —
+# the backend resolves `funky-protos` from the uv workspace (gen/python) and the
+# ConnectRPC stubs are generated from proto/ at build time. From the repo root:
+#
+#   docker build -f session_store/local_python_jsonl/Dockerfile \
+#     -t funky-session-store-jsonl .
+#
+# `buf generate` reaches Buf's remote plugins, so the build needs network access.
+# The whole local stack is wired together in docker-compose.yml at the repo root.
+
+FROM python:3.12-slim
+
+# uv for locked, reproducible dependency installation.
+COPY --from=ghcr.io/astral-sh/uv:0.10.9 /uv /uvx /bin/
+
+# buf, to generate the *_pb2 / *_connect stubs from proto/ at build time (they're
+# gitignored — the .proto files are the source of truth).
+ARG BUF_VERSION=1.70.0
+ARG TARGETARCH=amd64
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && buf_arch="$(case "$TARGETARCH" in arm64) echo aarch64 ;; *) echo x86_64 ;; esac)" \
+ && curl -fsSL "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-Linux-${buf_arch}" \
+      -o /usr/local/bin/buf \
+ && chmod +x /usr/local/bin/buf \
+ && apt-get purge -y --auto-remove curl \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . .
+
+# Generate the stubs, then install just this backend (plus funky-protos) from the
+# committed lockfile into /app/.venv. --no-dev drops the test-only deps.
+RUN buf generate \
+ && uv sync --frozen --no-dev --package funky-session-store-jsonl
+
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Bind all interfaces so sibling Compose services can reach it; --data-dir is a
+# mounted volume in Compose so the JSONL stores survive `docker compose down`.
+EXPOSE 8081
+CMD ["sh", "-c", "funky-session-store-jsonl --host 0.0.0.0 --port ${PORT:-8081} --data-dir ${DATA_DIR:-/data}"]


### PR DESCRIPTION
Brings up the entire local stack with a single `docker compose up`: the four local backends (JSONL ConfigRegistry/SessionStore, Docker SandboxRuntime, Anthropic AgentService) plus the local REST client, the only service published to the host (`:8000`). Adds a Dockerfile per local variant (repo-root build context, `buf generate` + `uv sync --package`, bound to `0.0.0.0`), a `docker-compose.yml`, and a `.env.example` for `ANTHROPIC_API_KEY`. The sandbox-runtime bind-mounts the host Docker socket and runs each sandbox as a sibling container (Docker-out-of-Docker), while the JSONL stores persist to named volumes. `.env` is added to `.gitignore` and `.dockerignore` so the key never lands in an image layer, and the README documents the workflow. Verified end-to-end against the running stack, including a real agent turn that execs `bash` in a sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)