### PR TITLE
Serve the web frontend from Docker Compose (nginx + reverse proxy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,19 +51,21 @@ Each is an interface. Funky doesn't care whether your `SandboxRuntime` is backed
 ## Run the whole stack locally with Docker Compose
 
 The repo ships a fully local implementation of each of the four contracts plus the
-REST client, wired together in [`docker-compose.yml`](./docker-compose.yml): a
-JSONL [`ConfigRegistry`](./config_registry/local_python_jsonl) and
+REST client and a web UI, wired together in [`docker-compose.yml`](./docker-compose.yml):
+a JSONL [`ConfigRegistry`](./config_registry/local_python_jsonl) and
 [`SessionStore`](./session_store/local_python_jsonl), a Docker-backed
 [`SandboxRuntime`](./sandbox_runtime/local_python_docker), an Anthropic
-[`AgentService`](./agent_service/local_python_anthropic), and the
-[`Client`](./client/local_python) as the one published front door (`:8000`).
+[`AgentService`](./agent_service/local_python_anthropic), the
+[`Client`](./client/local_python) front door (`:8000`), and a pixel-art
+[web frontend](./web) (`:5173`).
 
 ```bash
 cp .env.example .env        # then put your ANTHROPIC_API_KEY in it
 docker compose up --build
 ```
 
-Then drive a turn against the client (see [its README](./client/local_python)):
+Then open the chat UI at <http://localhost:5173>, or drive the client directly
+(see [its README](./client/local_python)):
 
 ```bash
 curl -s -X POST http://127.0.0.1:8000/v1/agents \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,19 @@
-# The whole local Funky stack in one file: the four backends plus the REST client,
-# all built from the repo as the build context (each Dockerfile generates the proto
-# stubs and installs just its own package). Bring it up from the repo root:
+# The whole local Funky stack in one file: the four backends, the REST client, and
+# the web frontend, all built from the repo (each Dockerfile installs just its own
+# package). Bring it up from the repo root:
 #
 #   cp .env.example .env        # then put your ANTHROPIC_API_KEY in it
 #   docker compose up --build
 #
-# Then drive a turn against the client on http://127.0.0.1:8000 (see
-# client/local_python/README.md). Only the client is published to the host; the
-# four backends talk to each other over the compose network by service name.
+# Then open the chat UI at http://localhost:5173, or drive the client directly on
+# http://127.0.0.1:8000 (see client/local_python/README.md). The web frontend
+# (:5173) and the client (:8000) are published to the host; the four backends talk
+# to each other over the compose network by service name.
 #
 # Ports mirror each backend's own default: config-registry 8080, session-store
-# 8081, sandbox-runtime 8082, agent-service 8083, client 8000. Every server is
-# launched with --host 0.0.0.0 (their default is loopback-only, which siblings
-# can't reach) via each image's CMD.
+# 8081, sandbox-runtime 8082, agent-service 8083, client 8000, web 5173. Every
+# backend server is launched with --host 0.0.0.0 (their default is loopback-only,
+# which siblings can't reach) via each image's CMD.
 
 services:
   config-registry:
@@ -70,7 +71,7 @@ services:
     build:
       context: .
       dockerfile: client/local_python/Dockerfile
-    # The one service published to the host.
+    # Published to the host; also the upstream the web frontend proxies to.
     ports:
       - "8000:8000"
     # The client reads each backend's base URL from the environment.
@@ -84,6 +85,20 @@ services:
       - session-store
       - sandbox-runtime
       - agent-service
+    restart: unless-stopped
+
+  web:
+    # The pixel-art frontend: nginx serves the built SPA and reverse-proxies /v1
+    # and /health to the client, so the browser only talks to this one origin
+    # (no CORS). For active UI development with hot reload, skip this service and
+    # run `npm run dev` in web/ instead (see web/README.md).
+    build:
+      context: ./web
+      dockerfile: Dockerfile
+    ports:
+      - "5173:80"
+    depends_on:
+      - client
     restart: unless-stopped
 
 # Persist the JSONL stores across `compose down`. Remove with `compose down -v`.

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,8 @@
+# Keep the build context small and reproducible: deps and the bundle are produced
+# inside the image, and local env/editor files shouldn't leak in.
+node_modules
+dist
+.env
+.env.local
+*.local
+.DS_Store

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,20 @@
+# Build the static SPA, then serve it with nginx. nginx also reverse-proxies the
+# API paths to the client service, so the browser only ever talks to this origin
+# (no CORS, no backend changes) — the same shape as the Vite dev-server proxy.
+#
+# Built with context ./web (see docker-compose.yml), so COPY paths are relative
+# to the web/ directory.
+
+# --- build the production bundle ---
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# --- serve it ---
+FROM nginx:alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80

--- a/web/README.md
+++ b/web/README.md
@@ -10,40 +10,53 @@ a fresh Docker sandbox) and the response streams back into the chat.
 
 ![three states: first run, the New Agent modal, and a live conversation]
 
-## Prerequisites
+## Run it
 
-The frontend talks to the Funky **client** on `:8000`. Bring up the whole local
-stack from the repo root first:
+Two ways, both serving the UI at <http://localhost:5173>.
+
+### Option A — the whole stack with Docker Compose (recommended)
+
+From the repo root, this builds and serves the frontend alongside the backends:
 
 ```bash
 cd ..                        # repo root
 cp .env.example .env         # then put your ANTHROPIC_API_KEY in it
-docker compose up --build    # client on :8000, four backends behind it
+docker compose up --build    # backends, client (:8000), and the web UI (:5173)
 ```
 
-(See the [repo README](../README.md) for what the stack is.)
+The `web` service builds the production bundle and serves it with nginx, which
+reverse-proxies `/v1` and `/health` to the `client` service (so the browser stays
+same-origin — no CORS). There's no hot reload, so use Option B when iterating on
+the UI.
 
-## Run the frontend
+### Option B — Vite dev server (for working on the UI, with hot reload)
+
+Bring up the stack so the client is reachable on `:8000` (`docker compose up` from
+the repo root), then:
 
 ```bash
 npm install
-npm run dev          # http://localhost:5173
+npm run dev          # http://localhost:5173 (or the next free port)
 ```
 
-Open http://localhost:5173 and click **+ NEW AGENT** (it's pre-filled with a
-sample). Create it, then type a message and hit **SEND** (or Enter).
+The dev server proxies the API to the client itself, so this works even while the
+Compose `web` service is running (Vite just picks the next free port).
+
+Either way, open the UI and click **+ NEW AGENT** (pre-filled with a sample),
+create it, then type a message and hit **SEND** (or Enter).
 
 ### How it connects (no CORS, no backend changes)
 
-The Funky client ships no CORS headers, so instead of calling it cross-origin the
-Vite dev server **proxies** the API paths to it (see `vite.config.ts`):
+The Funky client ships no CORS headers, so the browser never calls it
+cross-origin — a proxy sits in front and forwards the API paths, keeping every
+request same-origin. In dev that proxy is the Vite dev server (`vite.config.ts`);
+under Docker Compose it's nginx (`nginx.conf`). The dev-server path:
 
 ```
 browser ──/v1/*, /health──> Vite dev server (:5173) ──proxy──> client (:8000)
 ```
 
-So the app only ever makes same-origin requests. Point the proxy at a client on a
-different host/port with `VITE_API_TARGET`:
+Point the dev proxy at a client on a different host/port with `VITE_API_TARGET`:
 
 ```bash
 VITE_API_TARGET=http://192.168.1.50:8000 npm run dev

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,0 +1,28 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # Serve the static SPA, with a client-side-routing fallback (harmless here).
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  # Reverse-proxy the Funky REST API to the client service over the compose
+  # network, so the browser stays same-origin (no CORS). Mirrors the Vite
+  # dev-server proxy in vite.config.ts. `client` resolves because the web
+  # service depends_on it, so it's started first.
+  location /v1/ {
+    proxy_pass http://client:8000;
+    # One message runs a whole agent turn (sandbox + model + tool loop), which
+    # can take minutes — well past nginx's 60s default, so allow headroom.
+    proxy_read_timeout 600s;
+    proxy_send_timeout 600s;
+  }
+
+  location = /health {
+    proxy_pass http://client:8000;
+  }
+}


### PR DESCRIPTION
Follows up the merged frontend (#37) by adding a `web` service to `docker-compose.yml`, so `docker compose up` now serves the whole app — UI included — at <http://localhost:5173>. A multi-stage `web/Dockerfile` builds the static SPA and serves it with nginx, which reverse-proxies `/v1` and `/health` to the `client` service, keeping the browser same-origin (no CORS, no backend changes — the same shape as the Vite dev proxy). nginx proxy timeouts are raised to 600s because one message runs a full agent turn that can exceed nginx's 60s default. `npm run dev` remains the path for UI work with hot reload; both workflows are documented in the root and `web/` READMEs. Verified by building the image and confirming nginx serves the SPA, the config is valid, and the API routes are proxied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
