### PR TITLE
test(api): add Vitest suite for the HTTP layer and config

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,9 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.build.json",
     "start": "node dist/index.js",
-    "start:src": "tsx src/index.ts"
+    "start:src": "tsx src/index.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@funky/configs": "workspace:*",
@@ -23,6 +25,7 @@
     "@types/node": "^22.0.0",
     "@types/pg": "^8.11.0",
     "tsx": "^4.7.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/api/test/agents.test.ts
+++ b/apps/api/test/agents.test.ts
@@ -1,0 +1,263 @@
+// The /v1/agents routes: shape validation at the edge, correct delegation to the
+// service (auth context + camelCased options), and status-code mapping.
+import { describe, it, expect, vi } from "vitest";
+import { NotFoundError } from "@funky/configs";
+import {
+  AGENT_ID,
+  CTX,
+  agentFixture,
+  createBody,
+  get,
+  makeApp,
+  post,
+  versionFixture,
+} from "./helpers";
+
+describe("POST /v1/agents (create)", () => {
+  it("creates a new agent and returns 201", async () => {
+    const agent = agentFixture();
+    const { app, fake } = makeApp({
+      agents: { create: vi.fn().mockResolvedValue({ agent, created: true }) },
+    });
+
+    const res = await post(app, "/v1/agents", createBody());
+
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual(agent);
+    expect(fake.create).toHaveBeenCalledWith(CTX, createBody());
+  });
+
+  it("returns 200 for an idempotent (already-exists) create", async () => {
+    const agent = agentFixture();
+    const { app } = makeApp({
+      agents: { create: vi.fn().mockResolvedValue({ agent, created: false }) },
+    });
+
+    const res = await post(app, "/v1/agents", createBody({ id: AGENT_ID }));
+    expect(res.status).toBe(200);
+  });
+
+  it.each([
+    ["missing name", createBody({ name: undefined })],
+    ["empty name", createBody({ name: "" })],
+    ["name too long", createBody({ name: "x".repeat(257) })],
+    ["missing system_prompt", createBody({ system_prompt: undefined })],
+    ["empty system_prompt", createBody({ system_prompt: "" })],
+    ["missing model", createBody({ model: undefined })],
+    ["bad model provider", createBody({ model: { provider: "acme", model: "x" } })],
+    ["empty model name", createBody({ model: { provider: "anthropic", model: "" } })],
+    ["temperature out of range", createBody({ model: { provider: "anthropic", model: "m", temperature: 5 } })],
+    ["unknown top-level field (strict)", createBody({ nope: true })],
+    ["non-uuid id", createBody({ id: "not-a-uuid" })],
+    ["too many metadata pairs", createBody({ metadata: Object.fromEntries(Array.from({ length: 17 }, (_, i) => [`k${i}`, "v"])) })],
+  ])("rejects %s with 400 and does not call the service", async (_label, body) => {
+    const { app, fake } = makeApp();
+
+    const res = await post(app, "/v1/agents", body);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error.type).toBe("invalid_request_error");
+    expect(fake.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /v1/agents (list)", () => {
+  it("uses defaults when no query params are given", async () => {
+    const page = { data: [agentFixture()], has_more: false, last_id: AGENT_ID };
+    const { app, fake } = makeApp({ agents: { list: vi.fn().mockResolvedValue(page) } });
+
+    const res = await get(app, "/v1/agents");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(page);
+    expect(fake.list).toHaveBeenCalledWith(CTX, {
+      limit: 20,
+      afterId: undefined,
+      includeArchived: false,
+    });
+  });
+
+  it("maps query params to service options", async () => {
+    const { app, fake } = makeApp({
+      agents: { list: vi.fn().mockResolvedValue({ data: [], has_more: false }) },
+    });
+
+    await get(app, `/v1/agents?limit=5&after_id=${AGENT_ID}&include_archived=true`);
+
+    expect(fake.list).toHaveBeenCalledWith(CTX, {
+      limit: 5,
+      afterId: AGENT_ID,
+      includeArchived: true,
+    });
+  });
+
+  it.each([
+    ["limit=0", "/v1/agents?limit=0"],
+    ["limit=101", "/v1/agents?limit=101"],
+    ["limit=abc", "/v1/agents?limit=abc"],
+    ["non-uuid after_id", "/v1/agents?after_id=nope"],
+    ["invalid include_archived", "/v1/agents?include_archived=maybe"],
+  ])("rejects %s with 400", async (_label, path) => {
+    const { app, fake } = makeApp();
+    const res = await get(app, path);
+    expect(res.status).toBe(400);
+    expect(fake.list).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /v1/agents/:id (retrieve)", () => {
+  it("returns the agent from the service", async () => {
+    const agent = agentFixture();
+    const { app, fake } = makeApp({ agents: { get: vi.fn().mockResolvedValue(agent) } });
+
+    const res = await get(app, `/v1/agents/${AGENT_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(agent);
+    expect(fake.get).toHaveBeenCalledWith(CTX, AGENT_ID);
+  });
+
+  it("returns 404 when the service reports not found", async () => {
+    const { app } = makeApp({
+      agents: { get: vi.fn().mockRejectedValue(new NotFoundError("agent not found")) },
+    });
+    const res = await get(app, `/v1/agents/${AGENT_ID}`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /v1/agents/:id (update)", () => {
+  it("applies a partial update and returns the agent", async () => {
+    const agent = agentFixture({ name: "renamed" });
+    const { app, fake } = makeApp({ agents: { update: vi.fn().mockResolvedValue(agent) } });
+
+    const res = await post(app, `/v1/agents/${AGENT_ID}`, { name: "renamed" });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(agent);
+    expect(fake.update).toHaveBeenCalledWith(CTX, AGENT_ID, { name: "renamed" });
+  });
+
+  it("rejects an empty patch with 400", async () => {
+    const { app, fake } = makeApp();
+    const res = await post(app, `/v1/agents/${AGENT_ID}`, {});
+    expect(res.status).toBe(400);
+    expect(fake.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects an attempt to change the id with 400 (strict)", async () => {
+    const { app, fake } = makeApp();
+    const res = await post(app, `/v1/agents/${AGENT_ID}`, { id: AGENT_ID, name: "x" });
+    expect(res.status).toBe(400);
+    expect(fake.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid field value with 400", async () => {
+    const { app } = makeApp();
+    const res = await post(app, `/v1/agents/${AGENT_ID}`, { system_prompt: "" });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /v1/agents/:id/archive", () => {
+  it("archives and returns the agent", async () => {
+    const archived = agentFixture({ archived_at: "2026-01-02T00:00:00.000Z" });
+    const { app, fake } = makeApp({ agents: { archive: vi.fn().mockResolvedValue(archived) } });
+
+    const res = await post(app, `/v1/agents/${AGENT_ID}/archive`);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(archived);
+    expect(fake.archive).toHaveBeenCalledWith(CTX, AGENT_ID);
+  });
+
+  it("returns 404 when the agent does not exist", async () => {
+    const { app } = makeApp({
+      agents: { archive: vi.fn().mockRejectedValue(new NotFoundError("agent not found")) },
+    });
+    const res = await post(app, `/v1/agents/${AGENT_ID}/archive`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /v1/agents/:id/versions (list versions)", () => {
+  it("uses defaults when no query params are given", async () => {
+    const listing = { data: [versionFixture()], has_more: false };
+    const { app, fake } = makeApp({
+      agents: { listVersions: vi.fn().mockResolvedValue(listing) },
+    });
+
+    const res = await get(app, `/v1/agents/${AGENT_ID}/versions`);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(listing);
+    expect(fake.listVersions).toHaveBeenCalledWith(CTX, AGENT_ID, {
+      limit: 20,
+      afterVersion: undefined,
+    });
+  });
+
+  it("maps limit and after_version to service options", async () => {
+    const { app, fake } = makeApp({
+      agents: { listVersions: vi.fn().mockResolvedValue({ data: [], has_more: false }) },
+    });
+
+    await get(app, `/v1/agents/${AGENT_ID}/versions?limit=3&after_version=5`);
+
+    expect(fake.listVersions).toHaveBeenCalledWith(CTX, AGENT_ID, {
+      limit: 3,
+      afterVersion: 5,
+    });
+  });
+
+  it("rejects after_version=0 with 400", async () => {
+    const { app, fake } = makeApp();
+    const res = await get(app, `/v1/agents/${AGENT_ID}/versions?after_version=0`);
+    expect(res.status).toBe(400);
+    expect(fake.listVersions).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the agent does not exist", async () => {
+    const { app } = makeApp({
+      agents: { listVersions: vi.fn().mockRejectedValue(new NotFoundError("agent not found")) },
+    });
+    const res = await get(app, `/v1/agents/${AGENT_ID}/versions`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /v1/agents/:id/versions/:version (retrieve version)", () => {
+  it("parses the version and returns it", async () => {
+    const version = versionFixture({ version: 2 });
+    const { app, fake } = makeApp({
+      agents: { getVersion: vi.fn().mockResolvedValue(version) },
+    });
+
+    const res = await get(app, `/v1/agents/${AGENT_ID}/versions/2`);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(version);
+    expect(fake.getVersion).toHaveBeenCalledWith(CTX, AGENT_ID, 2);
+  });
+
+  it.each([
+    ["zero", "0"],
+    ["negative", "-1"],
+    ["non-integer", "1.5"],
+    ["non-numeric", "abc"],
+  ])("rejects version %s with 400 without calling the service", async (_label, version) => {
+    const { app, fake } = makeApp();
+    const res = await get(app, `/v1/agents/${AGENT_ID}/versions/${version}`);
+    expect(res.status).toBe(400);
+    expect(fake.getVersion).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the version does not exist", async () => {
+    const { app } = makeApp({
+      agents: { getVersion: vi.fn().mockRejectedValue(new NotFoundError("agent version not found")) },
+    });
+    const res = await get(app, `/v1/agents/${AGENT_ID}/versions/9`);
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -1,0 +1,186 @@
+// Cross-cutting behavior wired up in app.ts: health probe, auth gate,
+// request-id middleware, the error envelope, and the not-found fallback.
+import { describe, it, expect, vi } from "vitest";
+import { ConflictError, NotFoundError } from "@funky/configs";
+import { AGENT_ID, UUID_V7, agentFixture, get, makeApp, post } from "./helpers";
+
+describe("GET /healthz", () => {
+  it("returns ok and pings the database", async () => {
+    const ping = vi.fn(async () => ({ rows: [] }));
+    const { app } = makeApp({ ping });
+
+    const res = await get(app, "/healthz");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "ok" });
+    expect(ping).toHaveBeenCalledOnce();
+  });
+
+  it("is reachable without auth even when a token is configured", async () => {
+    const { app } = makeApp({ authToken: "super-secret-token-1234" });
+    const res = await get(app, "/healthz"); // no Authorization header
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 500 when the database ping fails", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { app } = makeApp({ ping: async () => Promise.reject(new Error("db down")) });
+
+    const res = await get(app, "/healthz");
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error.type).toBe("api_error");
+    expect(res.headers.get("request-id")).toMatch(UUID_V7);
+    expect(errSpy).toHaveBeenCalled(); // the failure is logged, not swallowed
+    errSpy.mockRestore();
+  });
+});
+
+describe("auth middleware", () => {
+  const token = "super-secret-token-1234";
+
+  it("rejects requests with no Authorization header", async () => {
+    const { app, fake } = makeApp({ authToken: token });
+
+    const res = await get(app, `/v1/agents/${AGENT_ID}`);
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body).toMatchObject({
+      type: "error",
+      error: { type: "authentication_error", message: "invalid or missing API token" },
+    });
+    expect(body.request_id).toMatch(UUID_V7);
+    expect(fake.get).not.toHaveBeenCalled();
+  });
+
+  it("rejects an incorrect bearer token", async () => {
+    const { app, fake } = makeApp({ authToken: token });
+    const res = await get(app, `/v1/agents/${AGENT_ID}`, { authorization: "Bearer wrong-token" });
+    expect(res.status).toBe(401);
+    expect(fake.get).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-bearer scheme", async () => {
+    const { app } = makeApp({ authToken: token });
+    const res = await get(app, `/v1/agents/${AGENT_ID}`, { authorization: `Basic ${token}` });
+    expect(res.status).toBe(401);
+  });
+
+  it("accepts the correct bearer token", async () => {
+    const { app, fake } = makeApp({
+      authToken: token,
+      agents: { get: vi.fn().mockResolvedValue(agentFixture()) },
+    });
+
+    const res = await get(app, `/v1/agents/${AGENT_ID}`, { authorization: `Bearer ${token}` });
+
+    expect(res.status).toBe(200);
+    expect(fake.get).toHaveBeenCalledOnce();
+  });
+
+  it("allows all requests when auth is disabled (token = null)", async () => {
+    const { app, fake } = makeApp({
+      authToken: null,
+      agents: { get: vi.fn().mockResolvedValue(agentFixture()) },
+    });
+    const res = await get(app, `/v1/agents/${AGENT_ID}`); // no header
+    expect(res.status).toBe(200);
+    expect(fake.get).toHaveBeenCalledOnce();
+  });
+});
+
+describe("request-id middleware", () => {
+  it("sets a uuid v7 request-id header on every response", async () => {
+    const { app } = makeApp();
+    const res = await get(app, "/healthz");
+    expect(res.headers.get("request-id")).toMatch(UUID_V7);
+  });
+
+  it("echoes the same id in the error envelope as in the header", async () => {
+    const { app } = makeApp({
+      agents: { get: vi.fn().mockRejectedValue(new NotFoundError("agent not found")) },
+    });
+
+    const res = await get(app, `/v1/agents/${AGENT_ID}`);
+    const body = await res.json();
+
+    expect(body.request_id).toBe(res.headers.get("request-id"));
+    expect(body.request_id).toMatch(UUID_V7);
+  });
+
+  it("issues a distinct id per request", async () => {
+    const { app } = makeApp();
+    const [a, b] = await Promise.all([get(app, "/healthz"), get(app, "/healthz")]);
+    expect(a.headers.get("request-id")).not.toBe(b.headers.get("request-id"));
+  });
+});
+
+describe("error mapping (onError)", () => {
+  it("maps NotFoundError to 404 not_found_error", async () => {
+    const { app } = makeApp({
+      agents: { get: vi.fn().mockRejectedValue(new NotFoundError("agent not found")) },
+    });
+
+    const res = await get(app, `/v1/agents/${AGENT_ID}`);
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({
+      type: "error",
+      error: { type: "not_found_error", message: "agent not found" },
+    });
+  });
+
+  it("maps ConflictError to 409 invalid_request_error", async () => {
+    const { app } = makeApp({
+      agents: {
+        update: vi.fn().mockRejectedValue(new ConflictError("agent is archived and read-only")),
+      },
+    });
+
+    const res = await post(app, `/v1/agents/${AGENT_ID}`, { name: "new name" });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({
+      type: "error",
+      error: { type: "invalid_request_error", message: "agent is archived and read-only" },
+    });
+  });
+
+  it("maps an unexpected error to a logged 500 api_error", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { app } = makeApp({
+      agents: { get: vi.fn().mockRejectedValue(new Error("kaboom")) },
+    });
+
+    const res = await get(app, `/v1/agents/${AGENT_ID}`);
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({
+      type: "error",
+      error: { type: "api_error", message: "internal server error" },
+    });
+    expect(errSpy).toHaveBeenCalled(); // the raw error is logged, not leaked
+    errSpy.mockRestore();
+  });
+});
+
+describe("not-found fallback", () => {
+  it("returns 404 not_found_error for an unknown route", async () => {
+    const { app } = makeApp();
+    const res = await get(app, "/does-not-exist");
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({
+      type: "error",
+      error: { type: "not_found_error", message: "unknown route" },
+    });
+  });
+
+  it("runs auth before the not-found fallback under /v1", async () => {
+    const { app } = makeApp({ authToken: "super-secret-token-1234" });
+    // Unknown /v1 route with no token: auth answers first with 401, not 404.
+    const res = await get(app, "/v1/nope");
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/api/test/config.test.ts
+++ b/apps/api/test/config.test.ts
@@ -1,0 +1,71 @@
+// loadConfig(env) is the single place env is parsed. It fails fast via
+// process.exit(1); tests stub exit so the failure path is observable.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { loadConfig } from "../src/config";
+
+const BASE = {
+  DATABASE_URL: "postgres://funky:funky@localhost:5432/funky",
+  FUNKY_AUTH_TOKEN: "a-sufficiently-long-token",
+};
+
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  // Turn process.exit into a throw so "fail fast" is catchable, and mute the logs.
+  exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new Error(`process.exit(${code})`);
+  }) as never);
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("loadConfig — valid input", () => {
+  it("parses a fully-specified environment", () => {
+    const cfg = loadConfig({ ...BASE, PORT: "8080", DB_POOL_MAX: "25" });
+    expect(cfg).toEqual({
+      databaseUrl: BASE.DATABASE_URL,
+      port: 8080,
+      dbPoolMax: 25,
+      authToken: BASE.FUNKY_AUTH_TOKEN,
+    });
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("applies defaults for PORT and DB_POOL_MAX", () => {
+    const cfg = loadConfig(BASE);
+    expect(cfg.port).toBe(3000);
+    expect(cfg.dbPoolMax).toBe(10);
+  });
+
+  it("returns a null token and warns when auth is disabled", () => {
+    const cfg = loadConfig({ DATABASE_URL: BASE.DATABASE_URL, FUNKY_AUTH: "disabled" });
+    expect(cfg.authToken).toBeNull();
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it("keeps the token when auth is disabled but a token is also present", () => {
+    const cfg = loadConfig({ ...BASE, FUNKY_AUTH: "disabled" });
+    expect(cfg.authToken).toBeNull(); // disabled wins over a supplied token
+  });
+});
+
+describe("loadConfig — invalid input exits the process", () => {
+  it.each([
+    ["missing DATABASE_URL", { FUNKY_AUTH_TOKEN: BASE.FUNKY_AUTH_TOKEN }],
+    ["empty DATABASE_URL", { ...BASE, DATABASE_URL: "" }],
+    ["auth enabled but no token", { DATABASE_URL: BASE.DATABASE_URL }],
+    ["token shorter than 16 chars", { ...BASE, FUNKY_AUTH_TOKEN: "short" }],
+    ["PORT out of range", { ...BASE, PORT: "70000" }],
+    ["PORT not a number", { ...BASE, PORT: "notaport" }],
+    ["DB_POOL_MAX below 1", { ...BASE, DB_POOL_MAX: "0" }],
+    ["invalid FUNKY_AUTH value", { ...BASE, FUNKY_AUTH: "maybe" }],
+  ])("exits on %s", (_label, env) => {
+    expect(() => loadConfig(env as NodeJS.ProcessEnv)).toThrow("process.exit(1)");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/apps/api/test/helpers.ts
+++ b/apps/api/test/helpers.ts
@@ -1,0 +1,127 @@
+// Shared test scaffolding: a fake AgentsService, fixtures, and request helpers.
+// The whole app is exercised network-free via buildApp(deps) + app.request(),
+// exactly as app.ts advertises. No database, no HTTP server.
+import { vi, type Mock } from "vitest";
+import type { Agent, AgentsService, AgentVersion, AuthContext } from "@funky/configs";
+import { buildApp } from "../src/app";
+
+/** What the static auth middleware injects for every /v1 request. */
+export const CTX: AuthContext = { namespace: "default", principal: "token:default" };
+
+/** A syntactically valid uuid v7 for path/query params. */
+export const AGENT_ID = "0192f1b2-3c4d-7e5f-8a90-1b2c3d4e5f60";
+
+/** Every AgentsService method, replaced by a spy the tests can program/inspect. */
+export type FakeAgents = {
+  create: Mock;
+  list: Mock;
+  get: Mock;
+  update: Mock;
+  archive: Mock;
+  listVersions: Mock;
+  getVersion: Mock;
+};
+
+function makeFakeAgents(overrides: Partial<FakeAgents> = {}): {
+  service: AgentsService;
+  fake: FakeAgents;
+} {
+  const fake: FakeAgents = {
+    create: vi.fn(),
+    list: vi.fn(),
+    get: vi.fn(),
+    update: vi.fn(),
+    archive: vi.fn(),
+    listVersions: vi.fn(),
+    getVersion: vi.fn(),
+    ...overrides,
+  };
+  // AgentsService has a private field, so a structural cast is required for the double.
+  return { service: fake as unknown as AgentsService, fake };
+}
+
+export type App = ReturnType<typeof buildApp>;
+
+/** Build the app with sensible test defaults (auth off, ping ok) and a programmable service. */
+export function makeApp(
+  opts: {
+    authToken?: string | null;
+    ping?: () => Promise<unknown>;
+    agents?: Partial<FakeAgents>;
+  } = {},
+): { app: App; fake: FakeAgents } {
+  const { service, fake } = makeFakeAgents(opts.agents);
+  const app = buildApp({
+    agents: service,
+    authToken: opts.authToken ?? null, // auth disabled by default; auth tests opt in
+    ping: opts.ping ?? (async () => ({ rows: [{ "?column?": 1 }] })),
+  });
+  return { app, fake };
+}
+
+// --------------------------------------------------------------- request helpers
+
+export function get(app: App, path: string, headers: Record<string, string> = {}) {
+  return app.request(path, { headers });
+}
+
+export function post(
+  app: App,
+  path: string,
+  body?: unknown,
+  headers: Record<string, string> = {},
+) {
+  return app.request(path, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+// ---------------------------------------------------------------------- fixtures
+
+export function agentFixture(over: Partial<Agent> = {}): Agent {
+  return {
+    type: "agent",
+    id: AGENT_ID,
+    name: "data cruncher",
+    description: null,
+    metadata: {},
+    version: 1,
+    system_prompt: "You are a data analyst.",
+    model: { provider: "anthropic", model: "claude-sonnet-5" },
+    tool_policy: {},
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    archived_at: null,
+    ...over,
+  };
+}
+
+export function versionFixture(over: Partial<AgentVersion> = {}): AgentVersion {
+  return {
+    type: "agent_version",
+    agent_id: AGENT_ID,
+    version: 1,
+    system_prompt: "You are a data analyst.",
+    model: { provider: "anthropic", model: "claude-sonnet-5" },
+    tool_policy: {},
+    created_at: "2026-01-01T00:00:00.000Z",
+    created_by: "token:default",
+    ...over,
+  };
+}
+
+/** A minimal valid create body; override/extend fields per test. */
+export function createBody(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: "data cruncher",
+    system_prompt: "You are a data analyst.",
+    model: { provider: "anthropic", model: "claude-sonnet-5" },
+    ...over,
+  };
+}
+
+/** uuid v7 shape — used to assert the request-id header/envelope value. */
+export const UUID_V7 =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0))
 
   packages/configs:
     dependencies:
@@ -93,6 +96,15 @@ packages:
 
   '@drizzle-team/brocli@0.11.0':
     resolution: {integrity: sha512-hD3pekGiPg0WPCCGAZmusBBJsDqGUR66Y452YgQsZOnkdQ7ViEPKuyP4huUGEZQefp8g34RRodXYmJ2TbCH+tg==}
+
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -418,15 +430,178 @@ packages:
       hono: '>=3.9.0'
       zod: ^3.25.0 || ^4.0.0
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@js-temporal/polyfill@0.5.1':
     resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
     engines: {node: '>=12'}
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/node@22.20.1':
     resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -552,6 +727,9 @@ packages:
       zod:
         optional: true
 
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -561,6 +739,22 @@ packages:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -580,6 +774,91 @@ packages:
 
   jsbi@4.3.2:
     resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pg-cloudflare@1.4.0:
     resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
@@ -615,6 +894,17 @@ packages:
   pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
@@ -634,9 +924,45 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.23.0:
     resolution: {integrity: sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==}
@@ -655,6 +981,95 @@ packages:
     resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
     hasBin: true
 
+  vite@8.1.4:
+    resolution: {integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -665,6 +1080,22 @@ packages:
 snapshots:
 
   '@drizzle-team/brocli@0.11.0': {}
+
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -831,9 +1262,87 @@ snapshots:
       hono: 4.12.29
       zod: 4.4.3
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@js-temporal/polyfill@0.5.1':
     dependencies:
       jsbi: 4.3.2
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@oxc-project/types@0.139.0': {}
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/node@22.20.1':
     dependencies:
@@ -844,6 +1353,55 @@ snapshots:
       '@types/node': 22.20.1
       pg-protocol: 1.15.0
       pg-types: 2.2.0
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  assertion-error@2.0.1: {}
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  detect-libc@2.1.2: {}
 
   dotenv@17.4.2: {}
 
@@ -860,6 +1418,8 @@ snapshots:
       '@types/pg': 8.20.0
       pg: 8.22.0
       zod: 4.4.3
+
+  es-module-lexer@2.3.0: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -919,6 +1479,16 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
   fsevents@2.3.3:
     optional: true
 
@@ -931,6 +1501,65 @@ snapshots:
   jiti@2.7.0: {}
 
   jsbi@4.3.2: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  nanoid@3.3.15: {}
+
+  obug@2.1.3: {}
+
+  pathe@2.0.3: {}
 
   pg-cloudflare@1.4.0:
     optional: true
@@ -967,6 +1596,16 @@ snapshots:
     dependencies:
       split2: 4.2.0
 
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.16:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postgres-array@2.0.0: {}
 
   postgres-bytea@1.0.1: {}
@@ -979,7 +1618,50 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  rolldown@1.1.5:
+    dependencies:
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
   split2@4.2.0: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
+
+  tslib@2.8.1:
+    optional: true
 
   tsx@4.23.0:
     dependencies:
@@ -992,6 +1674,52 @@ snapshots:
   undici-types@6.21.0: {}
 
   uuid@13.0.2: {}
+
+  vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.1
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.23.0
+
+  vitest@4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.20.1
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
`apps/api` had no tests, so this sets up Vitest (config + `test`/`test:watch` scripts, plus the `pnpm-lock.yaml` update) and adds 67 tests that exercise the whole app network-free via `buildApp(deps)` + `app.request()` with a fake `AgentsService` — no database or HTTP server required. Coverage spans all seven `/v1/agents` routes (edge validation, delegation with the correct auth context, query-param mapping, status codes), the auth and request-id middleware, the error envelope / not-found fallback, and `loadConfig`'s valid, auth-disabled, and fail-fast paths. Tests live under `apps/api/test/` (outside `src/`) so they don't affect the production build or the root `pnpm typecheck`. Run with `pnpm -F api test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)