### PR TITLE
Authenticate the agent's SandboxRuntime calls with a Cloud Run ID token

### DIFF
--- a/agent_service/gcp_python_openrouter/README.md
+++ b/agent_service/gcp_python_openrouter/README.md
@@ -167,3 +167,27 @@ gcloud run deploy funky-agent-service-openrouter \
   --set-secrets OPENROUTER_API_KEY=openrouter-api-key:latest \
   --set-env-vars SANDBOX_RUNTIME_URL=https://your-sandbox-runtime.run.app
 ```
+
+### Calling a private SandboxRuntime
+
+The agent execs its tools by calling the SandboxRuntime directly — a hop the
+client's auth never covers. When that runtime is `https` (Cloud Run), the agent
+mints a Google OIDC ID token (audience = the runtime URL) and attaches it to every
+`exec_command`, so the runtime can stay private. Two things must hold:
+
+- **Identity.** Grant the agent service's runtime service account
+  `roles/run.invoker` on the SandboxRuntime. A bare IAM grant is not enough on its
+  own — and neither is the token without the grant; both are required.
+
+  ```bash
+  AGENT_SA=$(gcloud run services describe agent-service --region REGION \
+    --format='value(spec.template.spec.serviceAccountName)')
+  # If empty, the service uses the Compute Engine default SA:
+  #   PROJECT_NUMBER-compute@developer.gserviceaccount.com
+  gcloud run services add-iam-policy-binding sandbox-runtime \
+    --region REGION --member "serviceAccount:$AGENT_SA" --role roles/run.invoker
+  ```
+
+- **Dependency.** The token path needs `google-auth`, already a dependency of this
+  backend (the Cloud Run image installs it). For a local `http` runtime the agent
+  skips auth entirely, so local dev and the tests are untouched.

--- a/agent_service/gcp_python_openrouter/pyproject.toml
+++ b/agent_service/gcp_python_openrouter/pyproject.toml
@@ -15,6 +15,11 @@ dependencies = [
   # Official OpenAI SDK, pointed at OpenRouter's base_url — OpenRouter exposes the
   # OpenAI Chat Completions wire format, and this is its recommended client.
   "openai>=1.40",
+  # Mint Cloud Run ID tokens so the agent can call a private (auth-required)
+  # SandboxRuntime; see funky_agent_service_openrouter._auth. The [requests]
+  # extra pulls in `requests`, which google.auth.transport.requests needs but
+  # google-auth does not install on its own. Only used for https runtimes.
+  "google-auth[requests]>=2.0",
 ]
 
 [project.scripts]

--- a/agent_service/gcp_python_openrouter/src/funky_agent_service_openrouter/_auth.py
+++ b/agent_service/gcp_python_openrouter/src/funky_agent_service_openrouter/_auth.py
@@ -1,0 +1,91 @@
+"""Authenticate the agent's calls to the SandboxRuntime with a Cloud Run ID token.
+
+The agent service runs as its own Cloud Run service and execs its tools by calling
+the SandboxRuntime directly (see ``loop._run_tool``). That hop is separate from the
+client's: the client's OIDC token authenticates client->agent and client->sandbox
+(create), but never travels into this agent->sandbox (exec) call. So when the
+SandboxRuntime is deployed private (``--no-allow-unauthenticated``, only callers
+granted ``roles/run.invoker``), the agent must mint and attach its own token here,
+or every ``exec_command`` is rejected 403.
+
+This mirrors ``funky_client.client._id_token_auth`` — kept local so the agent
+service doesn't depend on the client package (the dependency runs the other way).
+"""
+
+from __future__ import annotations
+
+import time
+
+
+def id_token_auth(url: str) -> tuple:
+    """ConnectRPC interceptors that authenticate the agent's calls to *url*.
+
+    A private (``--no-allow-unauthenticated``) Cloud Run SandboxRuntime rejects any
+    caller without a Google-signed OIDC ID token whose audience is its URL. Those
+    backends are always https; the local-dev SandboxRuntime is plain http and needs
+    no auth — so this returns nothing for http, leaving local runs and the tests
+    (which inject a fake sandbox client through the constructor) untouched.
+    """
+    if not url.startswith("https://"):
+        return ()
+    try:
+        import google.auth.transport.requests  # noqa: F401
+        import google.oauth2.id_token  # noqa: F401
+    except ModuleNotFoundError as err:  # pragma: no cover - deploy-time dependency
+        raise RuntimeError(
+            f"Calling the https SandboxRuntime {url!r} needs a Cloud Run ID token, "
+            "which requires google-auth (the Cloud Run image installs it). Install "
+            "it with: pip install 'google-auth[requests]'."
+        ) from err
+    return (_IdTokenAuth(url),)
+
+
+class _IdTokenAuth:
+    """Attaches a Cloud Run ID token to every request to the SandboxRuntime.
+
+    A ConnectRPC *metadata* interceptor: it implements ``on_start_sync`` /
+    ``on_end_sync``, so the runtime applies it to unary and streaming calls alike.
+    On Cloud Run, ``fetch_id_token`` mints an OIDC token for the agent service's
+    runtime service account via the metadata server, with the SandboxRuntime's URL
+    as the audience — exactly what the receiving service verifies. Tokens last an
+    hour; we cache and refresh five minutes early so we don't mint one per RPC.
+    """
+
+    def __init__(self, audience: str) -> None:
+        import google.auth.transport.requests
+
+        self._audience = audience
+        self._request = google.auth.transport.requests.Request()
+        self._token: str | None = None
+        self._refresh_at = 0.0
+
+    def on_start_sync(self, ctx):
+        ctx.request_headers()["authorization"] = f"Bearer {self._id_token()}"
+        return None
+
+    def on_end_sync(self, token, ctx, error) -> None:
+        return None
+
+    def _id_token(self) -> str:
+        if self._token is None or time.time() >= self._refresh_at:
+            import google.oauth2.id_token
+
+            self._token = google.oauth2.id_token.fetch_id_token(
+                self._request, self._audience
+            )
+            self._refresh_at = _jwt_expiry(self._token) - 300
+        return self._token
+
+
+def _jwt_expiry(token: str) -> float:
+    """The ``exp`` (epoch seconds) claim of a JWT, read without verifying it.
+
+    Used only to decide when to refresh a token we just minted ourselves, so
+    reading the claim without signature verification is fine here.
+    """
+    import base64
+    import json
+
+    payload = token.split(".")[1]
+    payload += "=" * (-len(payload) % 4)  # restore base64 padding
+    return float(json.loads(base64.urlsafe_b64decode(payload))["exp"])

--- a/agent_service/gcp_python_openrouter/src/funky_agent_service_openrouter/server.py
+++ b/agent_service/gcp_python_openrouter/src/funky_agent_service_openrouter/server.py
@@ -24,6 +24,7 @@ from waitress.server import create_server
 from funky.agent.v1.agent_service_connect import AgentServiceWSGIApplication
 from funky.sandbox.v1.sandbox_runtime_connect import SandboxRuntimeClientSync
 
+from ._auth import id_token_auth
 from .loop import DEFAULT_MAX_TOKENS
 from .service import AgentServiceOpenRouter
 
@@ -54,7 +55,13 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    sandbox_client = SandboxRuntimeClientSync(args.sandbox_runtime_url)
+    # A private (Cloud Run) SandboxRuntime requires a Google OIDC ID token; the
+    # agent execs its tools by calling it directly, so it must authenticate that
+    # hop itself. Local http runtimes are called as-is. See _auth.id_token_auth.
+    sandbox_client = SandboxRuntimeClientSync(
+        args.sandbox_runtime_url,
+        interceptors=id_token_auth(args.sandbox_runtime_url),
+    )
     service = AgentServiceOpenRouter(sandbox_client, max_tokens=args.max_tokens)
     app = AgentServiceWSGIApplication(service)
 

--- a/uv.lock
+++ b/uv.lock
@@ -886,6 +886,7 @@ version = "0.0.0"
 source = { editable = "agent_service/gcp_python_openrouter" }
 dependencies = [
     { name = "funky-protos" },
+    { name = "google-auth", extra = ["requests"] },
     { name = "openai" },
     { name = "waitress" },
 ]
@@ -893,6 +894,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "funky-protos", editable = "gen/python" },
+    { name = "google-auth", extras = ["requests"], specifier = ">=2.0" },
     { name = "openai", specifier = ">=1.40" },
     { name = "waitress", specifier = ">=3" },
 ]


### PR DESCRIPTION
The agent service runs as its own Cloud Run service and execs its tools by calling the SandboxRuntime directly, but that client was built with no auth interceptor — so a private SandboxRuntime (`--no-allow-unauthenticated`) rejected every `exec_command` with 403, and granting `run.invoker` alone could not fix it because no token was being sent. This mirrors `funky_client`'s `_id_token_auth` in a local `_auth` module (kept local so the dependency doesn't run backwards): for `https` runtimes the agent now mints and attaches a cached Google OIDC ID token (audience = the runtime URL), while `http` runtimes are called as-is, leaving local dev and the tests untouched. Adds `google-auth[requests]` as a dependency (with the relocked `uv.lock`) and documents the matching `roles/run.invoker` grant in the README. Verified: the agent service's 6 tests pass, the server module imports, and the auth gate returns no interceptor for `http` and exactly one for `https`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)