### PR TITLE
Align @funky/db tests with the rest of the workspace on vitest

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "generate": "drizzle-kit generate",
     "migrate": "drizzle-kit migrate",
-    "test": "tsx --test \"src/**/*.test.ts\""
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "drizzle-orm": "^1.0.0-beta.2",
@@ -20,6 +21,6 @@
     "@types/pg": "^8.20.0",
     "dotenv": "^17.2.0",
     "drizzle-kit": "^1.0.0-beta.2",
-    "tsx": "^4.7.1"
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -2,43 +2,46 @@
 // offline: a pg Pool connects lazily, and Drizzle builds SQL synchronously, so
 // we can assert wiring and rendered SQL without a running Postgres.
 
-import assert from "node:assert/strict";
-import { test } from "node:test";
 import { Pool } from "pg";
+import { describe, expect, it } from "vitest";
 import { createDb, tables, type Db } from "./client";
 import { agentConfigs, agentConfigVersions } from "./schema";
 
 const DUMMY_URL = "postgres://user:pass@localhost:5432/funky_test";
 
-test("createDb returns a Drizzle query builder without opening a connection", async () => {
-  const pool = new Pool({ connectionString: DUMMY_URL });
-  try {
-    const db: Db = createDb(pool);
-    assert.equal(typeof db.select, "function");
-    assert.equal(typeof db.insert, "function");
-    assert.equal(typeof db.update, "function");
-    assert.equal(typeof db.transaction, "function");
-  } finally {
-    await pool.end(); // no queries ran, so the pool never actually connected
-  }
+describe("createDb", () => {
+  it("returns a Drizzle query builder without opening a connection", async () => {
+    const pool = new Pool({ connectionString: DUMMY_URL });
+    try {
+      const db: Db = createDb(pool);
+      expect(typeof db.select).toBe("function");
+      expect(typeof db.insert).toBe("function");
+      expect(typeof db.update).toBe("function");
+      expect(typeof db.transaction).toBe("function");
+    } finally {
+      await pool.end(); // no queries ran, so the pool never actually connected
+    }
+  });
+
+  it("renders schema tables into SQL", async () => {
+    const pool = new Pool({ connectionString: DUMMY_URL });
+    try {
+      const db = createDb(pool);
+      const identity = db.select().from(agentConfigs).toSQL();
+      expect(identity.sql).toMatch(/from "agent_configs"/);
+
+      const versions = db.select().from(agentConfigVersions).toSQL();
+      expect(versions.sql).toMatch(/from "agent_config_versions"/);
+    } finally {
+      await pool.end();
+    }
+  });
 });
 
-test("the query builder renders schema tables into SQL", async () => {
-  const pool = new Pool({ connectionString: DUMMY_URL });
-  try {
-    const db = createDb(pool);
-    const identity = db.select().from(agentConfigs).toSQL();
-    assert.match(identity.sql, /from "agent_configs"/);
-
-    const versions = db.select().from(agentConfigVersions).toSQL();
-    assert.match(versions.sql, /from "agent_config_versions"/);
-  } finally {
-    await pool.end();
-  }
-});
-
-test("`tables` re-exports both schema tables by their identifiers", () => {
-  assert.equal(tables.agentConfigs, agentConfigs);
-  assert.equal(tables.agentConfigVersions, agentConfigVersions);
-  assert.deepEqual(Object.keys(tables).sort(), ["agentConfigVersions", "agentConfigs"].sort());
+describe("tables", () => {
+  it("re-exports both schema tables by their identifiers", () => {
+    expect(tables.agentConfigs).toBe(agentConfigs);
+    expect(tables.agentConfigVersions).toBe(agentConfigVersions);
+    expect(Object.keys(tables).sort()).toEqual(["agentConfigVersions", "agentConfigs"].sort());
+  });
 });

--- a/packages/db/src/schema.test.ts
+++ b/packages/db/src/schema.test.ts
@@ -4,9 +4,8 @@
 // so a rename, a dropped NOT NULL, a changed default, or a broken PK/FK/index
 // fails here loudly instead of silently drifting from migrations/.
 
-import assert from "node:assert/strict";
-import { test } from "node:test";
 import { getTableConfig, type PgTable } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
 import { agentConfigs, agentConfigVersions, type ModelConfig } from "./schema";
 
 type ColSpec = {
@@ -24,24 +23,22 @@ function columnsByName(table: PgTable) {
 /** Assert the table has exactly `expected`'s columns, each with the given shape. */
 function assertColumns(table: PgTable, expected: Record<string, ColSpec>) {
   const cols = columnsByName(table);
-  assert.deepEqual(
-    [...cols.keys()].sort(),
+  expect([...cols.keys()].sort(), "column set drifted (added/removed column)").toEqual(
     Object.keys(expected).sort(),
-    "column set drifted (added/removed column)",
   );
   for (const [name, spec] of Object.entries(expected)) {
     const col = cols.get(name);
-    assert.ok(col, `missing column ${name}`);
-    assert.equal(col.getSQLType(), spec.type, `${name}.type`);
-    assert.equal(col.notNull, spec.notNull, `${name}.notNull`);
+    expect(col, `missing column ${name}`).toBeDefined();
+    expect(col!.getSQLType(), `${name}.type`).toBe(spec.type);
+    expect(col!.notNull, `${name}.notNull`).toBe(spec.notNull);
     if (spec.hasDefault !== undefined) {
-      assert.equal(col.hasDefault, spec.hasDefault, `${name}.hasDefault`);
+      expect(col!.hasDefault, `${name}.hasDefault`).toBe(spec.hasDefault);
     }
     if (spec.default !== undefined) {
-      assert.deepEqual(col.default, spec.default, `${name}.default`);
+      expect(col!.default, `${name}.default`).toEqual(spec.default);
     }
     if (spec.primary !== undefined) {
-      assert.equal(col.primary, spec.primary, `${name}.primary`);
+      expect(col!.primary, `${name}.primary`).toBe(spec.primary);
     }
   }
 }
@@ -58,90 +55,93 @@ function indexSummaries(table: PgTable) {
 
 // ---------------------------------------------------------------- agent_configs
 
-test("agent_configs: table name", () => {
-  assert.equal(getTableConfig(agentConfigs).name, "agent_configs");
-});
-
-test("agent_configs: columns match the migration", () => {
-  assertColumns(agentConfigs, {
-    id: { type: "uuid", notNull: true, primary: true },
-    namespace: { type: "text", notNull: true },
-    name: { type: "text", notNull: true },
-    description: { type: "text", notNull: false },
-    metadata: { type: "jsonb", notNull: true, hasDefault: true, default: {} },
-    latest_version: { type: "integer", notNull: true, hasDefault: true, default: 1 },
-    created_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
-    updated_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
-    archived_at: { type: "timestamp with time zone", notNull: false },
+describe("agent_configs", () => {
+  it("has the expected table name", () => {
+    expect(getTableConfig(agentConfigs).name).toBe("agent_configs");
   });
-});
 
-test("agent_configs: id is an inline primary key (no composite PK, no FKs)", () => {
-  const cfg = getTableConfig(agentConfigs);
-  assert.equal(cfg.primaryKeys.length, 0, "identity uses an inline PK, not a composite one");
-  assert.equal(cfg.foreignKeys.length, 0, "identity table references nothing");
-});
+  it("columns match the migration", () => {
+    assertColumns(agentConfigs, {
+      id: { type: "uuid", notNull: true, primary: true },
+      namespace: { type: "text", notNull: true },
+      name: { type: "text", notNull: true },
+      description: { type: "text", notNull: false },
+      metadata: { type: "jsonb", notNull: true, hasDefault: true, default: {} },
+      latest_version: { type: "integer", notNull: true, hasDefault: true, default: 1 },
+      created_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
+      updated_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
+      archived_at: { type: "timestamp with time zone", notNull: false },
+    });
+  });
 
-test("agent_configs: has the two namespace lookup indexes, both non-unique", () => {
-  // name is a display label, not a reference — the (namespace, name) index must
-  // stay non-unique so duplicate names within a namespace are allowed.
-  assert.deepEqual(indexSummaries(agentConfigs), [
-    { name: "agent_configs_ns", columns: ["namespace"], unique: false },
-    { name: "agent_configs_ns_name", columns: ["namespace", "name"], unique: false },
-  ]);
+  it("uses an inline primary key on id (no composite PK, no FKs)", () => {
+    const cfg = getTableConfig(agentConfigs);
+    expect(cfg.primaryKeys, "identity uses an inline PK, not a composite one").toHaveLength(0);
+    expect(cfg.foreignKeys, "identity table references nothing").toHaveLength(0);
+  });
+
+  it("has the two namespace lookup indexes, both non-unique", () => {
+    // name is a display label, not a reference — the (namespace, name) index must
+    // stay non-unique so duplicate names within a namespace are allowed.
+    expect(indexSummaries(agentConfigs)).toEqual([
+      { name: "agent_configs_ns", columns: ["namespace"], unique: false },
+      { name: "agent_configs_ns_name", columns: ["namespace", "name"], unique: false },
+    ]);
+  });
 });
 
 // -------------------------------------------------------- agent_config_versions
 
-test("agent_config_versions: table name", () => {
-  assert.equal(getTableConfig(agentConfigVersions).name, "agent_config_versions");
-});
-
-test("agent_config_versions: columns match the migration", () => {
-  assertColumns(agentConfigVersions, {
-    agent_config_id: { type: "uuid", notNull: true },
-    version: { type: "integer", notNull: true },
-    namespace: { type: "text", notNull: true },
-    system_prompt: { type: "text", notNull: true },
-    model: { type: "jsonb", notNull: true },
-    tool_policy: { type: "jsonb", notNull: true, hasDefault: true, default: {} },
-    created_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
-    created_by: { type: "text", notNull: false },
+describe("agent_config_versions", () => {
+  it("has the expected table name", () => {
+    expect(getTableConfig(agentConfigVersions).name).toBe("agent_config_versions");
   });
-});
 
-test("agent_config_versions: composite primary key is (agent_config_id, version)", () => {
-  const pks = getTableConfig(agentConfigVersions).primaryKeys;
-  assert.equal(pks.length, 1);
-  assert.deepEqual(
-    pks[0]?.columns.map((c) => c.name),
-    ["agent_config_id", "version"],
-  );
-});
+  it("columns match the migration", () => {
+    assertColumns(agentConfigVersions, {
+      agent_config_id: { type: "uuid", notNull: true },
+      version: { type: "integer", notNull: true },
+      namespace: { type: "text", notNull: true },
+      system_prompt: { type: "text", notNull: true },
+      model: { type: "jsonb", notNull: true },
+      tool_policy: { type: "jsonb", notNull: true, hasDefault: true, default: {} },
+      created_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
+      created_by: { type: "text", notNull: false },
+    });
+  });
 
-test("agent_config_versions: agent_config_id references agent_configs.id", () => {
-  const fks = getTableConfig(agentConfigVersions).foreignKeys;
-  assert.equal(fks.length, 1, "exactly one foreign key");
-  const ref = fks[0]!.reference();
-  assert.deepEqual(ref.columns.map((c) => c.name), ["agent_config_id"]);
-  assert.deepEqual(ref.foreignColumns.map((c) => c.name), ["id"]);
-  assert.equal(getTableConfig(ref.foreignTable).name, "agent_configs");
+  it("has the composite primary key (agent_config_id, version)", () => {
+    const pks = getTableConfig(agentConfigVersions).primaryKeys;
+    expect(pks).toHaveLength(1);
+    expect(pks[0]?.columns.map((c) => c.name)).toEqual(["agent_config_id", "version"]);
+  });
+
+  it("references agent_configs.id via agent_config_id", () => {
+    const fks = getTableConfig(agentConfigVersions).foreignKeys;
+    expect(fks, "exactly one foreign key").toHaveLength(1);
+    const ref = fks[0]!.reference();
+    expect(ref.columns.map((c) => c.name)).toEqual(["agent_config_id"]);
+    expect(ref.foreignColumns.map((c) => c.name)).toEqual(["id"]);
+    expect(getTableConfig(ref.foreignTable).name).toBe("agent_configs");
+  });
 });
 
 // ------------------------------------------------------------------ ModelConfig
 
-test("ModelConfig: provider is constrained to the supported union", () => {
-  const model: ModelConfig = {
-    provider: "anthropic",
-    model: "claude-sonnet-5",
-    maxTokens: 1024,
-    temperature: 0.7,
-  };
-  assert.equal(model.provider, "anthropic");
+describe("ModelConfig", () => {
+  it("constrains provider to the supported union", () => {
+    const model: ModelConfig = {
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      maxTokens: 1024,
+      temperature: 0.7,
+    };
+    expect(model.provider).toBe("anthropic");
 
-  // Compile-time guard: an unsupported provider must not type-check. tsx strips
-  // types at runtime, so this line is inert then; `tsc --noEmit` enforces it.
-  // @ts-expect-error "cohere" is not a member of the provider union
-  const unsupported: ModelConfig = { provider: "cohere", model: "x" };
-  void unsupported;
+    // Compile-time guard: an unsupported provider must not type-check. Types are
+    // stripped at runtime, so this line is inert then; `tsc --noEmit` enforces it.
+    // @ts-expect-error "cohere" is not a member of the provider union
+    const unsupported: ModelConfig = { provider: "cohere", model: "x" };
+    void unsupported;
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,9 +101,9 @@ importers:
       drizzle-kit:
         specifier: ^1.0.0-beta.2
         version: 1.0.0-rc.4-ca0f029
-      tsx:
-        specifier: ^4.7.1
-        version: 4.23.0
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0))
 
 packages:
 


### PR DESCRIPTION
Follow-up to #45/#47: `@funky/db` ran its tests through `node:test` + `tsx` while `@funky/configs` and `apps/api` use vitest. This converts the two db suites to vitest `describe`/`it`/`expect` — same 12 tests, same coverage — so the whole workspace shares one runner and style. `tsx` is dropped from `@funky/db` devDeps since only the old test script used it. Verified: all 107 workspace tests pass and `tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)