### PR TITLE
Add agent config schema (identity + immutable versions)

### DIFF
--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'drizzle-kit';
 
 export default defineConfig({
   out: './drizzle',
-  schema: './src/db/schema.ts',
+  schema: './schema/index.ts',
   dialect: 'postgresql',
   dbCredentials: {
     url: process.env.DATABASE_URL!,

--- a/packages/db/drizzle/20260710062902_add_agent_configs/migration.sql
+++ b/packages/db/drizzle/20260710062902_add_agent_configs/migration.sql
@@ -1,0 +1,27 @@
+CREATE TABLE "agent_config_versions" (
+	"agent_config_id" uuid,
+	"version" integer,
+	"namespace" text NOT NULL,
+	"system_prompt" text NOT NULL,
+	"model" jsonb NOT NULL,
+	"tool_policy" jsonb DEFAULT '{}' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_by" text,
+	CONSTRAINT "agent_config_versions_pkey" PRIMARY KEY("agent_config_id","version")
+);
+--> statement-breakpoint
+CREATE TABLE "agent_configs" (
+	"id" uuid PRIMARY KEY,
+	"namespace" text NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"metadata" jsonb DEFAULT '{}' NOT NULL,
+	"latest_version" integer DEFAULT 1 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"archived_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE INDEX "agent_configs_ns_name" ON "agent_configs" ("namespace","name");--> statement-breakpoint
+CREATE INDEX "agent_configs_ns" ON "agent_configs" ("namespace");--> statement-breakpoint
+ALTER TABLE "agent_config_versions" ADD CONSTRAINT "agent_config_versions_agent_config_id_agent_configs_id_fkey" FOREIGN KEY ("agent_config_id") REFERENCES "agent_configs"("id");

--- a/packages/db/drizzle/20260710062902_add_agent_configs/snapshot.json
+++ b/packages/db/drizzle/20260710062902_add_agent_configs/snapshot.json
@@ -1,0 +1,331 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "195d61ba-466d-4b50-b36b-086a408cb6fa",
+  "prevIds": [
+    "00000000-0000-0000-0000-000000000000"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "agent_config_versions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "agent_configs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "agent_config_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "system_prompt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "model",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "tool_policy",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "1",
+      "generated": null,
+      "identity": null,
+      "name": "latest_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_configs_ns_name",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_configs_ns",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "agent_config_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "agent_configs",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "agent_config_versions_agent_config_id_agent_configs_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "columns": [
+        "agent_config_id",
+        "version"
+      ],
+      "nameExplicit": false,
+      "name": "agent_config_versions_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "agent_configs_pkey",
+      "schema": "public",
+      "table": "agent_configs",
+      "entityType": "pks"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db/schema/configs.ts
+++ b/packages/db/schema/configs.ts
@@ -1,0 +1,98 @@
+// packages/db/schema/configs.ts
+// Agent config = identity + immutable versions (two tables).
+// Sessions pin (agent_config_id, version) at creation; versions are never UPDATEd —
+// "editing" an agent = INSERT next version + bump latest_version, in one transaction.
+//
+// Identity vs version split rule: fields that change agent BEHAVIOR (system_prompt,
+// model, tool_policy) live on versions; labels (name, description, metadata)
+// live on identity and mutate freely without a version bump.
+//
+// Deliberately absent for v1 (worker doesn't support them yet — add when it does):
+// skills[], mcp_servers, tools[] beyond tool_policy. When skills land, they go on
+// the versions table (behavior) as jsonb refs into the skills registry. Env configs
+// live in envs.ts (single table + archive, NOT versioned — sessions snapshot
+// resolved_env at provision).
+
+import {
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+  uuid,
+} from "drizzle-orm/pg-core";
+
+/** Mirrors what the AI SDK needs to construct a model. Validated with zod at the API edge. */
+export type ModelConfig = {
+  provider:
+    | "anthropic"
+    | "openai"
+    | "google"
+    | "xai"
+    | "openrouter"
+    | "togetherai"
+    | "fireworks"
+    | "baseten";
+  model: string; // e.g. "claude-sonnet-5"
+  maxTokens?: number;
+  temperature?: number;
+};
+
+// ---------------------------------------------------------------------------
+// Identity: mutable pointer (name, latest_version), soft-deletable
+// ---------------------------------------------------------------------------
+export const agentConfigs = pgTable(
+  "agent_configs",
+  {
+    id: uuid("id").primaryKey(), // client-supplied → idempotent PUT /agents/:id
+    // Sessions reference agents by ID (+ optional version), matching the Managed
+    // Agents API. `name` is therefore a display label — NOT unique, NOT a reference.
+    namespace: text("namespace").notNull(), // opaque partition key ("default" in OSS)
+    name: text("name").notNull(), // 1-256 chars, free-form; validated at API edge
+    description: text("description"), // identity-level metadata: mutable WITHOUT a version bump
+    metadata: jsonb("metadata")
+      .$type<Record<string, string>>()
+      .notNull()
+      .default({}), // user labels; enforce ≤16 pairs at the API edge
+    latestVersion: integer("latest_version").notNull().default(1),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+    // Archive, not delete (matches Managed Agents: agents have no DELETE endpoint).
+    // Archived = permanent read-only: existing sessions continue, new sessions
+    // cannot reference it, no unarchive. Enforced in the service layer.
+    archivedAt: timestamp("archived_at", { withTimezone: true }),
+  },
+  (t) => [
+    // non-unique: supports list/search by name; duplicates are allowed
+    index("agent_configs_ns_name").on(t.namespace, t.name),
+    index("agent_configs_ns").on(t.namespace),
+  ],
+);
+
+// ---------------------------------------------------------------------------
+// Versions: append-only, immutable. No UPDATE on this table, ever.
+// ---------------------------------------------------------------------------
+export const agentConfigVersions = pgTable(
+  "agent_config_versions",
+  {
+    agentConfigId: uuid("agent_config_id")
+      .notNull()
+      .references(() => agentConfigs.id),
+    version: integer("version").notNull(), // 1, 2, 3… per agent
+    namespace: text("namespace").notNull(), // denormalized for tenancy scoping/RLS
+
+    // ---- the actual config (name/model/system prompt requirement lives here) ----
+    systemPrompt: text("system_prompt").notNull(),
+    model: jsonb("model").$type<ModelConfig>().notNull(),
+    toolPolicy: jsonb("tool_policy")
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default({}), // allowed tools, max turns/iterations, budgets
+
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    createdBy: text("created_by"), // opaque principal: "user:123" | "key:fk_live_a1b2"
+  },
+  (t) => [primaryKey({ columns: [t.agentConfigId, t.version] })],
+);

--- a/packages/db/schema/index.ts
+++ b/packages/db/schema/index.ts
@@ -1,0 +1,3 @@
+// Barrel for all schema modules. drizzle.config.ts and the db client both
+// consume the schema through this file. Add new domains (envs, sessions, …) here.
+export * from "./configs";

--- a/packages/db/src/db/schema.ts
+++ b/packages/db/src/db/schema.ts
@@ -1,8 +1,0 @@
-import { integer, pgTable, varchar } from "drizzle-orm/pg-core";
-
-export const usersTable = pgTable("users", {
-  id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  name: varchar({ length: 255 }).notNull(),
-  age: integer().notNull(),
-  email: varchar({ length: 255 }).notNull().unique(),
-});


### PR DESCRIPTION
Adds the agent-config schema to the `db` package as a new `schema/` directory. `agent_configs` holds the mutable identity (name, description, metadata, latest_version, archivable), while `agent_config_versions` is an append-only, immutable table for behavior (system_prompt, model, tool_policy) keyed by `(agent_config_id, version)`. Drizzle now reads from `schema/index.ts`, the placeholder `users` table was removed, and the generated migration + snapshot are included. Verified by running `drizzle-kit generate`, which compiled the schema and emitted correct SQL (both tables, the two namespace indexes, and the FK); the migration has not been applied to a live database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)