### PR TITLE
Add sessions schemas and event model (Phase A)

### DIFF
--- a/packages/db/migrations/20260713165838_smiling_metal_master/migration.sql
+++ b/packages/db/migrations/20260713165838_smiling_metal_master/migration.sql
@@ -1,0 +1,46 @@
+CREATE TABLE "session_events" (
+	"session_id" uuid,
+	"seq" bigint,
+	"namespace" text NOT NULL,
+	"type" text NOT NULL,
+	"payload" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "session_events_pkey" PRIMARY KEY("session_id","seq")
+);
+--> statement-breakpoint
+CREATE TABLE "sessions" (
+	"id" uuid PRIMARY KEY,
+	"namespace" text NOT NULL,
+	"agent_config_id" uuid NOT NULL,
+	"agent_version" integer NOT NULL,
+	"env_config_id" uuid NOT NULL,
+	"resolved_env" jsonb,
+	"sandbox_handle" jsonb,
+	"status" text DEFAULT 'provisioning' NOT NULL,
+	"title" text,
+	"metadata" jsonb DEFAULT '{}' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"archived_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "turn_jobs" (
+	"id" uuid PRIMARY KEY,
+	"namespace" text NOT NULL,
+	"session_id" uuid NOT NULL,
+	"kind" text DEFAULT 'turn' NOT NULL,
+	"state" text DEFAULT 'queued' NOT NULL,
+	"run_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"max_attempts" integer DEFAULT 5 NOT NULL,
+	"lease_expires_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "sessions_ns" ON "sessions" ("namespace");--> statement-breakpoint
+CREATE INDEX "turn_jobs_queued" ON "turn_jobs" ("run_at") WHERE "state" = 'queued';--> statement-breakpoint
+CREATE INDEX "turn_jobs_active_session" ON "turn_jobs" ("session_id") WHERE "state" IN ('queued', 'running');--> statement-breakpoint
+ALTER TABLE "session_events" ADD CONSTRAINT "session_events_session_id_sessions_id_fkey" FOREIGN KEY ("session_id") REFERENCES "sessions"("id");--> statement-breakpoint
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_agent_config_id_agent_configs_id_fkey" FOREIGN KEY ("agent_config_id") REFERENCES "agent_configs"("id");--> statement-breakpoint
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_env_config_id_env_configs_id_fkey" FOREIGN KEY ("env_config_id") REFERENCES "env_configs"("id");--> statement-breakpoint
+ALTER TABLE "turn_jobs" ADD CONSTRAINT "turn_jobs_session_id_sessions_id_fkey" FOREIGN KEY ("session_id") REFERENCES "sessions"("id");

--- a/packages/db/migrations/20260713165838_smiling_metal_master/snapshot.json
+++ b/packages/db/migrations/20260713165838_smiling_metal_master/snapshot.json
@@ -1,0 +1,1096 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "f0c96744-3ae3-4422-8968-44fe68d0149e",
+  "prevIds": [
+    "e1de5131-35bb-4164-b746-f12054f9ad80"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "agent_config_versions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "agent_configs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "env_configs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "session_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "sessions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "turn_jobs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "agent_config_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "system_prompt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "model",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "tool_policy",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "1",
+      "generated": null,
+      "identity": null,
+      "name": "latest_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "base_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{\"size_gb\":2}'",
+      "generated": null,
+      "identity": null,
+      "name": "persistent_fs",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{\"allow\":[]}'",
+      "generated": null,
+      "identity": null,
+      "name": "egress",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seq",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "agent_config_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "agent_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "env_config_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resolved_env",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "sandbox_handle",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'provisioning'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'turn'",
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'queued'",
+      "generated": null,
+      "identity": null,
+      "name": "state",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "run_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "attempts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "5",
+      "generated": null,
+      "identity": null,
+      "name": "max_attempts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "lease_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_configs_ns_name",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_configs_ns",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "env_configs_ns_name",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "env_configs_ns",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_ns",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "run_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"state\" = 'queued'",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "turn_jobs_queued",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"state\" IN ('queued', 'running')",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "turn_jobs_active_session",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "agent_config_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "agent_configs",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "agent_config_versions_agent_config_id_agent_configs_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "session_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "sessions",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "session_events_session_id_sessions_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "agent_config_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "agent_configs",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "sessions_agent_config_id_agent_configs_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "env_config_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "env_configs",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "sessions_env_config_id_env_configs_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "session_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "sessions",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "turn_jobs_session_id_sessions_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "columns": [
+        "agent_config_id",
+        "version"
+      ],
+      "nameExplicit": false,
+      "name": "agent_config_versions_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "columns": [
+        "session_id",
+        "seq"
+      ],
+      "nameExplicit": false,
+      "name": "session_events_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "agent_configs_pkey",
+      "schema": "public",
+      "table": "agent_configs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "env_configs_pkey",
+      "schema": "public",
+      "table": "env_configs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pkey",
+      "schema": "public",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "turn_jobs_pkey",
+      "schema": "public",
+      "table": "turn_jobs",
+      "entityType": "pks"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db/schema/sessions.ts
+++ b/packages/db/schema/sessions.ts
@@ -1,0 +1,101 @@
+// packages/db/schema/sessions.ts — Phase A: sessions, the event log, the turn queue.
+//
+// The composite PK on session_events (session_id, seq) IS the conditional append:
+// a worker inserts with a caller-computed seq; losing a race = PK violation = ErrConflict.
+// No other mechanism exists or is needed.
+
+import { sql } from "drizzle-orm";
+import {
+  bigint,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { agentConfigs } from "./configs";
+import { envConfigs } from "./envs"; // ⚠ adjust if the env iteration named this file differently
+
+/** Snapshot captured at sandbox provision; reboots rebuild from THIS, never from the
+ *  (mutable) env config. template_id is driver-specific (e.g. E2B template). */
+export type ResolvedEnv = {
+  base_image: string;
+  template_id?: string;
+  persistent_fs: { size_gb: number };
+  egress: { allow: string[] };
+};
+
+export type SessionStatus = "provisioning" | "ready" | "failed" | "archived";
+
+export const sessions = pgTable(
+  "sessions",
+  {
+    id: uuid("id").primaryKey(), // client-suppliable → idempotent create
+    namespace: text("namespace").notNull(),
+
+    agentConfigId: uuid("agent_config_id")
+      .notNull()
+      .references(() => agentConfigs.id),
+    agentVersion: integer("agent_version").notNull(),
+
+    envConfigId: uuid("env_config_id")
+      .notNull()
+      .references(() => envConfigs.id),
+    resolvedEnv: jsonb("resolved_env").$type<ResolvedEnv>(),
+    sandboxHandle: jsonb("sandbox_handle").$type<Record<string, unknown>>(),
+
+    status: text("status").$type<SessionStatus>().notNull().default("provisioning"),
+    title: text("title"),
+    metadata: jsonb("metadata").$type<Record<string, string>>().notNull().default({}),
+
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+    archivedAt: timestamp("archived_at", { withTimezone: true }),
+  },
+  (t) => [index("sessions_ns").on(t.namespace)],
+);
+
+export const sessionEvents = pgTable(
+  "session_events",
+  {
+    sessionId: uuid("session_id")
+      .notNull()
+      .references(() => sessions.id),
+    seq: bigint("seq", { mode: "number" }).notNull(),
+    namespace: text("namespace").notNull(),
+    type: text("type").notNull(),
+    payload: jsonb("payload").$type<Record<string, unknown>>().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [primaryKey({ columns: [t.sessionId, t.seq] })],
+);
+
+export type JobKind = "turn" | "provision";
+export type JobState = "queued" | "running" | "done" | "dead";
+
+export const turnJobs = pgTable(
+  "turn_jobs",
+  {
+    id: uuid("id").primaryKey(),
+    namespace: text("namespace").notNull(),
+    sessionId: uuid("session_id")
+      .notNull()
+      .references(() => sessions.id),
+    kind: text("kind").$type<JobKind>().notNull().default("turn"),
+    state: text("state").$type<JobState>().notNull().default("queued"),
+    runAt: timestamp("run_at", { withTimezone: true }).notNull().defaultNow(),
+    attempts: integer("attempts").notNull().default(0),
+    maxAttempts: integer("max_attempts").notNull().default(5),
+    leaseExpiresAt: timestamp("lease_expires_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index("turn_jobs_queued").on(t.runAt).where(sql`${t.state} = 'queued'`),
+    index("turn_jobs_active_session")
+      .on(t.sessionId)
+      .where(sql`${t.state} IN ('queued', 'running')`),
+  ],
+);

--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -5,7 +5,14 @@
 import { Pool } from "pg";
 import { describe, expect, it } from "vitest";
 import { createDb, tables, type Db } from "./client";
-import { agentConfigs, agentConfigVersions, envConfigs } from "./schema";
+import {
+  agentConfigs,
+  agentConfigVersions,
+  envConfigs,
+  sessionEvents,
+  sessions,
+  turnJobs,
+} from "./schema";
 
 const DUMMY_URL = "postgres://user:pass@localhost:5432/funky_test";
 
@@ -35,6 +42,15 @@ describe("createDb", () => {
 
       const envs = db.select().from(envConfigs).toSQL();
       expect(envs.sql).toMatch(/from "env_configs"/);
+
+      const sess = db.select().from(sessions).toSQL();
+      expect(sess.sql).toMatch(/from "sessions"/);
+
+      const events = db.select().from(sessionEvents).toSQL();
+      expect(events.sql).toMatch(/from "session_events"/);
+
+      const jobs = db.select().from(turnJobs).toSQL();
+      expect(jobs.sql).toMatch(/from "turn_jobs"/);
     } finally {
       await pool.end();
     }
@@ -46,8 +62,18 @@ describe("tables", () => {
     expect(tables.agentConfigs).toBe(agentConfigs);
     expect(tables.agentConfigVersions).toBe(agentConfigVersions);
     expect(tables.envConfigs).toBe(envConfigs);
+    expect(tables.sessions).toBe(sessions);
+    expect(tables.sessionEvents).toBe(sessionEvents);
+    expect(tables.turnJobs).toBe(turnJobs);
     expect(Object.keys(tables).sort()).toEqual(
-      ["agentConfigVersions", "agentConfigs", "envConfigs"].sort(),
+      [
+        "agentConfigVersions",
+        "agentConfigs",
+        "envConfigs",
+        "sessions",
+        "sessionEvents",
+        "turnJobs",
+      ].sort(),
     );
   });
 });

--- a/packages/db/src/schema.test.ts
+++ b/packages/db/src/schema.test.ts
@@ -6,7 +6,18 @@
 
 import { getTableConfig, type PgTable } from "drizzle-orm/pg-core";
 import { describe, expect, it } from "vitest";
-import { agentConfigs, agentConfigVersions, envConfigs, type ModelConfig } from "./schema";
+import {
+  agentConfigs,
+  agentConfigVersions,
+  envConfigs,
+  type JobState,
+  type ModelConfig,
+  type ResolvedEnv,
+  type SessionStatus,
+  sessionEvents,
+  sessions,
+  turnJobs,
+} from "./schema";
 
 type ColSpec = {
   type: string; // getSQLType() output, e.g. "uuid", "timestamp with time zone"
@@ -51,6 +62,13 @@ function indexSummaries(table: PgTable) {
       unique: i.config.unique,
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Map index name → whether it carries a WHERE predicate (i.e. is partial). */
+function partialByName(table: PgTable) {
+  return new Map(
+    getTableConfig(table).indexes.map((i) => [i.config.name ?? "", i.config.where !== undefined]),
+  );
 }
 
 // ---------------------------------------------------------------- agent_configs
@@ -165,6 +183,149 @@ describe("env_configs", () => {
   });
 });
 
+// -------------------------------------------------------------------- sessions
+
+describe("sessions", () => {
+  it("has the expected table name", () => {
+    expect(getTableConfig(sessions).name).toBe("sessions");
+  });
+
+  it("columns match the schema", () => {
+    assertColumns(sessions, {
+      id: { type: "uuid", notNull: true, primary: true },
+      namespace: { type: "text", notNull: true },
+      agent_config_id: { type: "uuid", notNull: true },
+      agent_version: { type: "integer", notNull: true },
+      env_config_id: { type: "uuid", notNull: true },
+      // resolved_env / sandbox_handle are nullable: filled at provision time.
+      resolved_env: { type: "jsonb", notNull: false },
+      sandbox_handle: { type: "jsonb", notNull: false },
+      status: { type: "text", notNull: true, hasDefault: true, default: "provisioning" },
+      title: { type: "text", notNull: false },
+      metadata: { type: "jsonb", notNull: true, hasDefault: true, default: {} },
+      created_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
+      updated_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
+      archived_at: { type: "timestamp with time zone", notNull: false },
+    });
+  });
+
+  it("uses an inline primary key on id", () => {
+    const cfg = getTableConfig(sessions);
+    expect(cfg.primaryKeys, "sessions use an inline PK, not a composite one").toHaveLength(0);
+  });
+
+  it("pins the agent (by id) and the env config via two foreign keys", () => {
+    const refs = getTableConfig(sessions).foreignKeys.map((fk) => {
+      const r = fk.reference();
+      return {
+        column: r.columns.map((c) => c.name).join(","),
+        foreignTable: getTableConfig(r.foreignTable).name,
+        foreignColumn: r.foreignColumns.map((c) => c.name).join(","),
+      };
+    });
+    expect(refs).toHaveLength(2);
+    expect(refs).toContainEqual({
+      column: "agent_config_id",
+      foreignTable: "agent_configs",
+      foreignColumn: "id",
+    });
+    expect(refs).toContainEqual({
+      column: "env_config_id",
+      foreignTable: "env_configs",
+      foreignColumn: "id",
+    });
+  });
+
+  it("has a single namespace lookup index, non-unique", () => {
+    expect(indexSummaries(sessions)).toEqual([
+      { name: "sessions_ns", columns: ["namespace"], unique: false },
+    ]);
+  });
+});
+
+// --------------------------------------------------------------- session_events
+
+describe("session_events", () => {
+  it("has the expected table name", () => {
+    expect(getTableConfig(sessionEvents).name).toBe("session_events");
+  });
+
+  it("columns match the schema (append-only: no updated_at)", () => {
+    assertColumns(sessionEvents, {
+      session_id: { type: "uuid", notNull: true },
+      seq: { type: "bigint", notNull: true },
+      namespace: { type: "text", notNull: true },
+      type: { type: "text", notNull: true },
+      payload: { type: "jsonb", notNull: true },
+      created_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
+    });
+  });
+
+  it("has the composite primary key (session_id, seq) — THE conditional-append invariant", () => {
+    const pks = getTableConfig(sessionEvents).primaryKeys;
+    expect(pks).toHaveLength(1);
+    expect(pks[0]?.columns.map((c) => c.name)).toEqual(["session_id", "seq"]);
+  });
+
+  it("has no other unique constraint or index (the PK alone gates appends)", () => {
+    const cfg = getTableConfig(sessionEvents);
+    expect(cfg.uniqueConstraints, "no extra unique constraint").toHaveLength(0);
+    expect(cfg.indexes, "no secondary index").toHaveLength(0);
+  });
+
+  it("references sessions.id via session_id", () => {
+    const fks = getTableConfig(sessionEvents).foreignKeys;
+    expect(fks, "exactly one foreign key").toHaveLength(1);
+    const ref = fks[0]!.reference();
+    expect(ref.columns.map((c) => c.name)).toEqual(["session_id"]);
+    expect(ref.foreignColumns.map((c) => c.name)).toEqual(["id"]);
+    expect(getTableConfig(ref.foreignTable).name).toBe("sessions");
+  });
+});
+
+// ------------------------------------------------------------------- turn_jobs
+
+describe("turn_jobs", () => {
+  it("has the expected table name", () => {
+    expect(getTableConfig(turnJobs).name).toBe("turn_jobs");
+  });
+
+  it("columns match the schema (queue semantics live in columns)", () => {
+    assertColumns(turnJobs, {
+      id: { type: "uuid", notNull: true, primary: true },
+      namespace: { type: "text", notNull: true },
+      session_id: { type: "uuid", notNull: true },
+      kind: { type: "text", notNull: true, hasDefault: true, default: "turn" },
+      state: { type: "text", notNull: true, hasDefault: true, default: "queued" },
+      run_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
+      attempts: { type: "integer", notNull: true, hasDefault: true, default: 0 },
+      max_attempts: { type: "integer", notNull: true, hasDefault: true, default: 5 },
+      lease_expires_at: { type: "timestamp with time zone", notNull: false },
+      created_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
+    });
+  });
+
+  it("references sessions.id via session_id", () => {
+    const fks = getTableConfig(turnJobs).foreignKeys;
+    expect(fks, "exactly one foreign key").toHaveLength(1);
+    const ref = fks[0]!.reference();
+    expect(ref.columns.map((c) => c.name)).toEqual(["session_id"]);
+    expect(ref.foreignColumns.map((c) => c.name)).toEqual(["id"]);
+    expect(getTableConfig(ref.foreignTable).name).toBe("sessions");
+  });
+
+  it("has both partial indexes: the dequeue scan and the active-turn check", () => {
+    expect(indexSummaries(turnJobs)).toEqual([
+      { name: "turn_jobs_active_session", columns: ["session_id"], unique: false },
+      { name: "turn_jobs_queued", columns: ["run_at"], unique: false },
+    ]);
+    // Both MUST be partial (WHERE predicate) — a full index changes the semantics.
+    const partial = partialByName(turnJobs);
+    expect(partial.get("turn_jobs_queued"), "dequeue index must be partial").toBe(true);
+    expect(partial.get("turn_jobs_active_session"), "active-turn index must be partial").toBe(true);
+  });
+});
+
 // ------------------------------------------------------------------ ModelConfig
 
 describe("ModelConfig", () => {
@@ -182,5 +343,40 @@ describe("ModelConfig", () => {
     // @ts-expect-error "cohere" is not a member of the provider union
     const unsupported: ModelConfig = { provider: "cohere", model: "x" };
     void unsupported;
+  });
+});
+
+// -------------------------------------------------------------- session types
+
+describe("session domain types", () => {
+  it("ResolvedEnv snapshots base image, optional template, fs size and egress", () => {
+    const env: ResolvedEnv = {
+      base_image: "funky/base-python:3.12",
+      template_id: "e2b-abc123",
+      persistent_fs: { size_gb: 2 },
+      egress: { allow: ["api.example.com"] },
+    };
+    expect(env.persistent_fs.size_gb).toBe(2);
+
+    // template_id is optional — driver-specific, absent for drivers that don't use it.
+    const minimal: ResolvedEnv = {
+      base_image: "funky/base:latest",
+      persistent_fs: { size_gb: 1 },
+      egress: { allow: [] },
+    };
+    expect(minimal.template_id).toBeUndefined();
+  });
+
+  it("constrains SessionStatus and JobState to their unions", () => {
+    const status: SessionStatus = "provisioning";
+    const state: JobState = "queued";
+    expect([status, state]).toEqual(["provisioning", "queued"]);
+
+    // @ts-expect-error "running" is a JobState, not a SessionStatus
+    const badStatus: SessionStatus = "running";
+    void badStatus;
+    // @ts-expect-error "archived" is a SessionStatus, not a JobState
+    const badState: JobState = "archived";
+    void badState;
   });
 });

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,2 +1,3 @@
 export * from "../schema/configs";
 export * from "../schema/envs";
+export * from "../schema/sessions";

--- a/packages/sessions/package.json
+++ b/packages/sessions/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@funky/sessions",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./events": "./src/events.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@funky/db": "workspace:*",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/sessions/src/events.test.ts
+++ b/packages/sessions/src/events.test.ts
@@ -1,0 +1,144 @@
+// Unit tests for the Phase A event model. These are the contract the DB rows are
+// stored against: every append goes through makeEvent(), every read through
+// parseEvent(). The round-trip below is the guarantee that a written event reads
+// back identically for every event type — and that the two deliberately
+// future-proofed shapes (ContentBlock[] content, capped-array tool_calls) hold.
+
+import { describe, expect, it } from "vitest";
+import {
+  type EventPayload,
+  type EventType,
+  eventPayloadSchemas,
+  idemKeyFor,
+  makeEvent,
+  parseEvent,
+  plainText,
+  textContent,
+} from "./events";
+
+const base = { sessionId: "11111111-1111-1111-1111-111111111111", namespace: "default", seq: 1 };
+const createdAt = new Date("2026-07-13T00:00:00.000Z");
+
+// One valid payload per event type. Keyed by EventType so the exhaustiveness
+// check below fails loudly if a new event type is added without a sample here.
+const samples: { [T in EventType]: EventPayload<T> } = {
+  user_message: { content: [{ type: "text", text: "hello" }] },
+  assistant_message: {
+    content: [{ type: "text", text: "on it" }],
+    tool_calls: [{ kind: "exec", cmd: "ls -la" }],
+    usage: { input_tokens: 12, output_tokens: 34 },
+  },
+  tool_result: { idem_key: idemKeyFor(base.sessionId, 2), output: "total 0", exit_code: 0, truncated: false },
+  turn_completed: {},
+  turn_failed: { error_class: "INTERNAL", message: "boom" },
+  session_provisioned: {},
+};
+
+describe("event model coverage", () => {
+  it("has a sample payload for every event type", () => {
+    expect(Object.keys(samples).sort()).toEqual(Object.keys(eventPayloadSchemas).sort());
+  });
+});
+
+describe("makeEvent → parseEvent round-trip", () => {
+  for (const type of Object.keys(samples) as EventType[]) {
+    it(`round-trips ${type}`, () => {
+      const made = makeEvent(base, type, samples[type]);
+      expect(made).toEqual({ ...base, type, payload: samples[type] });
+
+      // Simulate the DB row: envelope columns + jsonb payload + created_at.
+      const parsed = parseEvent({ ...made, createdAt, payload: made.payload });
+      expect(parsed.sessionId).toBe(base.sessionId);
+      expect(parsed.seq).toBe(base.seq);
+      expect(parsed.namespace).toBe(base.namespace);
+      expect(parsed.type).toBe(type);
+      expect(parsed.createdAt).toBe(createdAt);
+      expect(parsed.payload).toEqual(made.payload);
+    });
+  }
+
+  it("fills schema defaults on read (assistant_message.tool_calls, tool_result.truncated)", () => {
+    // A jsonb row that predates a field, or a producer that omits a defaulted one,
+    // must read back with the default applied — the defaults live on the parse path.
+    const asst = parseEvent({
+      ...base,
+      type: "assistant_message",
+      payload: { content: [{ type: "text", text: "hi" }] }, // no tool_calls
+      createdAt,
+    });
+    expect((asst.payload as EventPayload<"assistant_message">).tool_calls).toEqual([]); // .default([])
+
+    const res = parseEvent({
+      ...base,
+      type: "tool_result",
+      payload: { idem_key: "k", output: "o", exit_code: 0 }, // no truncated
+      createdAt,
+    });
+    expect((res.payload as EventPayload<"tool_result">).truncated).toBe(false); // .default(false)
+  });
+});
+
+describe("parseEvent guards", () => {
+  it("throws on an unknown event type", () => {
+    expect(() =>
+      parseEvent({ ...base, type: "not_a_real_type", payload: {}, createdAt }),
+    ).toThrow(/unknown event type in log: not_a_real_type/);
+  });
+
+  it("throws on a payload that violates its schema", () => {
+    // user_message requires content.min(1); an empty array must be rejected on read.
+    expect(() =>
+      parseEvent({ ...base, type: "user_message", payload: { content: [] }, createdAt }),
+    ).toThrow();
+  });
+});
+
+describe("tool_calls v1 cap", () => {
+  it("rejects an assistant_message with two tool_calls", () => {
+    expect(() =>
+      makeEvent(base, "assistant_message", {
+        content: [],
+        tool_calls: [
+          { kind: "exec", cmd: "ls" },
+          { kind: "exec", cmd: "pwd" },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it("accepts exactly one tool_call", () => {
+    const made = makeEvent(base, "assistant_message", {
+      content: [],
+      tool_calls: [{ kind: "exec", cmd: "ls" }],
+    });
+    expect(made.payload.tool_calls).toHaveLength(1);
+  });
+});
+
+describe("idemKeyFor", () => {
+  it("is deterministic and includes the trailing :index (default 0)", () => {
+    expect(idemKeyFor("sess", 7)).toBe("sess:7:0");
+    expect(idemKeyFor("sess", 7)).toBe(idemKeyFor("sess", 7));
+  });
+
+  it("carries a non-zero index in the suffix", () => {
+    expect(idemKeyFor("sess", 7, 2)).toBe("sess:7:2");
+  });
+});
+
+describe("textContent / plainText", () => {
+  it("wraps a string into a single text block", () => {
+    expect(textContent("hi")).toEqual([{ type: "text", text: "hi" }]);
+  });
+
+  it("round-trips through plainText", () => {
+    expect(plainText(textContent("hello world"))).toBe("hello world");
+  });
+
+  it("concatenates multiple text blocks in order", () => {
+    expect(plainText([
+      { type: "text", text: "a" },
+      { type: "text", text: "b" },
+    ])).toBe("ab");
+  });
+});

--- a/packages/sessions/src/events.ts
+++ b/packages/sessions/src/events.ts
@@ -1,0 +1,140 @@
+// packages/sessions/src/events.ts — Phase A: the event model.
+//
+// The DB stores {type: text, payload: jsonb} untyped; THIS file is the contract.
+// Every append goes through makeEvent(); every read through parseEvent().
+//
+// Two shapes are deliberately future-proofed (log format must never break):
+//  - message content is ContentBlock[] (multimodal becomes an additive block kind)
+//  - assistant tool calls are an ARRAY, runtime-capped at 1 for v1 (parallel tool
+//    use later = lift the cap, no migration)
+
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Content blocks — text today; image/document/... are additive variants.
+// ---------------------------------------------------------------------------
+export const contentBlockSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("text"),
+    text: z.string().max(100_000),
+  }),
+]);
+export type ContentBlock = z.infer<typeof contentBlockSchema>;
+
+/** Convenience: wrap a plain string as content blocks. */
+export function textContent(text: string): ContentBlock[] {
+  return [{ type: "text", text }];
+}
+
+/** Convenience: flatten blocks to plain text (for LLM context building, logs). */
+export function plainText(blocks: ContentBlock[]): string {
+  return blocks.map((b) => (b.type === "text" ? b.text : "")).join("");
+}
+
+// ---------------------------------------------------------------------------
+// Tool calls — v1 has exactly one tool: run a shell command in the sandbox.
+// A discriminated union from day one so file/browser/etc. tools are additive.
+// ---------------------------------------------------------------------------
+export const toolCallSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("exec"),
+    cmd: z.string().min(1),
+    timeout_ms: z.number().int().min(1).max(600_000).optional(),
+  }),
+]);
+export type ToolCall = z.infer<typeof toolCallSchema>;
+
+// ---------------------------------------------------------------------------
+// Payload schema per event type
+// ---------------------------------------------------------------------------
+export const eventPayloadSchemas = {
+  user_message: z.object({
+    content: z.array(contentBlockSchema).min(1).max(50),
+  }),
+
+  assistant_message: z.object({
+    content: z.array(contentBlockSchema).max(50), // may be [] when going straight to a tool
+    // v1 CAP: at most one call per message. The log format supports N — lifting the
+    // cap for parallel tool use is a runtime change, not a schema migration.
+    tool_calls: z.array(toolCallSchema).max(1).default([]),
+    usage: z
+      .object({ input_tokens: z.number().int(), output_tokens: z.number().int() })
+      .optional(),
+  }),
+
+  tool_result: z.object({
+    idem_key: z.string(), // pairs result → its call; see idemKeyFor()
+    output: z.string().max(200_000), // exec output is text; truncate in the executor
+    exit_code: z.number().int(),
+    truncated: z.boolean().default(false),
+  }),
+
+  turn_completed: z.object({}),
+
+  turn_failed: z.object({
+    error_class: z.enum([
+      "LLM_PERMANENT",
+      "SANDBOX_FATAL",
+      "BUDGET",
+      "INTERNAL",
+    ]), // transient classes never reach the log — they retry
+    message: z.string(),
+  }),
+
+  session_provisioned: z.object({}),
+} as const;
+
+export type EventType = keyof typeof eventPayloadSchemas;
+export type EventPayload<T extends EventType> = z.infer<(typeof eventPayloadSchemas)[T]>;
+
+// ---------------------------------------------------------------------------
+// The envelope — what the reducer and the SSE stream consume
+// ---------------------------------------------------------------------------
+export type SessionEvent<T extends EventType = EventType> = {
+  sessionId: string;
+  seq: number; // dense, from 1; SSE `id:` and cursor everywhere
+  namespace: string;
+  type: T;
+  payload: EventPayload<T>;
+  createdAt: Date;
+};
+
+/** Construct + validate before append. Throws ZodError on programmer error. */
+export function makeEvent<T extends EventType>(
+  base: { sessionId: string; namespace: string; seq: number },
+  type: T,
+  payload: EventPayload<T>,
+): Omit<SessionEvent<T>, "createdAt"> {
+  return { ...base, type, payload: eventPayloadSchemas[type].parse(payload) as EventPayload<T> };
+}
+
+/** Validate a DB row into a typed event. Parsing on read means a bad deploy can't
+ *  feed the reducer garbage silently. */
+export function parseEvent(row: {
+  sessionId: string;
+  seq: number;
+  namespace: string;
+  type: string;
+  payload: unknown;
+  createdAt: Date;
+}): SessionEvent {
+  const type = row.type as EventType;
+  const schema = eventPayloadSchemas[type];
+  if (!schema) throw new Error(`unknown event type in log: ${row.type} (seq ${row.seq})`);
+  return {
+    sessionId: row.sessionId,
+    seq: row.seq,
+    namespace: row.namespace,
+    type,
+    payload: schema.parse(row.payload),
+    createdAt: row.createdAt,
+  } as SessionEvent;
+}
+
+/** Idempotency key for a tool call, derived from LOG POSITION — a resumed worker
+ *  regenerates the identical key. Never replace with a random uuid.
+ *  `index` = position within the assistant_message's tool_calls (always 0 in v1;
+ *  present now so parallel tool use never changes the key format). */
+export function idemKeyFor(sessionId: string, assistantSeq: number, index = 0): string {
+  return `${sessionId}:${assistantSeq}:${index}`;
+}

--- a/packages/sessions/src/index.ts
+++ b/packages/sessions/src/index.ts
@@ -1,0 +1,2 @@
+// packages/sessions — public surface (grows in Phases C/D: queue, reducer, turn)
+export * from "./events";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,19 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0))
 
+  packages/sessions:
+    dependencies:
+      '@funky/db':
+        specifier: workspace:*
+        version: link:../db
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
+    devDependencies:
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0))
+
 packages:
 
   '@drizzle-team/brocli@0.11.0':


### PR DESCRIPTION
Phase A of the sessions iteration: three new tables, one new package, one migration. Adds `packages/db/schema/sessions.ts` with `sessions`, `session_events` (composite PK `(session_id, seq)` as the append-only conditional-append mechanism), and `turn_jobs` (queue state in columns plus two partial indexes), wired into the db barrel. Adds the `@funky/sessions` package with the typed event model — `ContentBlock[]` message content, a `tool_calls` array capped at 1, per-type payload schemas, and `makeEvent`/`parseEvent`/`idemKeyFor`. Includes the generated migration plus schema-shape regression tests and event-model unit tests. Verified end-to-end: `pnpm typecheck` clean, all suites green (db 32, sessions 17, configs 28, api 67), and the migration applied to Postgres with `\d` confirming the composite PK, both partial indexes, and all four foreign keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)