### PR TITLE
Add environment configs resource (/v1/environments)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Spin up agent swarms on demand. Define an agent (system prompt + model), give it a sandboxed environment, send it work — Funky handles the durability and the infrastructure.
 
-> **Status: early development.** The agent config API is functional. Environments, sessions, and the agent runtime are in active development.
+> **Status: early development.** The agent and environment config APIs are functional. Sessions and the agent runtime are in active development.
 
 ## Quickstart
 
@@ -34,6 +34,19 @@ curl -s -X POST localhost:3000/v1/agents \
 
 # list agents
 curl -s -H "Authorization: Bearer $TOKEN" localhost:3000/v1/agents
+
+# create an environment (the sandbox recipe for future sessions)
+curl -s -X POST localhost:3000/v1/environments \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "content-type: application/json" \
+  -d '{
+    "name": "python basic",
+    "base_image": "funky/base-python:3.12",
+    "egress": { "allow": ["pypi.org", "files.pythonhosted.org"] }
+  }'
+
+# list environments
+curl -s -H "Authorization: Bearer $TOKEN" localhost:3000/v1/environments
 ```
 
 Tear down with `docker compose down` (add `-v` to also delete the database).
@@ -61,7 +74,7 @@ Useful commands: `pnpm typecheck` · `pnpm -F @funky/db generate` (new migration
 
 ```
 apps/api           HTTP API (Hono)
-packages/configs   agent config domain logic
+packages/configs   agent + environment config domain logic
 packages/db        Drizzle schema + migrations
 ```
 
@@ -70,7 +83,7 @@ packages/db        Drizzle schema + migrations
 ## Roadmap
 
 - [x] Agent configs (versioned, archive-only) — create/update/list/archive + version history
-- [ ] Environment configs
+- [x] Environment configs (unversioned, archive or delete) — the sandbox recipe: base image, persistent fs, egress policy
 - [ ] Sessions & event log
 - [ ] Agent runtime worker (the loop)
 - [ ] Sandboxed execution

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,14 +1,16 @@
 // apps/api/src/app.ts
 // The whole application, network-free. Tests: buildApp(deps) + app.request().
 import { Hono } from "hono";
-import type { AgentsService, AuthContext } from "@funky/configs";
+import type { AgentsService, AuthContext, EnvsService } from "@funky/configs";
 import { errorHandler, errorResponse } from "./http";
 import { auth } from "./middleware/auth";
 import { requestId } from "./middleware/request-id";
 import { agentRoutes } from "./routes/agents";
+import { envRoutes } from "./routes/environments";
 
 export type AppDeps = {
   agents: AgentsService;
+  envs: EnvsService;
   /** null = auth disabled (dev only) */
   authToken: string | null;
   /** liveness of the DB, e.g. () => pool.query("SELECT 1") */
@@ -30,6 +32,7 @@ export function buildApp(deps: AppDeps) {
 
   app.use("/v1/*", auth(deps.authToken));
   app.route("/v1/agents", agentRoutes(deps.agents));
+  app.route("/v1/environments", envRoutes(deps.envs));
 
   app.notFound((c) => errorResponse(c, 404, "not_found_error", "unknown route"));
   app.onError(errorHandler);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,7 +3,7 @@ import "dotenv/config"; // dev convenience; production containers inject env dir
 import { serve } from "@hono/node-server";
 import { Pool } from "pg";
 import { createDb } from "@funky/db";
-import { AgentsService } from "@funky/configs";
+import { AgentsService, EnvsService } from "@funky/configs";
 import { buildApp } from "./app";
 import { loadConfig } from "./config";
 import { config } from "dotenv";
@@ -24,6 +24,7 @@ const db = createDb(pool);
 
 const app = buildApp({
   agents: new AgentsService(db),
+  envs: new EnvsService(db),
   authToken: cfg.authToken,
   ping: () => pool.query("SELECT 1"),
 });

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -1,10 +1,10 @@
 // apps/api/src/routes/agents.ts
 // Thin: validate shapes → call service → status code. No Drizzle imports here, ever.
 import { Hono } from "hono";
-import { zValidator } from "@hono/zod-validator";
-import { z, ZodType } from "zod";
+import { z } from "zod";
 import type { AgentsService, AuthContext } from "@funky/configs";
 import { errorResponse } from "../http";
+import { listQuerySchema, metadataSchema, validate } from "./common";
 
 type Env = { Variables: { auth: AuthContext; requestId: string } };
 
@@ -28,11 +28,6 @@ const modelSchema = z
   })
   .strict();
 
-// zod v4: record takes explicit key + value schemas (key length enforced there)
-const metadataSchema = z
-  .record(z.string().max(64), z.string().max(512))
-  .refine((m) => Object.keys(m).length <= 16, "metadata: at most 16 pairs");
-
 const createSchema = z
   .object({
     id: z.uuid().optional(),
@@ -51,29 +46,10 @@ const updateSchema = createSchema
   .strict()
   .refine((o) => Object.keys(o).length > 0, "at least one field is required");
 
-const listQuerySchema = z.object({
-  limit: z.coerce.number().int().min(1).max(100).default(20),
-  after_id: z.uuid().optional(),
-  include_archived: z
-    .enum(["true", "false"])
-    .default("false")
-    .transform((v) => v === "true"),
-});
-
 const versionsQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(20),
   after_version: z.coerce.number().int().min(1).optional(),
 });
-
-const validate = <T extends ZodType>(target: "json" | "query", schema: T) =>
-  zValidator(target, schema, (result, c) => {
-    if (!result.success) {
-      const msg = result.error.issues
-        .map((i) => `${i.path.map(String).join(".") || "body"}: ${i.message}`)
-        .join("; ");
-      return errorResponse(c, 400, "invalid_request_error", msg);
-    }
-  });
 
 // ---------------------------------------------------------------- routes
 

--- a/apps/api/src/routes/common.ts
+++ b/apps/api/src/routes/common.ts
@@ -1,0 +1,29 @@
+// apps/api/src/routes/common.ts
+// zod schemas + the validate wrapper shared by every resource's route file.
+import { zValidator } from "@hono/zod-validator";
+import { z, ZodType } from "zod";
+import { errorResponse } from "../http";
+
+// zod v4: record takes explicit key + value schemas (key length enforced there)
+export const metadataSchema = z
+  .record(z.string().max(64), z.string().max(512))
+  .refine((m) => Object.keys(m).length <= 16, "metadata: at most 16 pairs");
+
+export const listQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  after_id: z.uuid().optional(),
+  include_archived: z
+    .enum(["true", "false"])
+    .default("false")
+    .transform((v) => v === "true"),
+});
+
+export const validate = <T extends ZodType>(target: "json" | "query", schema: T) =>
+  zValidator(target, schema, (result, c) => {
+    if (!result.success) {
+      const msg = result.error.issues
+        .map((i) => `${i.path.map(String).join(".") || "body"}: ${i.message}`)
+        .join("; ");
+      return errorResponse(c, 400, "invalid_request_error", msg);
+    }
+  });

--- a/apps/api/src/routes/environments.ts
+++ b/apps/api/src/routes/environments.ts
@@ -1,0 +1,97 @@
+// apps/api/src/routes/environments.ts
+// Thin: validate shapes → call service → status code. No Drizzle imports here, ever.
+import { Hono } from "hono";
+import { z } from "zod";
+import type { AuthContext, EnvsService } from "@funky/configs";
+import { listQuerySchema, metadataSchema, validate } from "./common";
+
+type Env = { Variables: { auth: AuthContext; requestId: string } };
+
+// ------------------------------------------------------------ zod schemas
+
+// loose image-ref sanity (repo[:tag][@digest]); no whitespace
+const baseImageSchema = z
+  .string()
+  .min(1)
+  .max(512)
+  .regex(/^[\w][\w.\-\/:@]*$/, "must be a valid image reference");
+
+// bare or wildcard-prefixed domain, no scheme, no path
+const hostnameRegex =
+  /^(\*\.)?[a-z0-9]([a-z0-9\-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9\-]*[a-z0-9])?)*$/i;
+
+const persistentFsSchema = z
+  .object({ size_gb: z.number().int().min(1).max(100) })
+  .strict();
+
+const egressSchema = z
+  .object({
+    allow: z
+      .array(z.string().max(255).regex(hostnameRegex, "must be a bare or wildcard-prefixed hostname"))
+      .max(100),
+  })
+  .strict();
+
+const createSchema = z
+  .object({
+    id: z.uuid().optional(),
+    name: z.string().min(1).max(256),
+    description: z.string().max(2048).nullish(),
+    metadata: metadataSchema.optional(),
+    base_image: baseImageSchema,
+    persistent_fs: persistentFsSchema.optional(),
+    egress: egressSchema.optional(),
+  })
+  .strict();
+
+const updateSchema = createSchema
+  .omit({ id: true })
+  .partial()
+  .strict()
+  .refine((o) => Object.keys(o).length > 0, "at least one field is required");
+
+// ---------------------------------------------------------------- routes
+
+export function envRoutes(envs: EnvsService) {
+  const r = new Hono<Env>();
+
+  // 1. create (client-supplied id → idempotent)
+  r.post("/", validate("json", createSchema), async (c) => {
+    const { environment, created } = await envs.create(c.get("auth"), c.req.valid("json"));
+    return c.json(environment, created ? 201 : 200);
+  });
+
+  // 2. list
+  r.get("/", validate("query", listQuerySchema), async (c) => {
+    const q = c.req.valid("query");
+    const page = await envs.list(c.get("auth"), {
+      limit: q.limit,
+      afterId: q.after_id,
+      includeArchived: q.include_archived,
+    });
+    return c.json(page);
+  });
+
+  // 3. retrieve
+  r.get("/:id", async (c) => {
+    return c.json(await envs.get(c.get("auth"), c.req.param("id")));
+  });
+
+  // 4. update (plain UPDATE — envs are not versioned)
+  r.post("/:id", validate("json", updateSchema), async (c) => {
+    return c.json(await envs.update(c.get("auth"), c.req.param("id"), c.req.valid("json")));
+  });
+
+  // 5. archive (idempotent, permanent)
+  r.post("/:id/archive", async (c) => {
+    return c.json(await envs.archive(c.get("auth"), c.req.param("id")));
+  });
+
+  // 6. hard delete (unlike agents — envs support both archive and delete)
+  r.delete("/:id", async (c) => {
+    await envs.delete(c.get("auth"), c.req.param("id"));
+    return c.body(null, 204);
+  });
+
+  return r;
+}

--- a/packages/configs/src/envs-service.ts
+++ b/packages/configs/src/envs-service.ts
@@ -1,0 +1,183 @@
+// packages/configs/src/envs-service.ts
+// All business rules for the environments resource. Mirrors AgentsService minus
+// versioning: envs are a single row, consumed once at sandbox provision, so
+// update is a plain UPDATE (last-write-wins) and no transaction is needed.
+// Every query is scoped by ctx.namespace.
+
+import { and, desc, eq, isNull, lt } from "drizzle-orm";
+import { v7 as uuidv7 } from "uuid";
+import type { Db } from "@funky/db";
+import { envConfigs } from "@funky/db/schema";
+import { ConflictError, NotFoundError } from "./errors";
+import { isUniqueViolation, jsonEq } from "./util";
+import type { CreateEnvInput, Environment, UpdateEnvInput } from "./envs-types";
+import type { AuthContext, Page } from "./types";
+
+const DEFAULT_PERSISTENT_FS = { size_gb: 2 };
+const DEFAULT_EGRESS = { allow: [] as string[] }; // deny-all egress by default
+
+type EnvRow = typeof envConfigs.$inferSelect;
+
+export class EnvsService {
+  constructor(private readonly db: Db) {}
+
+  // ---------------------------------------------------------------- create
+  async create(
+    ctx: AuthContext,
+    input: CreateEnvInput,
+  ): Promise<{ environment: Environment; created: boolean }> {
+    const id = input.id ?? uuidv7();
+    try {
+      if (input.id) {
+        const existing = await this.findRaw(ctx, input.id);
+        if (existing) return this.resolveIdempotentCreate(existing, input);
+      }
+      const [row] = await this.db
+        .insert(envConfigs)
+        .values({
+          id,
+          namespace: ctx.namespace,
+          name: input.name,
+          description: input.description ?? null,
+          metadata: input.metadata ?? {},
+          baseImage: input.base_image,
+          persistentFs: input.persistent_fs ?? DEFAULT_PERSISTENT_FS,
+          egress: input.egress ?? DEFAULT_EGRESS,
+        })
+        .returning();
+      return { environment: toEnvironment(row!), created: true };
+    } catch (err) {
+      // Two same-id creates raced: loser hits the PK. Re-resolve via idempotency.
+      if (isUniqueViolation(err) && input.id) {
+        const existing = await this.findRaw(ctx, input.id);
+        if (existing) return this.resolveIdempotentCreate(existing, input);
+      }
+      throw err;
+    }
+  }
+
+  private resolveIdempotentCreate(
+    existing: EnvRow,
+    input: CreateEnvInput,
+  ): { environment: Environment; created: boolean } {
+    const same =
+      existing.name === input.name &&
+      (existing.description ?? null) === (input.description ?? null) &&
+      jsonEq(existing.metadata, input.metadata ?? {}) &&
+      existing.baseImage === input.base_image &&
+      jsonEq(existing.persistentFs, input.persistent_fs ?? DEFAULT_PERSISTENT_FS) &&
+      jsonEq(existing.egress, input.egress ?? DEFAULT_EGRESS);
+    if (!same) {
+      throw new ConflictError("an environment with this id exists with a different configuration");
+    }
+    return { environment: toEnvironment(existing), created: false };
+  }
+
+  // ------------------------------------------------------------------- get
+  async get(ctx: AuthContext, id: string): Promise<Environment> {
+    const row = await this.findRaw(ctx, id);
+    if (!row) throw new NotFoundError("environment not found");
+    return toEnvironment(row);
+  }
+
+  // ------------------------------------------------------------------ list
+  async list(
+    ctx: AuthContext,
+    opts: { limit: number; afterId?: string; includeArchived: boolean },
+  ): Promise<Page<Environment>> {
+    const where = [eq(envConfigs.namespace, ctx.namespace)];
+    if (opts.afterId) where.push(lt(envConfigs.id, opts.afterId));
+    if (!opts.includeArchived) where.push(isNull(envConfigs.archivedAt));
+
+    const rows = await this.db
+      .select()
+      .from(envConfigs)
+      .where(and(...where))
+      .orderBy(desc(envConfigs.id)) // uuidv7 ≈ newest first
+      .limit(opts.limit + 1);
+
+    const page = rows.slice(0, opts.limit);
+    return {
+      data: page.map(toEnvironment),
+      has_more: rows.length > opts.limit,
+      last_id: page.at(-1)?.id,
+    };
+  }
+
+  // ---------------------------------------------------------------- update
+  async update(ctx: AuthContext, id: string, patch: UpdateEnvInput): Promise<Environment> {
+    const existing = await this.findRaw(ctx, id);
+    if (!existing) throw new NotFoundError("environment not found");
+    if (existing.archivedAt) throw new ConflictError("environment is archived and read-only");
+
+    const [row] = await this.db
+      .update(envConfigs)
+      .set({
+        ...(patch.name !== undefined && { name: patch.name }),
+        ...(patch.description !== undefined && { description: patch.description }),
+        ...(patch.metadata !== undefined && { metadata: patch.metadata }), // replace, not merge
+        ...(patch.base_image !== undefined && { baseImage: patch.base_image }),
+        ...(patch.persistent_fs !== undefined && { persistentFs: patch.persistent_fs }),
+        ...(patch.egress !== undefined && { egress: patch.egress }),
+        updatedAt: new Date(),
+      })
+      .where(and(eq(envConfigs.id, id), eq(envConfigs.namespace, ctx.namespace)))
+      .returning();
+    if (!row) throw new NotFoundError("environment not found");
+    return toEnvironment(row);
+  }
+
+  // --------------------------------------------------------------- archive
+  async archive(ctx: AuthContext, id: string): Promise<Environment> {
+    // Idempotent: keeps the original archived_at if already set.
+    await this.db
+      .update(envConfigs)
+      .set({ archivedAt: new Date(), updatedAt: new Date() })
+      .where(
+        and(
+          eq(envConfigs.id, id),
+          eq(envConfigs.namespace, ctx.namespace),
+          isNull(envConfigs.archivedAt),
+        ),
+      );
+    return this.get(ctx, id); // throws NotFound if it never existed in this ns
+  }
+
+  // ---------------------------------------------------------------- delete
+  // TODO(sessions): once sessions reference envs, deletion of an in-use env
+  // must be blocked (FK RESTRICT will handle it).
+  async delete(ctx: AuthContext, id: string): Promise<void> {
+    const rows = await this.db
+      .delete(envConfigs)
+      .where(and(eq(envConfigs.id, id), eq(envConfigs.namespace, ctx.namespace)))
+      .returning({ id: envConfigs.id });
+    if (rows.length === 0) throw new NotFoundError("environment not found");
+  }
+
+  // --------------------------------------------------------------- helpers
+  private async findRaw(ctx: AuthContext, id: string): Promise<EnvRow | undefined> {
+    const [row] = await this.db
+      .select()
+      .from(envConfigs)
+      .where(and(eq(envConfigs.id, id), eq(envConfigs.namespace, ctx.namespace)));
+    return row;
+  }
+}
+
+// ------------------------------------------------------------ pure helpers
+
+function toEnvironment(row: EnvRow): Environment {
+  return {
+    type: "environment",
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    metadata: row.metadata,
+    base_image: row.baseImage,
+    persistent_fs: row.persistentFs,
+    egress: row.egress,
+    created_at: row.createdAt.toISOString(),
+    updated_at: row.updatedAt.toISOString(),
+    archived_at: row.archivedAt?.toISOString() ?? null,
+  };
+}

--- a/packages/configs/src/envs-types.ts
+++ b/packages/configs/src/envs-types.ts
@@ -1,0 +1,28 @@
+// packages/configs/src/envs-types.ts
+import type { EgressPolicy, PersistentFs } from "@funky/db/schema";
+
+export type Environment = {
+  type: "environment";
+  id: string;
+  name: string;
+  description: string | null;
+  metadata: Record<string, string>;
+  base_image: string;
+  persistent_fs: PersistentFs;
+  egress: EgressPolicy;
+  created_at: string;
+  updated_at: string;
+  archived_at: string | null;
+};
+
+export type CreateEnvInput = {
+  id?: string;
+  name: string;
+  description?: string | null;
+  metadata?: Record<string, string>;
+  base_image: string;
+  persistent_fs?: PersistentFs;
+  egress?: EgressPolicy;
+};
+
+export type UpdateEnvInput = Partial<Omit<CreateEnvInput, "id">>;

--- a/packages/configs/src/index.ts
+++ b/packages/configs/src/index.ts
@@ -1,5 +1,6 @@
 // packages/configs — public surface
 export { AgentsService } from "./service";
+export { EnvsService } from "./envs-service";
 export { ConflictError, NotFoundError } from "./errors";
 export type {
   Agent,
@@ -9,3 +10,4 @@ export type {
   Page,
   UpdateAgentInput,
 } from "./types";
+export type { CreateEnvInput, Environment, UpdateEnvInput } from "./envs-types";

--- a/packages/configs/src/service.ts
+++ b/packages/configs/src/service.ts
@@ -7,6 +7,7 @@ import { v7 as uuidv7 } from "uuid";
 import type { Db } from "@funky/db";
 import { agentConfigs, agentConfigVersions } from "@funky/db/schema";
 import { ConflictError, NotFoundError } from "./errors";
+import { isUniqueViolation, jsonEq } from "./util";
 import type {
   Agent,
   AgentVersion,
@@ -289,29 +290,4 @@ function toAgentVersion(v: VersionRow): AgentVersion {
     created_at: v.createdAt.toISOString(),
     created_by: v.createdBy,
   };
-}
-
-function jsonEq(a: unknown, b: unknown): boolean {
-  return JSON.stringify(sortKeys(a)) === JSON.stringify(sortKeys(b));
-}
-
-function sortKeys(x: unknown): unknown {
-  if (Array.isArray(x)) return x.map(sortKeys);
-  if (x && typeof x === "object") {
-    return Object.fromEntries(
-      Object.entries(x as Record<string, unknown>)
-        .sort(([k1], [k2]) => k1.localeCompare(k2))
-        .map(([k, v]) => [k, sortKeys(v)]),
-    );
-  }
-  return x;
-}
-
-function isUniqueViolation(err: unknown): boolean {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    "code" in err &&
-    (err as { code?: string }).code === "23505"
-  );
 }

--- a/packages/configs/src/util.ts
+++ b/packages/configs/src/util.ts
@@ -1,0 +1,29 @@
+// packages/configs/src/util.ts
+// Pure helpers shared by the resource services. Internal — not exported from index.ts.
+
+/** Key-order-insensitive deep equality for jsonb columns. */
+export function jsonEq(a: unknown, b: unknown): boolean {
+  return JSON.stringify(sortKeys(a)) === JSON.stringify(sortKeys(b));
+}
+
+function sortKeys(x: unknown): unknown {
+  if (Array.isArray(x)) return x.map(sortKeys);
+  if (x && typeof x === "object") {
+    return Object.fromEntries(
+      Object.entries(x as Record<string, unknown>)
+        .sort(([k1], [k2]) => k1.localeCompare(k2))
+        .map(([k, v]) => [k, sortKeys(v)]),
+    );
+  }
+  return x;
+}
+
+/** Postgres unique_violation (two same-id creates raced; loser hits the PK). */
+export function isUniqueViolation(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: string }).code === "23505"
+  );
+}

--- a/packages/db/migrations/20260711000328_known_the_hunter/migration.sql
+++ b/packages/db/migrations/20260711000328_known_the_hunter/migration.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "env_configs" (
+	"id" uuid PRIMARY KEY,
+	"namespace" text NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"metadata" jsonb DEFAULT '{}' NOT NULL,
+	"base_image" text NOT NULL,
+	"persistent_fs" jsonb DEFAULT '{"size_gb":2}' NOT NULL,
+	"egress" jsonb DEFAULT '{"allow":[]}' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"archived_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE INDEX "env_configs_ns_name" ON "env_configs" ("namespace","name");--> statement-breakpoint
+CREATE INDEX "env_configs_ns" ON "env_configs" ("namespace");

--- a/packages/db/migrations/20260711000328_known_the_hunter/snapshot.json
+++ b/packages/db/migrations/20260711000328_known_the_hunter/snapshot.json
@@ -1,0 +1,539 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "e1de5131-35bb-4164-b746-f12054f9ad80",
+  "prevIds": [
+    "37bb4263-8d0e-4256-bb7f-343e1605bd88"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "agent_config_versions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "agent_configs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "env_configs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "agent_config_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "system_prompt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "model",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "tool_policy",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "1",
+      "generated": null,
+      "identity": null,
+      "name": "latest_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "base_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{\"size_gb\":2}'",
+      "generated": null,
+      "identity": null,
+      "name": "persistent_fs",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{\"allow\":[]}'",
+      "generated": null,
+      "identity": null,
+      "name": "egress",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_configs_ns_name",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_configs_ns",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "env_configs_ns_name",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "env_configs_ns",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "agent_config_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "agent_configs",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "agent_config_versions_agent_config_id_agent_configs_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "columns": [
+        "agent_config_id",
+        "version"
+      ],
+      "nameExplicit": false,
+      "name": "agent_config_versions_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "agent_configs_pkey",
+      "schema": "public",
+      "table": "agent_configs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "env_configs_pkey",
+      "schema": "public",
+      "table": "env_configs",
+      "entityType": "pks"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db/schema/envs.ts
+++ b/packages/db/schema/envs.ts
@@ -1,0 +1,36 @@
+// packages/db/schema/envs.ts
+// Environment config = the recipe for a session's sandbox (base image, persistent
+// filesystem, egress policy). Single table + archive, NOT versioned: the config is
+// consumed once at sandbox provision, so updates only affect future sessions.
+// When sessions land they snapshot resolved_env at provision; see configs.ts.
+
+import {
+  index, jsonb, pgTable, text, timestamp, uuid,
+} from "drizzle-orm/pg-core";
+
+export type PersistentFs = { size_gb: number };
+export type EgressPolicy = { allow: string[] }; // domain allowlist; [] = deny all egress
+
+export const envConfigs = pgTable(
+  "env_configs",
+  {
+    id: uuid("id").primaryKey(),              // client-supplied → idempotent create
+    namespace: text("namespace").notNull(),
+    name: text("name").notNull(),             // display label, non-unique
+    description: text("description"),
+    metadata: jsonb("metadata").$type<Record<string, string>>().notNull().default({}),
+
+    // ---- the recipe ----
+    baseImage: text("base_image").notNull(),  // e.g. "funky/base-python:3.12"
+    persistentFs: jsonb("persistent_fs").$type<PersistentFs>().notNull().default({ size_gb: 2 }),
+    egress: jsonb("egress").$type<EgressPolicy>().notNull().default({ allow: [] }),
+
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+    archivedAt: timestamp("archived_at", { withTimezone: true }),
+  },
+  (t) => [
+    index("env_configs_ns_name").on(t.namespace, t.name),
+    index("env_configs_ns").on(t.namespace),
+  ],
+);

--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -6,7 +6,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { Pool } from "pg";
 import { createDb, tables, type Db } from "./client";
-import { agentConfigs, agentConfigVersions } from "./schema";
+import { agentConfigs, agentConfigVersions, envConfigs } from "./schema";
 
 const DUMMY_URL = "postgres://user:pass@localhost:5432/funky_test";
 
@@ -32,13 +32,20 @@ test("the query builder renders schema tables into SQL", async () => {
 
     const versions = db.select().from(agentConfigVersions).toSQL();
     assert.match(versions.sql, /from "agent_config_versions"/);
+
+    const envs = db.select().from(envConfigs).toSQL();
+    assert.match(envs.sql, /from "env_configs"/);
   } finally {
     await pool.end();
   }
 });
 
-test("`tables` re-exports both schema tables by their identifiers", () => {
+test("`tables` re-exports all schema tables by their identifiers", () => {
   assert.equal(tables.agentConfigs, agentConfigs);
   assert.equal(tables.agentConfigVersions, agentConfigVersions);
-  assert.deepEqual(Object.keys(tables).sort(), ["agentConfigVersions", "agentConfigs"].sort());
+  assert.equal(tables.envConfigs, envConfigs);
+  assert.deepEqual(
+    Object.keys(tables).sort(),
+    ["agentConfigVersions", "agentConfigs", "envConfigs"].sort(),
+  );
 });

--- a/packages/db/src/schema.test.ts
+++ b/packages/db/src/schema.test.ts
@@ -7,7 +7,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { getTableConfig, type PgTable } from "drizzle-orm/pg-core";
-import { agentConfigs, agentConfigVersions, type ModelConfig } from "./schema";
+import { agentConfigs, agentConfigVersions, envConfigs, type ModelConfig } from "./schema";
 
 type ColSpec = {
   type: string; // getSQLType() output, e.g. "uuid", "timestamp with time zone"
@@ -126,6 +126,43 @@ test("agent_config_versions: agent_config_id references agent_configs.id", () =>
   assert.deepEqual(ref.columns.map((c) => c.name), ["agent_config_id"]);
   assert.deepEqual(ref.foreignColumns.map((c) => c.name), ["id"]);
   assert.equal(getTableConfig(ref.foreignTable).name, "agent_configs");
+});
+
+// ----------------------------------------------------------------- env_configs
+
+test("env_configs: table name", () => {
+  assert.equal(getTableConfig(envConfigs).name, "env_configs");
+});
+
+test("env_configs: columns match the migration", () => {
+  assertColumns(envConfigs, {
+    id: { type: "uuid", notNull: true, primary: true },
+    namespace: { type: "text", notNull: true },
+    name: { type: "text", notNull: true },
+    description: { type: "text", notNull: false },
+    metadata: { type: "jsonb", notNull: true, hasDefault: true, default: {} },
+    base_image: { type: "text", notNull: true },
+    persistent_fs: { type: "jsonb", notNull: true, hasDefault: true, default: { size_gb: 2 } },
+    egress: { type: "jsonb", notNull: true, hasDefault: true, default: { allow: [] } },
+    created_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
+    updated_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
+    archived_at: { type: "timestamp with time zone", notNull: false },
+  });
+});
+
+test("env_configs: id is an inline primary key (no composite PK, no FKs)", () => {
+  const cfg = getTableConfig(envConfigs);
+  assert.equal(cfg.primaryKeys.length, 0, "envs use an inline PK, not a composite one");
+  assert.equal(cfg.foreignKeys.length, 0, "env table references nothing (yet — sessions later)");
+});
+
+test("env_configs: has the two namespace lookup indexes, both non-unique", () => {
+  // name is a display label, not a reference — the (namespace, name) index must
+  // stay non-unique so duplicate names within a namespace are allowed.
+  assert.deepEqual(indexSummaries(envConfigs), [
+    { name: "env_configs_ns", columns: ["namespace"], unique: false },
+    { name: "env_configs_ns_name", columns: ["namespace", "name"], unique: false },
+  ]);
 });
 
 // ------------------------------------------------------------------ ModelConfig

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,1 +1,2 @@
 export * from "../schema/configs";
+export * from "../schema/envs";


### PR DESCRIPTION
Implements the environments resource per the roadmap: an environment config is the recipe for a session's sandbox (base image, persistent filesystem, egress allowlist), stored in a new `env_configs` table with a generated migration. Unlike agents, environments are unversioned (consumed once at sandbox provision) and support both archive and hard delete; create is idempotent via client-supplied id, and all queries are namespace-scoped. Shared zod schemas and the validate wrapper were extracted from `agents.ts` into `routes/common.ts` with no behavior change, and `jsonEq`/unique-violation helpers moved into `packages/configs/src/util.ts` for reuse by the new `EnvsService`. Schema-shape and client tests now cover `env_configs`, and the README quickstart/status/roadmap were updated to include environments. Verified with the full definition-of-done curl suite (35 checks), an agents regression suite (17 checks), `pnpm test` (16/16), and `pnpm typecheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)