### PR TITLE
Add integration tests for @funky/configs AgentsService

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "scripts": {
       "preinstall": "npx only-allow pnpm",
       "typecheck": "tsc --noEmit",
+      "test": "pnpm -r test",
       "dev": "pnpm -F api dev"
     },
     "devDependencies": {

--- a/packages/configs/package.json
+++ b/packages/configs/package.json
@@ -1,11 +1,21 @@
 {
-    "name": "@funky/configs",
-    "private": true,
-    "type": "module",
-    "exports": { ".": "./src/index.ts" },
-    "dependencies": {
-      "@funky/db": "workspace:*",
-      "drizzle-orm": "^1.0.0-beta.2",
-      "uuid": "^13.0.0"
-    }
+  "name": "@funky/configs",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@funky/db": "workspace:*",
+    "drizzle-orm": "^1.0.0-beta.2",
+    "uuid": "^13.0.0"
+  },
+  "devDependencies": {
+    "@electric-sql/pglite": "^0.5.4",
+    "vitest": "^4.1.10"
   }
+}

--- a/packages/configs/src/service.test.ts
+++ b/packages/configs/src/service.test.ts
@@ -1,0 +1,451 @@
+// packages/configs/src/service.test.ts
+// Integration tests for AgentsService against in-process Postgres (PGlite)
+// with the real migrations applied. No mocks: the service is mostly SQL, so
+// mocking Drizzle would test nothing.
+//
+// One PGlite instance serves the whole file; each test isolates itself with a
+// fresh namespace — the same mechanism that isolates tenants in production.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { v7 as uuidv7 } from "uuid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Db } from "@funky/db";
+import { ConflictError, NotFoundError } from "./errors";
+import { AgentsService } from "./service";
+import type { AuthContext, CreateAgentInput } from "./types";
+
+const migrationsDir = fileURLToPath(new URL("../../db/migrations", import.meta.url));
+
+let client: PGlite;
+let service: AgentsService;
+
+beforeAll(async () => {
+  client = new PGlite();
+  for (const dir of readdirSync(migrationsDir).sort()) {
+    await client.exec(readFileSync(join(migrationsDir, dir, "migration.sql"), "utf8"));
+  }
+  // The PGlite drizzle instance is runtime-compatible with the node-postgres Db.
+  service = new AgentsService(drizzle({ client }) as unknown as Db);
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+let nsSeq = 0;
+function freshCtx(principal = "user:tester"): AuthContext {
+  return { namespace: `test-ns-${++nsSeq}`, principal };
+}
+
+function baseInput(overrides: Partial<CreateAgentInput> = {}): CreateAgentInput {
+  return {
+    name: "support-bot",
+    system_prompt: "You are a helpful support agent.",
+    model: { provider: "anthropic", model: "claude-sonnet-5" },
+    ...overrides,
+  };
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// ------------------------------------------------------------------ create
+
+describe("create", () => {
+  it("creates an agent at version 1 with defaults applied", async () => {
+    const ctx = freshCtx();
+    const { agent, created } = await service.create(ctx, baseInput());
+
+    expect(created).toBe(true);
+    expect(agent).toMatchObject({
+      type: "agent",
+      name: "support-bot",
+      description: null,
+      metadata: {},
+      version: 1,
+      system_prompt: "You are a helpful support agent.",
+      model: { provider: "anthropic", model: "claude-sonnet-5" },
+      tool_policy: {},
+      archived_at: null,
+    });
+    expect(agent.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(new Date(agent.created_at).getTime()).not.toBeNaN();
+    expect(new Date(agent.updated_at).getTime()).not.toBeNaN();
+  });
+
+  it("honors a client-supplied id and records the creating principal on v1", async () => {
+    const ctx = freshCtx("key:fk_live_a1b2");
+    const id = uuidv7();
+    const { agent } = await service.create(ctx, baseInput({ id }));
+
+    expect(agent.id).toBe(id);
+    const v1 = await service.getVersion(ctx, id, 1);
+    expect(v1).toMatchObject({
+      type: "agent_version",
+      agent_id: id,
+      version: 1,
+      system_prompt: "You are a helpful support agent.",
+      created_by: "key:fk_live_a1b2",
+    });
+  });
+
+  it("is idempotent: replaying the same create returns created=false and mints no version", async () => {
+    const ctx = freshCtx();
+    const id = uuidv7();
+    const input = baseInput({
+      id,
+      description: "handles refunds",
+      metadata: { team: "support" },
+      tool_policy: { allowed_tools: ["search"] },
+    });
+
+    const first = await service.create(ctx, input);
+    const replay = await service.create(ctx, input);
+
+    expect(first.created).toBe(true);
+    expect(replay.created).toBe(false);
+    expect(replay.agent).toEqual(first.agent);
+    const versions = await service.listVersions(ctx, id, { limit: 10 });
+    expect(versions.data).toHaveLength(1);
+  });
+
+  it("idempotency ignores json key order and treats omitted optionals as defaults", async () => {
+    const ctx = freshCtx();
+    const id = uuidv7();
+    await service.create(
+      ctx,
+      baseInput({
+        id,
+        metadata: {},
+        tool_policy: {},
+        model: { provider: "anthropic", model: "claude-sonnet-5", maxTokens: 1024 },
+      }),
+    );
+
+    const replay = await service.create(
+      ctx,
+      baseInput({
+        id,
+        // metadata / tool_policy omitted → same as the explicit {} above
+        model: { maxTokens: 1024, model: "claude-sonnet-5", provider: "anthropic" },
+      }),
+    );
+    expect(replay.created).toBe(false);
+  });
+
+  it("rejects a same-id create with a different configuration", async () => {
+    const ctx = freshCtx();
+    const id = uuidv7();
+    await service.create(ctx, baseInput({ id }));
+
+    await expect(
+      service.create(ctx, baseInput({ id, system_prompt: "Different prompt." })),
+    ).rejects.toBeInstanceOf(ConflictError);
+
+    // the original is untouched
+    const agent = await service.get(ctx, id);
+    expect(agent.system_prompt).toBe("You are a helpful support agent.");
+    expect(agent.version).toBe(1);
+  });
+
+  it("does not leak or adopt an id owned by another namespace", async () => {
+    const ctxA = freshCtx();
+    const ctxB = freshCtx();
+    const id = uuidv7();
+    await service.create(ctxA, baseInput({ id }));
+
+    // the id PK is global, so tenant B's create must fail — never resolve idempotently
+    await expect(service.create(ctxB, baseInput({ id }))).rejects.toThrow();
+    await expect(service.get(ctxB, id)).rejects.toBeInstanceOf(NotFoundError);
+    expect((await service.get(ctxA, id)).name).toBe("support-bot");
+  });
+});
+
+// --------------------------------------------------------------------- get
+
+describe("get", () => {
+  it("throws NotFoundError for an unknown id", async () => {
+    await expect(service.get(freshCtx(), uuidv7())).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it("throws NotFoundError for an agent that belongs to another namespace", async () => {
+    const ctxA = freshCtx();
+    const { agent } = await service.create(ctxA, baseInput());
+    await expect(service.get(freshCtx(), agent.id)).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
+// -------------------------------------------------------------------- list
+
+describe("list", () => {
+  it("returns agents newest-first and paginates with after_id", async () => {
+    const ctx = freshCtx();
+    const a = (await service.create(ctx, baseInput({ name: "a" }))).agent;
+    const b = (await service.create(ctx, baseInput({ name: "b" }))).agent;
+    const c = (await service.create(ctx, baseInput({ name: "c" }))).agent;
+
+    const page1 = await service.list(ctx, { limit: 2, includeArchived: false });
+    expect(page1.data.map((x) => x.id)).toEqual([c.id, b.id]);
+    expect(page1.has_more).toBe(true);
+    expect(page1.last_id).toBe(b.id);
+
+    const page2 = await service.list(ctx, {
+      limit: 2,
+      afterId: page1.last_id,
+      includeArchived: false,
+    });
+    expect(page2.data.map((x) => x.id)).toEqual([a.id]);
+    expect(page2.has_more).toBe(false);
+    expect(page2.last_id).toBe(a.id);
+  });
+
+  it("returns an empty page for an empty namespace", async () => {
+    const page = await service.list(freshCtx(), { limit: 20, includeArchived: false });
+    expect(page).toEqual({ data: [], has_more: false, last_id: undefined });
+  });
+
+  it("hides archived agents unless includeArchived is set", async () => {
+    const ctx = freshCtx();
+    const keep = (await service.create(ctx, baseInput({ name: "keep" }))).agent;
+    const gone = (await service.create(ctx, baseInput({ name: "gone" }))).agent;
+    await service.archive(ctx, gone.id);
+
+    const visible = await service.list(ctx, { limit: 20, includeArchived: false });
+    expect(visible.data.map((x) => x.id)).toEqual([keep.id]);
+
+    const all = await service.list(ctx, { limit: 20, includeArchived: true });
+    expect(all.data.map((x) => x.id).sort()).toEqual([keep.id, gone.id].sort());
+  });
+
+  it("never returns another namespace's agents", async () => {
+    const ctxA = freshCtx();
+    const ctxB = freshCtx();
+    await service.create(ctxA, baseInput());
+    const mine = (await service.create(ctxB, baseInput({ name: "mine" }))).agent;
+
+    const page = await service.list(ctxB, { limit: 20, includeArchived: false });
+    expect(page.data.map((x) => x.id)).toEqual([mine.id]);
+  });
+});
+
+// ------------------------------------------------------------------ update
+
+describe("update", () => {
+  it("updates labels without minting a new version", async () => {
+    const ctx = freshCtx();
+    const { agent } = await service.create(ctx, baseInput());
+
+    const updated = await service.update(ctx, agent.id, {
+      name: "renamed",
+      description: "now with a description",
+    });
+
+    expect(updated.name).toBe("renamed");
+    expect(updated.description).toBe("now with a description");
+    expect(updated.version).toBe(1);
+    const versions = await service.listVersions(ctx, agent.id, { limit: 10 });
+    expect(versions.data).toHaveLength(1);
+  });
+
+  it("replaces metadata wholesale rather than merging", async () => {
+    const ctx = freshCtx();
+    const { agent } = await service.create(
+      ctx,
+      baseInput({ metadata: { team: "support", tier: "1" } }),
+    );
+
+    const updated = await service.update(ctx, agent.id, { metadata: { env: "prod" } });
+    expect(updated.metadata).toEqual({ env: "prod" });
+  });
+
+  it("mints a new version on behavior change, carrying forward omitted behavior fields", async () => {
+    const ctx = freshCtx();
+    const { agent } = await service.create(
+      ctx,
+      baseInput({
+        model: { provider: "anthropic", model: "claude-sonnet-5", temperature: 0.2 },
+        tool_policy: { allowed_tools: ["search"] },
+      }),
+    );
+
+    const updated = await service.update(ctx, agent.id, { system_prompt: "Be terse." });
+
+    expect(updated.version).toBe(2);
+    expect(updated.system_prompt).toBe("Be terse.");
+    // untouched behavior fields carried forward from v1
+    expect(updated.model).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      temperature: 0.2,
+    });
+    expect(updated.tool_policy).toEqual({ allowed_tools: ["search"] });
+
+    // v1 is immutable history
+    const v1 = await service.getVersion(ctx, agent.id, 1);
+    expect(v1.system_prompt).toBe("You are a helpful support agent.");
+  });
+
+  it("applies label and behavior changes together with a single version bump", async () => {
+    const ctx = freshCtx();
+    const { agent } = await service.create(ctx, baseInput());
+
+    const updated = await service.update(ctx, agent.id, {
+      name: "both",
+      model: { provider: "openai", model: "gpt-5" },
+    });
+
+    expect(updated.name).toBe("both");
+    expect(updated.version).toBe(2);
+    expect(updated.model).toEqual({ provider: "openai", model: "gpt-5" });
+    expect(updated.system_prompt).toBe("You are a helpful support agent.");
+  });
+
+  it("records the updating principal on the minted version", async () => {
+    const alice = freshCtx("user:alice");
+    const bob: AuthContext = { namespace: alice.namespace, principal: "user:bob" };
+    const { agent } = await service.create(alice, baseInput());
+    await service.update(bob, agent.id, { system_prompt: "v2 prompt" });
+
+    expect((await service.getVersion(alice, agent.id, 1)).created_by).toBe("user:alice");
+    expect((await service.getVersion(alice, agent.id, 2)).created_by).toBe("user:bob");
+  });
+
+  it("treats an empty patch as a no-op", async () => {
+    const ctx = freshCtx();
+    const { agent } = await service.create(ctx, baseInput());
+    await sleep(10);
+
+    const updated = await service.update(ctx, agent.id, {});
+    expect(updated.version).toBe(1);
+    expect(updated.updated_at).toBe(agent.updated_at);
+  });
+
+  it("bumps updated_at on a real update", async () => {
+    const ctx = freshCtx();
+    const { agent } = await service.create(ctx, baseInput());
+    await sleep(10);
+
+    const updated = await service.update(ctx, agent.id, { name: "later" });
+    expect(new Date(updated.updated_at).getTime()).toBeGreaterThan(
+      new Date(agent.updated_at).getTime(),
+    );
+    expect(updated.created_at).toBe(agent.created_at);
+  });
+
+  it("throws NotFoundError for unknown ids and other namespaces", async () => {
+    const ctxA = freshCtx();
+    const { agent } = await service.create(ctxA, baseInput());
+
+    await expect(service.update(ctxA, uuidv7(), { name: "x" })).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+    await expect(service.update(freshCtx(), agent.id, { name: "x" })).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+  });
+
+  it("rejects updates to an archived agent", async () => {
+    const ctx = freshCtx();
+    const { agent } = await service.create(ctx, baseInput());
+    await service.archive(ctx, agent.id);
+
+    await expect(service.update(ctx, agent.id, { name: "nope" })).rejects.toBeInstanceOf(
+      ConflictError,
+    );
+    await expect(
+      service.update(ctx, agent.id, { system_prompt: "nope" }),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+});
+
+// ----------------------------------------------------------------- archive
+
+describe("archive", () => {
+  it("archives an agent; it stays readable with archived_at set", async () => {
+    const ctx = freshCtx();
+    const { agent } = await service.create(ctx, baseInput());
+
+    const archived = await service.archive(ctx, agent.id);
+    expect(archived.archived_at).not.toBeNull();
+    expect(new Date(archived.archived_at!).getTime()).not.toBeNaN();
+
+    // still retrievable directly, and its versions remain readable
+    expect((await service.get(ctx, agent.id)).archived_at).toBe(archived.archived_at);
+    expect((await service.getVersion(ctx, agent.id, 1)).version).toBe(1);
+  });
+
+  it("is idempotent: a second archive keeps the original timestamp", async () => {
+    const ctx = freshCtx();
+    const { agent } = await service.create(ctx, baseInput());
+
+    const first = await service.archive(ctx, agent.id);
+    await sleep(10);
+    const second = await service.archive(ctx, agent.id);
+    expect(second.archived_at).toBe(first.archived_at);
+  });
+
+  it("throws NotFoundError for unknown ids and cannot archive across namespaces", async () => {
+    const ctxA = freshCtx();
+    const { agent } = await service.create(ctxA, baseInput());
+
+    await expect(service.archive(ctxA, uuidv7())).rejects.toBeInstanceOf(NotFoundError);
+    await expect(service.archive(freshCtx(), agent.id)).rejects.toBeInstanceOf(NotFoundError);
+    expect((await service.get(ctxA, agent.id)).archived_at).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------- versions
+
+describe("listVersions", () => {
+  async function agentWithThreeVersions(ctx: AuthContext) {
+    const { agent } = await service.create(ctx, baseInput({ system_prompt: "v1" }));
+    await service.update(ctx, agent.id, { system_prompt: "v2" });
+    await service.update(ctx, agent.id, { system_prompt: "v3" });
+    return agent;
+  }
+
+  it("returns versions newest-first and paginates with after_version", async () => {
+    const ctx = freshCtx();
+    const agent = await agentWithThreeVersions(ctx);
+
+    const page1 = await service.listVersions(ctx, agent.id, { limit: 2 });
+    expect(page1.data.map((v) => v.version)).toEqual([3, 2]);
+    expect(page1.data.map((v) => v.system_prompt)).toEqual(["v3", "v2"]);
+    expect(page1.has_more).toBe(true);
+
+    const page2 = await service.listVersions(ctx, agent.id, { limit: 2, afterVersion: 2 });
+    expect(page2.data.map((v) => v.version)).toEqual([1]);
+    expect(page2.has_more).toBe(false);
+  });
+
+  it("throws NotFoundError for unknown agents and other namespaces", async () => {
+    const ctxA = freshCtx();
+    const agent = await agentWithThreeVersions(ctxA);
+
+    await expect(service.listVersions(ctxA, uuidv7(), { limit: 10 })).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+    await expect(
+      service.listVersions(freshCtx(), agent.id, { limit: 10 }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
+describe("getVersion", () => {
+  it("throws NotFoundError for a version that does not exist", async () => {
+    const ctx = freshCtx();
+    const { agent } = await service.create(ctx, baseInput());
+    await expect(service.getVersion(ctx, agent.id, 99)).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it("throws NotFoundError across namespaces", async () => {
+    const ctxA = freshCtx();
+    const { agent } = await service.create(ctxA, baseInput());
+    await expect(service.getVersion(freshCtx(), agent.id, 1)).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+  });
+});

--- a/packages/configs/src/service.ts
+++ b/packages/configs/src/service.ts
@@ -308,10 +308,8 @@ function sortKeys(x: unknown): unknown {
 }
 
 function isUniqueViolation(err: unknown): boolean {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    "code" in err &&
-    (err as { code?: string }).code === "23505"
-  );
+  if (typeof err !== "object" || err === null) return false;
+  if ((err as { code?: unknown }).code === "23505") return true;
+  // drizzle v1 wraps driver errors (DrizzleQueryError) with the pg error as `cause`
+  return isUniqueViolation((err as { cause?: unknown }).cause);
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -15,8 +15,9 @@
     "pg": "^8.22.0"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.5.4",
     "@types/pg": "^8.20.0",
-    "drizzle-kit": "^1.0.0-beta.2",
-    "dotenv": "^17.2.0"
+    "dotenv": "^17.2.0",
+    "drizzle-kit": "^1.0.0-beta.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,20 +65,30 @@ importers:
         version: link:../db
       drizzle-orm:
         specifier: ^1.0.0-beta.2
-        version: 1.0.0-rc.4-5d5b77c(@types/pg@8.20.0)(pg@8.22.0)(zod@4.4.3)
+        version: 1.0.0-rc.4-5d5b77c(@electric-sql/pglite@0.5.4)(@types/pg@8.20.0)(pg@8.22.0)(zod@4.4.3)
       uuid:
         specifier: ^13.0.0
         version: 13.0.2
+    devDependencies:
+      '@electric-sql/pglite':
+        specifier: ^0.5.4
+        version: 0.5.4
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0))
 
   packages/db:
     dependencies:
       drizzle-orm:
         specifier: ^1.0.0-beta.2
-        version: 1.0.0-rc.4-5d5b77c(@types/pg@8.20.0)(pg@8.22.0)(zod@4.4.3)
+        version: 1.0.0-rc.4-5d5b77c(@electric-sql/pglite@0.5.4)(@types/pg@8.20.0)(pg@8.22.0)(zod@4.4.3)
       pg:
         specifier: ^8.22.0
         version: 8.22.0
     devDependencies:
+      '@electric-sql/pglite':
+        specifier: ^0.5.4
+        version: 0.5.4
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
@@ -93,6 +103,18 @@ packages:
 
   '@drizzle-team/brocli@0.11.0':
     resolution: {integrity: sha512-hD3pekGiPg0WPCCGAZmusBBJsDqGUR66Y452YgQsZOnkdQ7ViEPKuyP4huUGEZQefp8g34RRodXYmJ2TbCH+tg==}
+
+  '@electric-sql/pglite@0.5.4':
+    resolution: {integrity: sha512-yYZUyyXrHU7tPlCjwZQJ6hIG9DscdCCn7Uk0mYKwC1FeHX286AbcmFveMiRBEak8e9iPupjsoVImN3yJZVed2g==}
+
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -418,15 +440,178 @@ packages:
       hono: '>=3.9.0'
       zod: ^3.25.0 || ^4.0.0
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@js-temporal/polyfill@0.5.1':
     resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
     engines: {node: '>=12'}
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/node@22.20.1':
     resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -552,6 +737,9 @@ packages:
       zod:
         optional: true
 
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -561,6 +749,22 @@ packages:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -580,6 +784,91 @@ packages:
 
   jsbi@4.3.2:
     resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pg-cloudflare@1.4.0:
     resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
@@ -615,6 +904,17 @@ packages:
   pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
@@ -634,9 +934,45 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.23.0:
     resolution: {integrity: sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==}
@@ -655,6 +991,95 @@ packages:
     resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
     hasBin: true
 
+  vite@8.1.4:
+    resolution: {integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -665,6 +1090,24 @@ packages:
 snapshots:
 
   '@drizzle-team/brocli@0.11.0': {}
+
+  '@electric-sql/pglite@0.5.4': {}
+
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -831,9 +1274,87 @@ snapshots:
       hono: 4.12.29
       zod: 4.4.3
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@js-temporal/polyfill@0.5.1':
     dependencies:
       jsbi: 4.3.2
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@oxc-project/types@0.139.0': {}
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/node@22.20.1':
     dependencies:
@@ -845,6 +1366,55 @@ snapshots:
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  assertion-error@2.0.1: {}
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  detect-libc@2.1.2: {}
+
   dotenv@17.4.2: {}
 
   drizzle-kit@1.0.0-rc.4-ca0f029:
@@ -855,11 +1425,14 @@ snapshots:
       get-tsconfig: 4.14.0
       jiti: 2.7.0
 
-  drizzle-orm@1.0.0-rc.4-5d5b77c(@types/pg@8.20.0)(pg@8.22.0)(zod@4.4.3):
+  drizzle-orm@1.0.0-rc.4-5d5b77c(@electric-sql/pglite@0.5.4)(@types/pg@8.20.0)(pg@8.22.0)(zod@4.4.3):
     optionalDependencies:
+      '@electric-sql/pglite': 0.5.4
       '@types/pg': 8.20.0
       pg: 8.22.0
       zod: 4.4.3
+
+  es-module-lexer@2.3.0: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -919,6 +1492,16 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
   fsevents@2.3.3:
     optional: true
 
@@ -931,6 +1514,65 @@ snapshots:
   jiti@2.7.0: {}
 
   jsbi@4.3.2: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  nanoid@3.3.15: {}
+
+  obug@2.1.3: {}
+
+  pathe@2.0.3: {}
 
   pg-cloudflare@1.4.0:
     optional: true
@@ -967,6 +1609,16 @@ snapshots:
     dependencies:
       split2: 4.2.0
 
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.16:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postgres-array@2.0.0: {}
 
   postgres-bytea@1.0.1: {}
@@ -979,7 +1631,50 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  rolldown@1.1.5:
+    dependencies:
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
   split2@4.2.0: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
+
+  tslib@2.8.1:
+    optional: true
 
   tsx@4.23.0:
     dependencies:
@@ -992,6 +1687,52 @@ snapshots:
   undici-types@6.21.0: {}
 
   uuid@13.0.2: {}
+
+  vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.1
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.23.0
+
+  vitest@4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.20.1
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
Adds a 28-test vitest suite for `AgentsService`, running against in-process Postgres (PGlite) with the real migrations applied — hermetic, no Docker, ~1.5s. Tests isolate via fresh namespaces (the same mechanism that scopes tenants in production) and cover create idempotency, conflict detection, pagination, label-vs-behavior updates with version minting and carry-forward, archive semantics, and cross-namespace isolation.

Also fixes a bug the tests surfaced: drizzle v1 wraps driver errors in `DrizzleQueryError` with the pg error on `cause`, so `isUniqueViolation`'s top-level `code` check never matched and `create()`'s race-recovery path was dead code; it now walks `err.cause`.

`@funky/db` gains `@electric-sql/pglite` as a devDep so both packages resolve the same drizzle-orm peer variant — otherwise pnpm creates split instances that break `tsc --noEmit`. Wiring: `test`/`test:watch` scripts in `packages/configs` and a root `pnpm test` (`pnpm -r test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)