### PR TITLE
Phase B: @funky/sandbox port + subprocess driver + TCK

### DIFF
--- a/packages/ports/llm/package.json
+++ b/packages/ports/llm/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@funky/llm",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./port": "./src/port.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@ai-sdk/anthropic": "^4.0.0",
+    "@ai-sdk/openai": "^4.0.0",
+    "@funky/db": "workspace:*",
+    "@funky/sessions": "workspace:*",
+    "ai": "^7.0.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/ports/llm/src/ai-sdk.mock.test.ts
+++ b/packages/ports/llm/src/ai-sdk.mock.test.ts
@@ -1,0 +1,67 @@
+// Offline unit test for the v1 tool-call cap's second layer (defensive truncation). The
+// AI SDK's generateText is mocked, so no key / network is needed: we feed a provider
+// response carrying THREE tool calls and assert the driver surfaces exactly one and counts
+// the drops via llm_tool_calls_dropped_total.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ai")>();
+  return { ...actual, generateText: vi.fn() };
+});
+
+import { generateText } from "ai";
+import type { ModelConfig } from "@funky/db/schema";
+import { AiSdkLlm } from "./drivers/ai-sdk";
+import { getCounter, resetCounters } from "./metrics";
+import type { ChatMessage } from "./port";
+
+const MODEL: ModelConfig = { provider: "anthropic", model: "claude-sonnet-5" };
+const MSGS: ChatMessage[] = [{ role: "user", content: "do three things" }];
+
+function mockResult(toolCalls: Array<{ toolName: string; input: unknown }>) {
+  // Only the fields the driver reads; cast past the full GenerateTextResult shape.
+  vi.mocked(generateText).mockResolvedValue({
+    text: "",
+    toolCalls,
+    usage: { inputTokens: 10, outputTokens: 4 },
+  } as unknown as Awaited<ReturnType<typeof generateText>>);
+}
+
+describe("AiSdkLlm parallel-tool-call cap", () => {
+  beforeEach(() => {
+    resetCounters();
+    vi.mocked(generateText).mockReset();
+  });
+
+  it("returns exactly one tool call and counts the dropped ones", async () => {
+    mockResult([
+      { toolName: "exec", input: { cmd: "ls" } },
+      { toolName: "exec", input: { cmd: "pwd" } },
+      { toolName: "exec", input: { cmd: "whoami" } },
+    ]);
+
+    const r = await new AiSdkLlm().complete({ model: MODEL, messages: MSGS });
+
+    expect(r.toolCall).toEqual({ kind: "exec", cmd: "ls" });
+    expect(getCounter("llm_tool_calls_dropped_total")).toBe(2); // 3 returned − 1 kept
+  });
+
+  it("does not count drops when the provider returns a single call", async () => {
+    mockResult([{ toolName: "exec", input: { cmd: "ls" } }]);
+
+    const r = await new AiSdkLlm().complete({ model: MODEL, messages: MSGS });
+
+    expect(r.toolCall).toEqual({ kind: "exec", cmd: "ls" });
+    expect(getCounter("llm_tool_calls_dropped_total")).toBe(0);
+  });
+
+  it("requests provider-side disable of parallel tool use", async () => {
+    mockResult([]);
+
+    await new AiSdkLlm().complete({ model: MODEL, messages: MSGS });
+
+    const call = vi.mocked(generateText).mock.calls[0]![0];
+    expect(call.providerOptions).toEqual({ anthropic: { disableParallelToolUse: true } });
+  });
+});

--- a/packages/ports/llm/src/ai-sdk.test.ts
+++ b/packages/ports/llm/src/ai-sdk.test.ts
@@ -1,0 +1,33 @@
+// Gated real round-trip against Anthropic. Skipped in CI (no key); run locally with
+// ANTHROPIC_API_KEY set to confirm the exec tool round-trips into our ToolCall shape.
+
+import { describe, expect, it } from "vitest";
+import type { ModelConfig } from "@funky/db/schema";
+import { AiSdkLlm } from "./drivers/ai-sdk";
+import type { ChatMessage } from "./port";
+
+const hasKey = !!process.env.ANTHROPIC_API_KEY;
+
+describe.skipIf(!hasKey)("AiSdkLlm (real anthropic round-trip)", () => {
+  const model: ModelConfig = { provider: "anthropic", model: "claude-sonnet-5", maxTokens: 1024 };
+
+  it("returns an exec ToolCall when the prompt requires a shell command", async () => {
+    const llm = new AiSdkLlm();
+    const messages: ChatMessage[] = [
+      {
+        role: "system",
+        content:
+          "You control a Linux sandbox. To answer any question about the machine, you MUST call the exec tool. Never guess.",
+      },
+      { role: "user", content: "What is the current working directory? Use the exec tool." },
+    ];
+
+    const result = await llm.complete({ model, messages });
+
+    expect(result.usage.inputTokens).toBeGreaterThan(0);
+    expect(result.toolCall).toBeDefined();
+    expect(result.toolCall?.kind).toBe("exec");
+    expect(typeof result.toolCall?.cmd).toBe("string");
+    expect(result.toolCall?.cmd.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/ports/llm/src/drivers/ai-sdk.ts
+++ b/packages/ports/llm/src/drivers/ai-sdk.ts
@@ -1,0 +1,211 @@
+// packages/ports/llm/src/drivers/ai-sdk.ts — real providers via the Vercel AI SDK.
+//
+// Single tool (`exec`) exposed to the model; its tool call is translated back into our
+// ToolCall. Transient failures are retried 3× with exponential backoff INSIDE the driver
+// so the worker sees at most one LlmTransientError after the driver has exhausted its
+// retries; non-retryable failures surface immediately as LlmPermanentError.
+
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createOpenAI } from "@ai-sdk/openai";
+import {
+  APICallError,
+  type LanguageModel,
+  type ModelMessage,
+  type TextPart,
+  type ToolCallPart,
+  generateText,
+  tool,
+} from "ai";
+import { z } from "zod";
+import type { ModelConfig } from "@funky/db/schema";
+import type { ToolCall } from "@funky/sessions/events";
+import { incrCounter } from "../metrics";
+import {
+  type ChatMessage,
+  type LlmPort,
+  LlmPermanentError,
+  type LlmRequest,
+  type LlmResult,
+  LlmTransientError,
+} from "../port";
+
+const EXEC_TOOL = "exec";
+const MAX_ATTEMPTS = 3;
+
+// No `execute`: the model's exec call is returned and generation stops after one step
+// (generateText's default). The worker runs the command in the sandbox, not the SDK.
+const execTool = tool({
+  description:
+    "Run a shell command in the session's sandbox and return its combined stdout/stderr and exit code.",
+  inputSchema: z.object({
+    cmd: z.string().min(1).describe("The shell command to run."),
+    timeout_ms: z
+      .number()
+      .int()
+      .min(1)
+      .max(600_000)
+      .optional()
+      .describe("Optional wall-clock timeout in milliseconds."),
+  }),
+});
+
+export class AiSdkLlm implements LlmPort {
+  async complete(req: LlmRequest): Promise<LlmResult> {
+    const model = resolveModel(req.model);
+    const messages = toModelMessages(req.messages);
+    const providerOptions = parallelToolUseOff(req.model);
+
+    let lastTransient: LlmTransientError | undefined;
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      try {
+        const result = await generateText({
+          model,
+          messages,
+          tools: { [EXEC_TOOL]: execTool },
+          providerOptions, // disables parallel tool use so the model plans sequentially
+          maxOutputTokens: req.model.maxTokens,
+          temperature: req.model.temperature,
+          maxRetries: 0, // we own the retry loop below (with our error taxonomy)
+        });
+        return {
+          content: result.text,
+          toolCall: pickSingleToolCall(result.toolCalls),
+          usage: {
+            inputTokens: result.usage.inputTokens ?? 0,
+            outputTokens: result.usage.outputTokens ?? 0,
+          },
+        };
+      } catch (err) {
+        const classified = classify(err);
+        if (classified instanceof LlmPermanentError) throw classified;
+        lastTransient = classified;
+        if (attempt < MAX_ATTEMPTS - 1) await sleep(backoffMs(attempt));
+      }
+    }
+    // Retries exhausted: hand the worker one transient error to retry at its own layer.
+    throw lastTransient ?? new LlmTransientError("llm transient failure");
+  }
+}
+
+function resolveModel(cfg: ModelConfig): LanguageModel {
+  switch (cfg.provider) {
+    case "anthropic":
+      return createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })(cfg.model);
+    case "openai":
+      return createOpenAI({ apiKey: process.env.OPENAI_API_KEY })(cfg.model);
+    default:
+      // v1 ships anthropic + openai; the others are wired identically when needed.
+      throw new LlmPermanentError(`llm provider not supported in v1: ${cfg.provider}`);
+  }
+}
+
+// Layer 1 of the v1 tool-call cap: tell the provider to plan sequentially so it never
+// emits a batch in the first place — no intent is dropped. Anthropic and OpenAI spell it
+// differently; both go through the AI SDK's per-provider providerOptions.
+function parallelToolUseOff(cfg: ModelConfig): Record<string, Record<string, boolean>> | undefined {
+  switch (cfg.provider) {
+    case "anthropic":
+      return { anthropic: { disableParallelToolUse: true } };
+    case "openai":
+      return { openai: { parallelToolCalls: false } };
+    default:
+      return undefined;
+  }
+}
+
+// Layer 2 — defensive truncation: if a provider ignores the flag above and returns a
+// batch, keep calls[0] and drop the rest so we never exceed the log's tool_calls.max(1).
+// The drop counter is the signal that it's time to lift the cap. This is only safe because
+// buildContext (Phase D) rebuilds messages from OUR event log — which recorded one call —
+// never from provider-native response objects, so the next request stays internally
+// consistent (one tool_use answered by one tool_result).
+function pickSingleToolCall(
+  toolCalls: ReadonlyArray<{ toolName: string; input: unknown }>,
+): ToolCall | undefined {
+  if (toolCalls.length === 0) return undefined;
+  if (toolCalls.length > 1) {
+    incrCounter("llm_tool_calls_dropped_total", toolCalls.length - 1);
+  }
+  const first = toolCalls[0]!;
+  if (first.toolName !== EXEC_TOOL) return undefined;
+  const input = first.input as { cmd?: unknown; timeout_ms?: unknown };
+  if (typeof input?.cmd !== "string" || input.cmd.length === 0) return undefined;
+  return typeof input.timeout_ms === "number"
+    ? { kind: "exec", cmd: input.cmd, timeout_ms: input.timeout_ms }
+    : { kind: "exec", cmd: input.cmd };
+}
+
+// ChatMessage[] → the AI SDK's ModelMessage[]. An assistant tool call and its paired tool
+// result must share a toolCallId; we reuse the tool message's idemKey as that id (the log
+// already pairs result → call by idemKey), so the reconstruction round-trips cleanly.
+function toModelMessages(messages: ChatMessage[]): ModelMessage[] {
+  const out: ModelMessage[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const m = messages[i]!;
+    switch (m.role) {
+      case "system":
+        out.push({ role: "system", content: m.content });
+        break;
+      case "user":
+        out.push({ role: "user", content: m.content });
+        break;
+      case "assistant": {
+        if (m.toolCall) {
+          const next = messages[i + 1];
+          const id = next && next.role === "tool" ? next.idemKey : `call-${i}`;
+          const parts: Array<TextPart | ToolCallPart> = [];
+          if (m.content) parts.push({ type: "text", text: m.content });
+          parts.push({ type: "tool-call", toolCallId: id, toolName: EXEC_TOOL, input: execInput(m.toolCall) });
+          out.push({ role: "assistant", content: parts });
+        } else {
+          out.push({ role: "assistant", content: m.content });
+        }
+        break;
+      }
+      case "tool":
+        out.push({
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: m.idemKey,
+              toolName: EXEC_TOOL,
+              output: { type: "text", value: m.output },
+            },
+          ],
+        });
+        break;
+    }
+  }
+  return out;
+}
+
+function execInput(tc: ToolCall): { cmd: string; timeout_ms?: number } {
+  return tc.timeout_ms !== undefined ? { cmd: tc.cmd, timeout_ms: tc.timeout_ms } : { cmd: tc.cmd };
+}
+
+// Map SDK/provider failures onto the port's two-class taxonomy. 429 / 5xx / network /
+// timeout → transient (retry). Everything else (4xx, context-length, bad request) →
+// permanent (no retry; becomes turn_failed(LLM_PERMANENT)).
+function classify(err: unknown): LlmTransientError | LlmPermanentError {
+  if (APICallError.isInstance(err)) {
+    const status = err.statusCode;
+    if (err.isRetryable || status === 429 || (status !== undefined && status >= 500)) {
+      return new LlmTransientError(err.message);
+    }
+    return new LlmPermanentError(err.message);
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  if (/timeout|timed out|ETIMEDOUT|ECONNRESET|ECONNREFUSED|EAI_AGAIN|fetch failed|network/i.test(msg)) {
+    return new LlmTransientError(msg);
+  }
+  return new LlmPermanentError(msg);
+}
+
+function backoffMs(attempt: number): number {
+  return 2 ** attempt * 200; // 200ms, 400ms, ...
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/ports/llm/src/drivers/fake.ts
+++ b/packages/ports/llm/src/drivers/fake.ts
@@ -1,0 +1,54 @@
+// packages/ports/llm/src/drivers/fake.ts — deterministic scripted driver.
+//
+// The single most-used object in every later test: hand it a script per session and it
+// replays turns one per complete() call. No network, no keys, fully deterministic.
+
+import { type LlmPort, type LlmRequest, type LlmResult, LlmTransientError } from "../port";
+
+export type FakeTurn = { content: string; toolCall?: LlmResult["toolCall"] };
+
+export class FakeLlm implements LlmPort {
+  private readonly scripts: Record<string, FakeTurn[]>;
+  private readonly cursor: Record<string, number> = {};
+  private readonly failOnce: Set<number>;
+  private readonly fired = new Set<number>();
+  private callIndex = 0;
+
+  constructor(opts: {
+    scripts: Record<string, FakeTurn[]>; // sessionId → ordered turns
+    failOnce?: number[]; // global call-indices that throw LlmTransientError ONCE, then succeed
+  }) {
+    this.scripts = opts.scripts;
+    this.failOnce = new Set(opts.failOnce ?? []);
+  }
+
+  async complete(req: LlmRequest): Promise<LlmResult> {
+    const index = this.callIndex++;
+    // Transient failure fires BEFORE consuming a script turn: the worker's retry re-calls
+    // complete() and gets the same logical turn, just on a later global index.
+    if (this.failOnce.has(index) && !this.fired.has(index)) {
+      this.fired.add(index);
+      throw new LlmTransientError(`fake transient failure at call ${index}`);
+    }
+
+    const sessionId = req.trace?.sessionId;
+    if (!sessionId) {
+      throw new Error("FakeLlm requires req.trace.sessionId to select a script");
+    }
+    const script = this.scripts[sessionId] ?? [];
+    const at = this.cursor[sessionId] ?? 0;
+    const turn = script[at];
+
+    // Script exhausted → a terminal turn with no tool call (the turn ends).
+    if (!turn) {
+      return { content: "done", usage: usageFor(req, "done") };
+    }
+    this.cursor[sessionId] = at + 1;
+    return { content: turn.content, toolCall: turn.toolCall, usage: usageFor(req, turn.content) };
+  }
+}
+
+// Deterministic, cheap: enough to assert usage flows through, never a real token count.
+function usageFor(req: LlmRequest, content: string): LlmResult["usage"] {
+  return { inputTokens: req.messages.length, outputTokens: content.length };
+}

--- a/packages/ports/llm/src/fake.test.ts
+++ b/packages/ports/llm/src/fake.test.ts
@@ -1,0 +1,73 @@
+// Unit tests for the FakeLlm — the deterministic scripted driver every later phase leans
+// on. Two guarantees: a per-session script replays one turn per complete() call, and
+// failOnce throws a transient error exactly once at a given global call index.
+
+import { describe, expect, it } from "vitest";
+import type { ModelConfig } from "@funky/db/schema";
+import { FakeLlm } from "./drivers/fake";
+import { LlmTransientError } from "./port";
+import type { ChatMessage } from "./port";
+
+const MODEL: ModelConfig = { provider: "anthropic", model: "claude-sonnet-5" };
+const MSGS: ChatMessage[] = [{ role: "user", content: "hi" }];
+
+function req(sessionId: string) {
+  return { model: MODEL, messages: MSGS, trace: { sessionId } };
+}
+
+describe("FakeLlm", () => {
+  it("replays a 3-turn script for one session, then goes terminal", async () => {
+    const llm = new FakeLlm({
+      scripts: {
+        s1: [
+          { content: "step 1", toolCall: { kind: "exec", cmd: "ls" } },
+          { content: "step 2", toolCall: { kind: "exec", cmd: "cat file" } },
+          { content: "step 3" },
+        ],
+      },
+    });
+
+    const r1 = await llm.complete(req("s1"));
+    expect(r1.content).toBe("step 1");
+    expect(r1.toolCall).toEqual({ kind: "exec", cmd: "ls" });
+
+    const r2 = await llm.complete(req("s1"));
+    expect(r2.content).toBe("step 2");
+    expect(r2.toolCall).toEqual({ kind: "exec", cmd: "cat file" });
+
+    const r3 = await llm.complete(req("s1"));
+    expect(r3.content).toBe("step 3");
+    expect(r3.toolCall).toBeUndefined();
+
+    // Script exhausted → terminal turn with no tool call, forever.
+    const r4 = await llm.complete(req("s1"));
+    expect(r4.content).toBe("done");
+    expect(r4.toolCall).toBeUndefined();
+
+    expect(r1.usage).toEqual({ inputTokens: 1, outputTokens: "step 1".length });
+  });
+
+  it("keeps a separate cursor per session", async () => {
+    const llm = new FakeLlm({
+      scripts: { a: [{ content: "a1" }, { content: "a2" }], b: [{ content: "b1" }] },
+    });
+    expect((await llm.complete(req("a"))).content).toBe("a1");
+    expect((await llm.complete(req("b"))).content).toBe("b1");
+    expect((await llm.complete(req("a"))).content).toBe("a2");
+  });
+
+  it("failOnce throws a transient error exactly once, then succeeds", async () => {
+    const llm = new FakeLlm({ scripts: { s1: [{ content: "ok" }] }, failOnce: [0] });
+
+    await expect(llm.complete(req("s1"))).rejects.toBeInstanceOf(LlmTransientError);
+
+    // The retry (call index 1) is no longer failed and delivers the first script turn.
+    const r = await llm.complete(req("s1"));
+    expect(r.content).toBe("ok");
+  });
+
+  it("requires trace.sessionId to pick a script", async () => {
+    const llm = new FakeLlm({ scripts: { s1: [{ content: "ok" }] } });
+    await expect(llm.complete({ model: MODEL, messages: MSGS })).rejects.toThrow(/sessionId/);
+  });
+});

--- a/packages/ports/llm/src/index.ts
+++ b/packages/ports/llm/src/index.ts
@@ -1,0 +1,29 @@
+// packages/ports/llm — public surface.
+// The worker (Phase E) imports the port; the entrypoint selects a driver by config.
+
+export * from "./port";
+export { FakeLlm, type FakeTurn } from "./drivers/fake";
+export { AiSdkLlm } from "./drivers/ai-sdk";
+export { getCounter, incrCounter, resetCounters } from "./metrics";
+
+import type { LlmPort } from "./port";
+import { AiSdkLlm } from "./drivers/ai-sdk";
+import type { FakeLlm } from "./drivers/fake";
+
+// Fake construction args come from test setup, not env — so the factory takes the
+// already-built driver in tests. The worker entrypoint reads FUNKY_LLM and builds the
+// ai-sdk driver from env.
+export type LlmConfig = { driver: "fake"; instance: FakeLlm } | { driver: "ai-sdk" };
+
+export function makeLlm(cfg: LlmConfig): LlmPort {
+  switch (cfg.driver) {
+    case "fake":
+      return cfg.instance;
+    case "ai-sdk":
+      return new AiSdkLlm();
+    default: {
+      const never: never = cfg;
+      throw new Error(`unknown llm driver: ${JSON.stringify(never)}`);
+    }
+  }
+}

--- a/packages/ports/llm/src/metrics.ts
+++ b/packages/ports/llm/src/metrics.ts
@@ -1,0 +1,20 @@
+// packages/ports/llm/src/metrics.ts — minimal in-process counters.
+//
+// Phase B has no metrics client yet (that arrives with the worker in Phase E). These are
+// plain process-global counters whose NAMES match what the worker will emit, so the
+// signal is captured now and re-homed later without renaming. Tests read them directly.
+
+const counters: Record<string, number> = Object.create(null);
+
+export function incrCounter(name: string, by = 1): void {
+  counters[name] = (counters[name] ?? 0) + by;
+}
+
+export function getCounter(name: string): number {
+  return counters[name] ?? 0;
+}
+
+/** Test helper: zero everything (counters are process-global). */
+export function resetCounters(): void {
+  for (const k of Object.keys(counters)) delete counters[k];
+}

--- a/packages/ports/llm/src/port.ts
+++ b/packages/ports/llm/src/port.ts
@@ -1,0 +1,43 @@
+// packages/ports/llm/src/port.ts — the LLM port (Phase B).
+//
+// A plain TypeScript interface, NOT proto/codegen: a same-process contract the worker
+// (Phase E) imports directly. Drivers are selected by config at the entrypoint; the
+// worker never imports a driver.
+
+import type { ModelConfig } from "@funky/db/schema";
+import type { ToolCall } from "@funky/sessions/events";
+
+/** Provider-neutral chat message. content is already flattened to a string here —
+ *  the LLM port does not deal in ContentBlocks (that's a log concern). */
+export type ChatMessage =
+  | { role: "system"; content: string }
+  | { role: "user"; content: string }
+  | { role: "assistant"; content: string; toolCall?: ToolCall }
+  | { role: "tool"; idemKey: string; output: string; exitCode: number };
+
+export type LlmResult = {
+  content: string;
+  toolCall?: ToolCall; // v1 cap: at most ONE (matches the log's tool_calls.max(1))
+  usage: { inputTokens: number; outputTokens: number };
+};
+
+export type LlmRequest = {
+  model: ModelConfig;
+  messages: ChatMessage[];
+  /** Opaque driver bookkeeping; providers ignore it. The fake reads `sessionId` to pick
+   *  its script — identity is NEVER inferred by parsing message content. */
+  trace?: { sessionId: string };
+};
+
+export interface LlmPort {
+  complete(req: LlmRequest): Promise<LlmResult>;
+}
+
+/** 429 / 5xx / timeout — worker retries (driver already retried 3× w/ backoff). */
+export class LlmTransientError extends Error {
+  readonly kind = "llm_transient" as const;
+}
+/** 4xx / context-length / bad request — no retry; becomes turn_failed(LLM_PERMANENT). */
+export class LlmPermanentError extends Error {
+  readonly kind = "llm_permanent" as const;
+}

--- a/packages/ports/sandbox/package.json
+++ b/packages/ports/sandbox/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@funky/sandbox",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./port": "./src/port.ts",
+    "./tck": "./src/tck.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@funky/db": "workspace:*",
+    "@funky/sessions": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/ports/sandbox/src/drivers/subprocess.ts
+++ b/packages/ports/sandbox/src/drivers/subprocess.ts
@@ -1,0 +1,236 @@
+// packages/ports/sandbox/src/drivers/subprocess.ts — spawn-on-host dev driver.
+//
+// The idemKey shell protocol, implemented EXACTLY as the port contract requires so it
+// matches every future driver: the filesystem IS the shared state. exec and attach both
+// tail the same `out`/`exit` files, so two concurrent readers of one running command
+// converge naturally — there is no subscriber registry, no in-memory coordination. Let
+// the filesystem be the bus.
+//
+// v1 simplifications (intentional, not gaps — see the handoff's non-goals): reboot is a
+// no-op (the FS is just a directory), and stderr is folded into stdout via `2>&1` (the
+// `stderr` ExecEvent variant exists for future drivers; subprocess emits stdout + exit).
+
+import { spawn } from "node:child_process";
+import { type FileHandle, open } from "node:fs/promises";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { ResolvedEnv } from "@funky/db/schema";
+import { type ExecEvent, type Executor, type SandboxDriver, type SandboxHandle, SandboxUnavailableError } from "../port";
+
+const ROOT = "/tmp/funky";
+const MAX_OUTPUT_BYTES = 200_000;
+const POLL_MS = 100;
+
+export class SubprocessDriver implements SandboxDriver {
+  async provision(_spec: ResolvedEnv, sessionId: string): Promise<SandboxHandle> {
+    const workdir = path.join(ROOT, sessionId);
+    await fs.mkdir(workdir, { recursive: true });
+    return { driver: "subprocess", workdir };
+  }
+
+  // Reboot is a no-op: the persistent FS is just `workdir`, so it survives trivially.
+  async reboot(handle: SandboxHandle): Promise<SandboxHandle> {
+    return handle;
+  }
+
+  // rm -rf, force ignores ENOENT → calling teardown twice never throws.
+  async teardown(handle: SandboxHandle): Promise<void> {
+    await fs.rm(workdirOf(handle), { recursive: true, force: true });
+  }
+
+  connect(handle: SandboxHandle): Executor {
+    return new SubprocessExecutor(workdirOf(handle));
+  }
+}
+
+class SubprocessExecutor implements Executor {
+  constructor(private readonly workdir: string) {}
+
+  exec(req: { cmd: string; idemKey: string; timeoutMs?: number }): AsyncIterable<ExecEvent> {
+    const { workdir } = this;
+    return (async function* () {
+      // No workdir → torn down / unreachable: we can't observe a result, so this is an
+      // infrastructure error (throw), never a synthesized exit code.
+      if (!(await exists(workdir))) throw new SandboxUnavailableError("sandbox is not provisioned");
+      const funkyRoot = path.join(workdir, ".funky");
+      await fs.mkdir(funkyRoot, { recursive: true });
+      const dir = path.join(funkyRoot, req.idemKey);
+
+      // Atomic first-run detection: mkdir(dir) is the lock. Success → we own this run and
+      // spawn. EEXIST → someone already started this idemKey; fall through to attach
+      // semantics (tail the shared files). Either way exactly one process is spawned.
+      let firstRun = false;
+      try {
+        await fs.mkdir(dir);
+        firstRun = true;
+      } catch (err) {
+        if (errno(err) !== "EEXIST") throw err;
+      }
+      if (firstRun) spawnCommand(workdir, dir, req.cmd, req.timeoutMs);
+      yield* tail(dir);
+    })();
+  }
+
+  attach(idemKey: string): AsyncIterable<ExecEvent> {
+    const dir = path.join(this.workdir, ".funky", idemKey);
+    return (async function* () {
+      // Nothing recorded under this idemKey → no result to observe: infrastructure error.
+      if (!(await exists(dir))) throw new SandboxUnavailableError(`no running command for idemKey: ${idemKey}`);
+      yield* tail(dir);
+    })();
+  }
+
+  async readFile(p: string): Promise<Uint8Array> {
+    return await fs.readFile(this.resolveInside(p));
+  }
+
+  async writeFile(p: string, data: Uint8Array): Promise<void> {
+    const abs = this.resolveInside(p);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, data);
+  }
+
+  // Reject paths escaping the workdir (absolute paths, `..` traversal, the workdir itself).
+  private resolveInside(p: string): string {
+    const abs = path.resolve(this.workdir, p);
+    const rel = path.relative(this.workdir, abs);
+    if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) {
+      throw new Error(`path escapes the sandbox: ${p}`);
+    }
+    return abs;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The spawn: `sh -c '(<cmd>) > out 2>&1; echo $? > exit'`. The `exit` file is the
+// completion marker; readers tail `out` until it appears. detached + process-group kill
+// on timeout so orphaned `sleep`s can't survive teardown.
+// ---------------------------------------------------------------------------
+function spawnCommand(workdir: string, dir: string, cmd: string, timeoutMs?: number): void {
+  const outPath = path.join(dir, "out");
+  const exitPath = path.join(dir, "exit");
+  const script = `(${cmd}) > ${shq(outPath)} 2>&1; echo $? > ${shq(exitPath)}`;
+  const child = spawn("sh", ["-c", script], {
+    cwd: workdir, // commands run inside the sandbox, not the host's cwd
+    detached: true, // own process group so we can kill the whole tree on timeout
+    stdio: "ignore",
+  });
+  child.unref();
+
+  if (timeoutMs && timeoutMs > 0) {
+    const timer = setTimeout(() => {
+      try {
+        if (child.pid) process.kill(-child.pid, "SIGKILL");
+      } catch {
+        // group already gone
+      }
+      // Only stamp 124 if the command didn't finish first (bash timeout convention).
+      exists(exitPath).then((done) => {
+        if (!done) void fs.writeFile(exitPath, "124\n").catch(() => {});
+      });
+    }, timeoutMs);
+    child.on("exit", () => clearTimeout(timer));
+  }
+}
+
+// tail streams `out` from byte 0, polling until `exit` appears with a parseable code.
+// A fresh tail (exec first-run OR a later attach) re-reads from the start, so every
+// reader sees the full output — the files are the single source of truth.
+async function* tail(dir: string): AsyncGenerator<ExecEvent> {
+  const outPath = path.join(dir, "out");
+  const exitPath = path.join(dir, "exit");
+  let offset = 0;
+  let total = 0;
+  let truncated = false;
+
+  // Emit any bytes appended since `offset`, clipping the total stream at MAX_OUTPUT_BYTES.
+  async function* drain(): AsyncGenerator<ExecEvent> {
+    const { data, size } = await readSlice(outPath, offset);
+    if (size <= offset) return;
+    offset = size;
+    if (truncated) return; // still advance offset, but stop yielding once clipped
+    let buf = data;
+    if (total + buf.length > MAX_OUTPUT_BYTES) {
+      buf = buf.subarray(0, MAX_OUTPUT_BYTES - total);
+      truncated = true;
+    }
+    if (buf.length > 0) {
+      total += buf.length;
+      yield { kind: "stdout", data: buf.toString("utf8") };
+    }
+  }
+
+  for (;;) {
+    yield* drain();
+    if (await exists(exitPath)) {
+      const code = await readExitCode(exitPath);
+      if (code !== null) {
+        yield* drain(); // final flush: bytes written between the last read and `exit`
+        yield { kind: "exit", code, truncated };
+        return;
+      }
+      // `exit` file created but not yet written — keep polling.
+    }
+    await sleep(POLL_MS);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Small fs helpers. None of these leak the workdir path upward — errors surfaced from
+// exec/attach never mention it (it's a driver-internal detail, like the opaque handle).
+// ---------------------------------------------------------------------------
+async function readSlice(p: string, offset: number): Promise<{ data: Buffer; size: number }> {
+  let fh: FileHandle | undefined;
+  try {
+    fh = await open(p, "r");
+    const { size } = await fh.stat();
+    if (size <= offset) return { data: Buffer.alloc(0), size };
+    const data = Buffer.alloc(size - offset);
+    await fh.read(data, 0, data.length, offset);
+    return { data, size };
+  } catch (err) {
+    if (errno(err) === "ENOENT") return { data: Buffer.alloc(0), size: offset }; // not created yet
+    throw err;
+  } finally {
+    await fh?.close();
+  }
+}
+
+async function readExitCode(p: string): Promise<number | null> {
+  try {
+    const raw = (await fs.readFile(p, "utf8")).trim();
+    if (raw === "") return null;
+    const n = Number.parseInt(raw, 10);
+    return Number.isNaN(n) ? null : n;
+  } catch {
+    return null;
+  }
+}
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function workdirOf(handle: SandboxHandle): string {
+  const w = (handle as { workdir?: unknown }).workdir;
+  if (typeof w !== "string") throw new Error("not a subprocess sandbox handle");
+  return w;
+}
+
+function errno(err: unknown): string | undefined {
+  return (err as NodeJS.ErrnoException | undefined)?.code;
+}
+
+// Single-quote a path for `sh -c`, escaping embedded single quotes.
+function shq(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/ports/sandbox/src/index.ts
+++ b/packages/ports/sandbox/src/index.ts
@@ -1,0 +1,25 @@
+// packages/ports/sandbox — public surface.
+// The worker (Phase E) imports the port; the entrypoint selects a driver by config.
+
+export type { ExecEvent, Executor, SandboxDriver, SandboxHandle } from "./port";
+export { SandboxUnavailableError } from "./port";
+export { SubprocessDriver } from "./drivers/subprocess";
+export { runSandboxTck } from "./tck";
+
+import type { SandboxDriver } from "./port";
+import { SubprocessDriver } from "./drivers/subprocess";
+
+export type SandboxConfig = { driver: "subprocess" };
+
+/** Build a driver from config. Only `subprocess` exists in v1; container / computesdk
+ *  drivers slot in here later without touching callers. */
+export function makeSandbox(cfg: SandboxConfig): SandboxDriver {
+  switch (cfg.driver) {
+    case "subprocess":
+      return new SubprocessDriver();
+    default: {
+      const never: never = cfg.driver;
+      throw new Error(`unknown sandbox driver: ${never}`);
+    }
+  }
+}

--- a/packages/ports/sandbox/src/port.ts
+++ b/packages/ports/sandbox/src/port.ts
@@ -1,0 +1,48 @@
+// packages/ports/sandbox/src/port.ts — the sandbox port (Phase B).
+//
+// Plain TypeScript interfaces, NOT proto/codegen: same-process contracts the worker
+// (Phase E) imports directly. Drivers are selected by config at the entrypoint; the
+// worker never imports a driver. The binding contract for every driver — including
+// future container / computesdk drivers — is the idemKey exec protocol: calling exec
+// (or attach) with an idemKey that is already running/finished MUST replay the existing
+// output, never run the command twice. See src/tck.ts for the conformance suite.
+
+import type { ResolvedEnv } from "@funky/db/schema";
+
+/** Opaque outside its own driver: only the driver that produced a handle may read its
+ *  fields. Persisted as jsonb on the session row; `driver` selects who can interpret it. */
+export type SandboxHandle = { driver: string } & Record<string, unknown>;
+
+export type ExecEvent =
+  | { kind: "stdout"; data: string }
+  | { kind: "stderr"; data: string }
+  | { kind: "exit"; code: number; truncated: boolean };
+
+export interface Executor {
+  // exec runs cmd under idemKey. Calling exec OR attach with an idemKey that is already
+  // running/finished MUST NOT run the command again — it streams the existing output.
+  exec(req: { cmd: string; idemKey: string; timeoutMs?: number }): AsyncIterable<ExecEvent>;
+  attach(idemKey: string): AsyncIterable<ExecEvent>;
+  readFile(path: string): Promise<Uint8Array>;
+  writeFile(path: string, data: Uint8Array): Promise<void>;
+}
+
+export interface SandboxDriver {
+  provision(spec: ResolvedEnv, sessionId: string): Promise<SandboxHandle>;
+  reboot(handle: SandboxHandle): Promise<SandboxHandle>; // persistent FS survives
+  teardown(handle: SandboxHandle): Promise<void>; //         idempotent
+  connect(handle: SandboxHandle): Executor; //               sync; cheap; any worker from the handle
+}
+
+/** Thrown when the Executor cannot OBSERVE a command's result — sandbox unreachable,
+ *  connection dropped, executord dead. This is NOT how a command that RAN and failed is
+ *  reported: a non-zero exit, a timeout (exit 124), or an OOM (137) all still HAVE an exit
+ *  code, so they are yielded as `{kind:"exit", code}` events for the model to react to.
+ *
+ *  The rule is mechanical: exit code exists ⇒ yield it; no exit code ⇒ throw this. Never
+ *  synthesize a fake exit code for an infrastructure failure — that lies to the model,
+ *  telling it a command failed when it may have succeeded. Phase D handles this throw by
+ *  retrying the exec by idemKey (→ attach) and rebooting if the sandbox is fatally gone. */
+export class SandboxUnavailableError extends Error {
+  readonly kind = "sandbox_unavailable" as const;
+}

--- a/packages/ports/sandbox/src/subprocess.test.ts
+++ b/packages/ports/sandbox/src/subprocess.test.ts
@@ -1,0 +1,6 @@
+// Runs the sandbox TCK against the subprocess driver. computesdk / container drivers
+// add their own <driver>.test.ts calling the same runSandboxTck().
+import { SubprocessDriver } from "./drivers/subprocess";
+import { runSandboxTck } from "./tck";
+
+runSandboxTck("subprocess", () => new SubprocessDriver());

--- a/packages/ports/sandbox/src/tck.ts
+++ b/packages/ports/sandbox/src/tck.ts
@@ -1,0 +1,156 @@
+// packages/ports/sandbox/src/tck.ts — the sandbox conformance suite.
+//
+// Exported so any driver runs the identical suite: subprocess in CI today, computesdk
+// (or a container driver) later. A driver that passes all 8 cases honours the idemKey
+// exec protocol — that's the contract the worker depends on. Invoke from a *.test.ts:
+//
+//   import { runSandboxTck } from "./tck";
+//   runSandboxTck("subprocess", () => new SubprocessDriver());
+
+import { randomUUID } from "node:crypto";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { type ExecEvent, type Executor, type SandboxDriver, SandboxUnavailableError } from "./port";
+import type { ResolvedEnv } from "@funky/db/schema";
+
+const SPEC: ResolvedEnv = {
+  base_image: "funky/tck",
+  persistent_fs: { size_gb: 1 },
+  egress: { allow: [] },
+};
+
+type Collected = { stdout: string; stderr: string; exit: { code: number; truncated: boolean } };
+
+async function collect(it: AsyncIterable<ExecEvent>): Promise<Collected> {
+  let stdout = "";
+  let stderr = "";
+  let exit = { code: -1, truncated: false };
+  for await (const ev of it) {
+    if (ev.kind === "stdout") stdout += ev.data;
+    else if (ev.kind === "stderr") stderr += ev.data;
+    else exit = { code: ev.code, truncated: ev.truncated };
+  }
+  return { stdout, stderr, exit };
+}
+
+export function runSandboxTck(name: string, makeDriver: () => SandboxDriver): void {
+  describe(`sandbox TCK: ${name}`, () => {
+    // Every case provisions its own sandbox (unique sessionId) and registers teardown.
+    const cleanups: Array<() => Promise<void>> = [];
+    afterEach(async () => {
+      for (const c of cleanups.splice(0)) await c().catch(() => {});
+    });
+
+    async function sandbox(): Promise<{ driver: SandboxDriver; handle: Awaited<ReturnType<SandboxDriver["provision"]>>; exec: Executor }> {
+      const driver = makeDriver();
+      const handle = await driver.provision(SPEC, randomUUID());
+      cleanups.push(() => driver.teardown(handle));
+      return { driver, handle, exec: driver.connect(handle) };
+    }
+
+    it("1. exec streams stdout and exits 0", async () => {
+      const { exec } = await sandbox();
+      const r = await collect(exec.exec({ cmd: "echo hello", idemKey: "k1" }));
+      expect(r.stdout).toContain("hello");
+      expect(r.exit.code).toBe(0);
+      expect(r.exit.truncated).toBe(false);
+    });
+
+    it("2. exit codes propagate", async () => {
+      const { exec } = await sandbox();
+      const r = await collect(exec.exec({ cmd: "exit 3", idemKey: "k2" }));
+      expect(r.exit.code).toBe(3);
+    });
+
+    it("3. dedupe: two concurrent execs of one idemKey run the command once", async () => {
+      const { exec } = await sandbox();
+      const dir = await mkdtemp(join(tmpdir(), "funky-tck-"));
+      const marker = join(dir, "marker");
+      cleanups.push(() => rm(dir, { recursive: true, force: true }));
+
+      const cmd = `echo shared; echo $$ >> ${quote(marker)}; sleep 0.3`;
+      // Both start ~together; whichever wins the mkdir spawns, the other attaches. The
+      // filesystem is the bus, so both iterables observe the same output either way.
+      const [a, b] = await Promise.all([
+        collect(exec.exec({ cmd, idemKey: "k3" })),
+        collect(exec.exec({ cmd, idemKey: "k3" })),
+      ]);
+
+      expect(a.stdout).toContain("shared");
+      expect(b.stdout).toEqual(a.stdout);
+      expect(a.exit.code).toBe(0);
+      expect(b.exit.code).toBe(0);
+
+      const lines = (await readFile(marker, "utf8")).trim().split("\n").filter(Boolean);
+      expect(lines).toHaveLength(1); // command body executed exactly once
+    });
+
+    it("4. attach after the exec iterator is dropped sees full output + exit", async () => {
+      const { exec } = await sandbox();
+      // Kick exec until the command has surely spawned (first stdout), then abandon it.
+      // The detached process keeps running; attach re-reads the shared files from byte 0.
+      const it = exec.exec({ cmd: "echo start; sleep 0.3; echo done", idemKey: "k4" });
+      for await (const ev of it) {
+        if (ev.kind === "stdout") break;
+      }
+      const r = await collect(exec.attach("k4"));
+      expect(r.stdout).toContain("start");
+      expect(r.stdout).toContain("done");
+      expect(r.exit.code).toBe(0);
+    });
+
+    it("5. attach to an unknown idemKey throws SandboxUnavailableError", async () => {
+      const { exec } = await sandbox();
+      // No result to observe → infrastructure error, never a synthesized exit code.
+      await expect(collect(exec.attach("never-ran"))).rejects.toBeInstanceOf(SandboxUnavailableError);
+    });
+
+    it("6. output over 200KB is truncated", async () => {
+      const { exec } = await sandbox();
+      const r = await collect(exec.exec({ cmd: `head -c 300000 /dev/zero | tr '\\0' 'x'`, idemKey: "k6" }));
+      expect(r.exit.truncated).toBe(true);
+      expect(r.stdout.length).toBe(200_000);
+    });
+
+    it("7. teardown is idempotent; exec after teardown throws SandboxUnavailableError", async () => {
+      const { driver, handle, exec } = await sandbox();
+      await driver.teardown(handle);
+      await driver.teardown(handle); // twice → no throw
+      await expect(collect(exec.exec({ cmd: "echo hi", idemKey: "k7" }))).rejects.toBeInstanceOf(
+        SandboxUnavailableError,
+      );
+    });
+
+    it("8. reboot preserves the filesystem", async () => {
+      const { driver, handle } = await sandbox();
+      const bytes = new TextEncoder().encode("persist me");
+      await driver.connect(handle).writeFile("state.txt", bytes);
+
+      const rebooted = await driver.reboot(handle);
+      const read = await driver.connect(rebooted).readFile("state.txt");
+      expect(new TextDecoder().decode(read)).toBe("persist me");
+    });
+
+    it("9. a command that ran and failed is a result, not an error", async () => {
+      const { exec } = await sandbox();
+      // Non-zero exit + stderr: the command RAN, so this yields an exit event (the model's
+      // problem to react to) — it does NOT throw.
+      const r = await collect(exec.exec({ cmd: "echo boom >&2; exit 7", idemKey: "k9" }));
+      expect(r.exit.code).toBe(7);
+      expect(r.stdout).toContain("boom"); // stderr folded into stdout via 2>&1 for v1
+    });
+
+    it("10. a timeout yields exit 124, it does not throw", async () => {
+      const { exec } = await sandbox();
+      const r = await collect(exec.exec({ cmd: "sleep 5", idemKey: "k10", timeoutMs: 200 }));
+      expect(r.exit.code).toBe(124); // bash timeout convention — still a result, not an error
+    });
+  });
+}
+
+// Single-quote for the shell (the marker path we hand into the test command).
+function quote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,19 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0))
 
+  packages/ports/sandbox:
+    dependencies:
+      '@funky/db':
+        specifier: workspace:*
+        version: link:../../db
+      '@funky/sessions':
+        specifier: workspace:*
+        version: link:../../sessions
+    devDependencies:
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0))
+
   packages/sessions:
     dependencies:
       '@funky/db':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,31 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0))
 
+  packages/ports/llm:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^4.0.0
+        version: 4.0.12(zod@4.4.3)
+      '@ai-sdk/openai':
+        specifier: ^4.0.0
+        version: 4.0.11(zod@4.4.3)
+      '@funky/db':
+        specifier: workspace:*
+        version: link:../../db
+      '@funky/sessions':
+        specifier: workspace:*
+        version: link:../../sessions
+      ai:
+        specifier: ^7.0.0
+        version: 7.0.22(zod@4.4.3)
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
+    devDependencies:
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0))
+
   packages/ports/sandbox:
     dependencies:
       '@funky/db':
@@ -132,6 +157,34 @@ importers:
         version: 4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0))
 
 packages:
+
+  '@ai-sdk/anthropic@4.0.12':
+    resolution: {integrity: sha512-IquWNkGRSF2ulYJ6YIIUqMsNAIDeZFB3/4W92aSOtCxH1TfuVoq3qw4M4TxTxIw4As9cnkeRLe7b9LDMzPDsnA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@4.0.16':
+    resolution: {integrity: sha512-9iYxdOLquoOFk5e+02P9qfBIA+EJU0FNJvyjGxi4iXJabt2+GlbaCg7TX0sTtxOsBVkdabkatqWM6+kvp53tBg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@4.0.11':
+    resolution: {integrity: sha512-2PLnVPBsdJusgquPVYgPWd3ox4lbUFkp7DVUSmM0lQ4VISQoNxdgo6TvFAHgwQn9wJ/ckVYVRLU7+BvHc7T8ww==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.7':
+    resolution: {integrity: sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.3':
+    resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
+    engines: {node: '>=22'}
 
   '@drizzle-team/brocli@0.11.0':
     resolution: {integrity: sha512-hD3pekGiPg0WPCCGAZmusBBJsDqGUR66Y452YgQsZOnkdQ7ViEPKuyP4huUGEZQefp8g34RRodXYmJ2TbCH+tg==}
@@ -601,6 +654,10 @@ packages:
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
@@ -629,6 +686,15 @@ packages:
 
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
+  ai@7.0.22:
+    resolution: {integrity: sha512-iAXYwQtR18qN7GXwNmGVAQM4uSJOh2+nZ5RP9NtDXfH5d4tlYyYzAM133O3U+eVcyWrvNRzecN9yW58xpCdfMg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -785,6 +851,10 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
@@ -816,6 +886,9 @@ packages:
 
   jsbi@4.3.2:
     resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1121,6 +1194,37 @@ packages:
 
 snapshots:
 
+  '@ai-sdk/anthropic@4.0.12(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/gateway@4.0.16(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/openai@4.0.11(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.7(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider@4.0.3':
+    dependencies:
+      json-schema: 0.4.0
+
   '@drizzle-team/brocli@0.11.0': {}
 
   '@electric-sql/pglite@0.5.4': {}
@@ -1398,6 +1502,8 @@ snapshots:
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -1438,6 +1544,15 @@ snapshots:
       '@vitest/pretty-format': 4.1.10
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+
+  '@workflow/serde@4.1.0': {}
+
+  ai@7.0.22(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.16(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
+      zod: 4.4.3
 
   assertion-error@2.0.1: {}
 
@@ -1528,6 +1643,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
+  eventsource-parser@3.1.0: {}
+
   expect-type@1.4.0: {}
 
   fdir@6.5.0(picomatch@4.0.5):
@@ -1546,6 +1663,8 @@ snapshots:
   jiti@2.7.0: {}
 
   jsbi@4.3.2: {}
+
+  json-schema@0.4.0: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - "apps/*"
   - "packages/*"
+  - "packages/ports/*"
 
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
Part 1 of 2 for Phase B (ports). Adds the **sandbox** port and its offline `subprocess` dev driver. No worker/queue/API changes — this is a library later phases consume.

**PR 2 (`@funky/llm`) is stacked on this branch** — review/merge this first.

## What's here
- **`port.ts`** — `SandboxDriver`, `Executor`, `SandboxHandle`, `ExecEvent`, and `SandboxUnavailableError`. The load-bearing failure rule: *exit code exists ⇒ yield `{kind:"exit"}`; can't observe a result ⇒ throw*. Command failures are the model's problem; infrastructure failures are the system's.
- **`drivers/subprocess.ts`** — the idemKey shell protocol. `mkdir(dir)` is the atomic first-run lock; `exec` and `attach` both tail the same `out`/`exit` files, so two concurrent readers of one running command converge with no in-memory coordination (the filesystem is the bus). Detached spawn + process-group kill on timeout; 200KB truncation; workdir-escape rejection; idempotent teardown.
- **`tck.ts`** — exported conformance suite (**10 cases**) any driver can run; `subprocess.test.ts` runs it in CI. Streaming, exit codes, dedupe, attach-after-drop, truncation, idempotent teardown, reboot-preserves-FS, and result-vs-error (exit 7 and timeout→124 *yield*, not throw).

## Notes
- Types-only dependency on `@funky/db` (`ResolvedEnv`) — no db client import.
- `reboot` no-op and stderr-folded-into-stdout are intentional subprocess-only simplifications.
- Adds `packages/ports/*` to the workspace; no new third-party deps (workspace deps + vitest only).

## Verification
`pnpm typecheck` clean; sandbox TCK 10/10 green; timeout path verified out-of-band (kills the process group, exit 124, no orphaned process).

🤖 Generated with [Claude Code](https://claude.com/claude-code)