### PR TITLE
Add tests for @funky/db package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "scripts": {
       "preinstall": "npx only-allow pnpm",
       "typecheck": "tsc --noEmit",
+      "test": "pnpm -r --if-present test",
       "dev": "pnpm -F api dev"
     },
     "devDependencies": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "generate": "drizzle-kit generate",
-    "migrate": "drizzle-kit migrate"
+    "migrate": "drizzle-kit migrate",
+    "test": "tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
     "drizzle-orm": "^1.0.0-beta.2",
@@ -17,6 +18,7 @@
   "devDependencies": {
     "@types/pg": "^8.20.0",
     "drizzle-kit": "^1.0.0-beta.2",
-    "dotenv": "^17.2.0"
+    "dotenv": "^17.2.0",
+    "tsx": "^4.7.1"
   }
 }

--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -1,0 +1,44 @@
+// Tests for the createDb() factory and the `tables` re-export. These stay
+// offline: a pg Pool connects lazily, and Drizzle builds SQL synchronously, so
+// we can assert wiring and rendered SQL without a running Postgres.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Pool } from "pg";
+import { createDb, tables, type Db } from "./client";
+import { agentConfigs, agentConfigVersions } from "./schema";
+
+const DUMMY_URL = "postgres://user:pass@localhost:5432/funky_test";
+
+test("createDb returns a Drizzle query builder without opening a connection", async () => {
+  const pool = new Pool({ connectionString: DUMMY_URL });
+  try {
+    const db: Db = createDb(pool);
+    assert.equal(typeof db.select, "function");
+    assert.equal(typeof db.insert, "function");
+    assert.equal(typeof db.update, "function");
+    assert.equal(typeof db.transaction, "function");
+  } finally {
+    await pool.end(); // no queries ran, so the pool never actually connected
+  }
+});
+
+test("the query builder renders schema tables into SQL", async () => {
+  const pool = new Pool({ connectionString: DUMMY_URL });
+  try {
+    const db = createDb(pool);
+    const identity = db.select().from(agentConfigs).toSQL();
+    assert.match(identity.sql, /from "agent_configs"/);
+
+    const versions = db.select().from(agentConfigVersions).toSQL();
+    assert.match(versions.sql, /from "agent_config_versions"/);
+  } finally {
+    await pool.end();
+  }
+});
+
+test("`tables` re-exports both schema tables by their identifiers", () => {
+  assert.equal(tables.agentConfigs, agentConfigs);
+  assert.equal(tables.agentConfigVersions, agentConfigVersions);
+  assert.deepEqual(Object.keys(tables).sort(), ["agentConfigVersions", "agentConfigs"].sort());
+});

--- a/packages/db/src/schema.test.ts
+++ b/packages/db/src/schema.test.ts
@@ -1,0 +1,147 @@
+// Schema-shape regression tests: assert the Drizzle table definitions in
+// schema/configs.ts still match the physical shape the migrations created.
+// These run without a database — getTableConfig() reflects the in-memory model,
+// so a rename, a dropped NOT NULL, a changed default, or a broken PK/FK/index
+// fails here loudly instead of silently drifting from migrations/.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { getTableConfig, type PgTable } from "drizzle-orm/pg-core";
+import { agentConfigs, agentConfigVersions, type ModelConfig } from "./schema";
+
+type ColSpec = {
+  type: string; // getSQLType() output, e.g. "uuid", "timestamp with time zone"
+  notNull: boolean;
+  hasDefault?: boolean;
+  default?: unknown; // deep-equal check; omit for SQL defaults like now()
+  primary?: boolean; // inline single-column primary key
+};
+
+function columnsByName(table: PgTable) {
+  return new Map(getTableConfig(table).columns.map((c) => [c.name, c]));
+}
+
+/** Assert the table has exactly `expected`'s columns, each with the given shape. */
+function assertColumns(table: PgTable, expected: Record<string, ColSpec>) {
+  const cols = columnsByName(table);
+  assert.deepEqual(
+    [...cols.keys()].sort(),
+    Object.keys(expected).sort(),
+    "column set drifted (added/removed column)",
+  );
+  for (const [name, spec] of Object.entries(expected)) {
+    const col = cols.get(name);
+    assert.ok(col, `missing column ${name}`);
+    assert.equal(col.getSQLType(), spec.type, `${name}.type`);
+    assert.equal(col.notNull, spec.notNull, `${name}.notNull`);
+    if (spec.hasDefault !== undefined) {
+      assert.equal(col.hasDefault, spec.hasDefault, `${name}.hasDefault`);
+    }
+    if (spec.default !== undefined) {
+      assert.deepEqual(col.default, spec.default, `${name}.default`);
+    }
+    if (spec.primary !== undefined) {
+      assert.equal(col.primary, spec.primary, `${name}.primary`);
+    }
+  }
+}
+
+function indexSummaries(table: PgTable) {
+  return getTableConfig(table)
+    .indexes.map((i) => ({
+      name: i.config.name ?? "", // named indexes only here; guard the type anyway
+      columns: i.config.columns.map((c) => (c as { name?: string }).name),
+      unique: i.config.unique,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// ---------------------------------------------------------------- agent_configs
+
+test("agent_configs: table name", () => {
+  assert.equal(getTableConfig(agentConfigs).name, "agent_configs");
+});
+
+test("agent_configs: columns match the migration", () => {
+  assertColumns(agentConfigs, {
+    id: { type: "uuid", notNull: true, primary: true },
+    namespace: { type: "text", notNull: true },
+    name: { type: "text", notNull: true },
+    description: { type: "text", notNull: false },
+    metadata: { type: "jsonb", notNull: true, hasDefault: true, default: {} },
+    latest_version: { type: "integer", notNull: true, hasDefault: true, default: 1 },
+    created_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
+    updated_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
+    archived_at: { type: "timestamp with time zone", notNull: false },
+  });
+});
+
+test("agent_configs: id is an inline primary key (no composite PK, no FKs)", () => {
+  const cfg = getTableConfig(agentConfigs);
+  assert.equal(cfg.primaryKeys.length, 0, "identity uses an inline PK, not a composite one");
+  assert.equal(cfg.foreignKeys.length, 0, "identity table references nothing");
+});
+
+test("agent_configs: has the two namespace lookup indexes, both non-unique", () => {
+  // name is a display label, not a reference — the (namespace, name) index must
+  // stay non-unique so duplicate names within a namespace are allowed.
+  assert.deepEqual(indexSummaries(agentConfigs), [
+    { name: "agent_configs_ns", columns: ["namespace"], unique: false },
+    { name: "agent_configs_ns_name", columns: ["namespace", "name"], unique: false },
+  ]);
+});
+
+// -------------------------------------------------------- agent_config_versions
+
+test("agent_config_versions: table name", () => {
+  assert.equal(getTableConfig(agentConfigVersions).name, "agent_config_versions");
+});
+
+test("agent_config_versions: columns match the migration", () => {
+  assertColumns(agentConfigVersions, {
+    agent_config_id: { type: "uuid", notNull: true },
+    version: { type: "integer", notNull: true },
+    namespace: { type: "text", notNull: true },
+    system_prompt: { type: "text", notNull: true },
+    model: { type: "jsonb", notNull: true },
+    tool_policy: { type: "jsonb", notNull: true, hasDefault: true, default: {} },
+    created_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
+    created_by: { type: "text", notNull: false },
+  });
+});
+
+test("agent_config_versions: composite primary key is (agent_config_id, version)", () => {
+  const pks = getTableConfig(agentConfigVersions).primaryKeys;
+  assert.equal(pks.length, 1);
+  assert.deepEqual(
+    pks[0]?.columns.map((c) => c.name),
+    ["agent_config_id", "version"],
+  );
+});
+
+test("agent_config_versions: agent_config_id references agent_configs.id", () => {
+  const fks = getTableConfig(agentConfigVersions).foreignKeys;
+  assert.equal(fks.length, 1, "exactly one foreign key");
+  const ref = fks[0]!.reference();
+  assert.deepEqual(ref.columns.map((c) => c.name), ["agent_config_id"]);
+  assert.deepEqual(ref.foreignColumns.map((c) => c.name), ["id"]);
+  assert.equal(getTableConfig(ref.foreignTable).name, "agent_configs");
+});
+
+// ------------------------------------------------------------------ ModelConfig
+
+test("ModelConfig: provider is constrained to the supported union", () => {
+  const model: ModelConfig = {
+    provider: "anthropic",
+    model: "claude-sonnet-5",
+    maxTokens: 1024,
+    temperature: 0.7,
+  };
+  assert.equal(model.provider, "anthropic");
+
+  // Compile-time guard: an unsupported provider must not type-check. tsx strips
+  // types at runtime, so this line is inert then; `tsc --noEmit` enforces it.
+  // @ts-expect-error "cohere" is not a member of the provider union
+  const unsupported: ModelConfig = { provider: "cohere", model: "x" };
+  void unsupported;
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       drizzle-kit:
         specifier: ^1.0.0-beta.2
         version: 1.0.0-rc.4-ca0f029
+      tsx:
+        specifier: ^4.7.1
+        version: 4.23.0
 
 packages:
 


### PR DESCRIPTION
Adds the first test coverage for the `@funky/db` package, which previously had none. Tests run offline with Node's built-in `node:test` runner via `tsx`, so no new test framework is introduced. `schema.test.ts` uses Drizzle's `getTableConfig` to assert the `agent_configs` and `agent_config_versions` tables still match their migration shape (columns, SQL types, `NOT NULL`, defaults, the composite primary key, the foreign key, and the namespace indexes), and `client.test.ts` covers `createDb()` and the `tables` re-export. A `test` script is wired into both the db package and the repo root (`pnpm test`), and `tsx` is added as a db devDependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)