### PR TITLE
Phase B: @funky/llm port + fake and ai-sdk drivers

### DIFF
--- a/packages/ports/llm/package.json
+++ b/packages/ports/llm/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@funky/llm",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./port": "./src/port.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@ai-sdk/anthropic": "^4.0.0",
+    "@ai-sdk/openai": "^4.0.0",
+    "@funky/db": "workspace:*",
+    "@funky/sessions": "workspace:*",
+    "ai": "^7.0.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/ports/llm/src/ai-sdk.mock.test.ts
+++ b/packages/ports/llm/src/ai-sdk.mock.test.ts
@@ -1,0 +1,67 @@
+// Offline unit test for the v1 tool-call cap's second layer (defensive truncation). The
+// AI SDK's generateText is mocked, so no key / network is needed: we feed a provider
+// response carrying THREE tool calls and assert the driver surfaces exactly one and counts
+// the drops via llm_tool_calls_dropped_total.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ai")>();
+  return { ...actual, generateText: vi.fn() };
+});
+
+import { generateText } from "ai";
+import type { ModelConfig } from "@funky/db/schema";
+import { AiSdkLlm } from "./drivers/ai-sdk";
+import { getCounter, resetCounters } from "./metrics";
+import type { ChatMessage } from "./port";
+
+const MODEL: ModelConfig = { provider: "anthropic", model: "claude-sonnet-5" };
+const MSGS: ChatMessage[] = [{ role: "user", content: "do three things" }];
+
+function mockResult(toolCalls: Array<{ toolName: string; input: unknown }>) {
+  // Only the fields the driver reads; cast past the full GenerateTextResult shape.
+  vi.mocked(generateText).mockResolvedValue({
+    text: "",
+    toolCalls,
+    usage: { inputTokens: 10, outputTokens: 4 },
+  } as unknown as Awaited<ReturnType<typeof generateText>>);
+}
+
+describe("AiSdkLlm parallel-tool-call cap", () => {
+  beforeEach(() => {
+    resetCounters();
+    vi.mocked(generateText).mockReset();
+  });
+
+  it("returns exactly one tool call and counts the dropped ones", async () => {
+    mockResult([
+      { toolName: "exec", input: { cmd: "ls" } },
+      { toolName: "exec", input: { cmd: "pwd" } },
+      { toolName: "exec", input: { cmd: "whoami" } },
+    ]);
+
+    const r = await new AiSdkLlm().complete({ model: MODEL, messages: MSGS });
+
+    expect(r.toolCall).toEqual({ kind: "exec", cmd: "ls" });
+    expect(getCounter("llm_tool_calls_dropped_total")).toBe(2); // 3 returned − 1 kept
+  });
+
+  it("does not count drops when the provider returns a single call", async () => {
+    mockResult([{ toolName: "exec", input: { cmd: "ls" } }]);
+
+    const r = await new AiSdkLlm().complete({ model: MODEL, messages: MSGS });
+
+    expect(r.toolCall).toEqual({ kind: "exec", cmd: "ls" });
+    expect(getCounter("llm_tool_calls_dropped_total")).toBe(0);
+  });
+
+  it("requests provider-side disable of parallel tool use", async () => {
+    mockResult([]);
+
+    await new AiSdkLlm().complete({ model: MODEL, messages: MSGS });
+
+    const call = vi.mocked(generateText).mock.calls[0]![0];
+    expect(call.providerOptions).toEqual({ anthropic: { disableParallelToolUse: true } });
+  });
+});

--- a/packages/ports/llm/src/ai-sdk.test.ts
+++ b/packages/ports/llm/src/ai-sdk.test.ts
@@ -1,0 +1,33 @@
+// Gated real round-trip against Anthropic. Skipped in CI (no key); run locally with
+// ANTHROPIC_API_KEY set to confirm the exec tool round-trips into our ToolCall shape.
+
+import { describe, expect, it } from "vitest";
+import type { ModelConfig } from "@funky/db/schema";
+import { AiSdkLlm } from "./drivers/ai-sdk";
+import type { ChatMessage } from "./port";
+
+const hasKey = !!process.env.ANTHROPIC_API_KEY;
+
+describe.skipIf(!hasKey)("AiSdkLlm (real anthropic round-trip)", () => {
+  const model: ModelConfig = { provider: "anthropic", model: "claude-sonnet-5", maxTokens: 1024 };
+
+  it("returns an exec ToolCall when the prompt requires a shell command", async () => {
+    const llm = new AiSdkLlm();
+    const messages: ChatMessage[] = [
+      {
+        role: "system",
+        content:
+          "You control a Linux sandbox. To answer any question about the machine, you MUST call the exec tool. Never guess.",
+      },
+      { role: "user", content: "What is the current working directory? Use the exec tool." },
+    ];
+
+    const result = await llm.complete({ model, messages });
+
+    expect(result.usage.inputTokens).toBeGreaterThan(0);
+    expect(result.toolCall).toBeDefined();
+    expect(result.toolCall?.kind).toBe("exec");
+    expect(typeof result.toolCall?.cmd).toBe("string");
+    expect(result.toolCall?.cmd.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/ports/llm/src/drivers/ai-sdk.ts
+++ b/packages/ports/llm/src/drivers/ai-sdk.ts
@@ -1,0 +1,211 @@
+// packages/ports/llm/src/drivers/ai-sdk.ts — real providers via the Vercel AI SDK.
+//
+// Single tool (`exec`) exposed to the model; its tool call is translated back into our
+// ToolCall. Transient failures are retried 3× with exponential backoff INSIDE the driver
+// so the worker sees at most one LlmTransientError after the driver has exhausted its
+// retries; non-retryable failures surface immediately as LlmPermanentError.
+
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createOpenAI } from "@ai-sdk/openai";
+import {
+  APICallError,
+  type LanguageModel,
+  type ModelMessage,
+  type TextPart,
+  type ToolCallPart,
+  generateText,
+  tool,
+} from "ai";
+import { z } from "zod";
+import type { ModelConfig } from "@funky/db/schema";
+import type { ToolCall } from "@funky/sessions/events";
+import { incrCounter } from "../metrics";
+import {
+  type ChatMessage,
+  type LlmPort,
+  LlmPermanentError,
+  type LlmRequest,
+  type LlmResult,
+  LlmTransientError,
+} from "../port";
+
+const EXEC_TOOL = "exec";
+const MAX_ATTEMPTS = 3;
+
+// No `execute`: the model's exec call is returned and generation stops after one step
+// (generateText's default). The worker runs the command in the sandbox, not the SDK.
+const execTool = tool({
+  description:
+    "Run a shell command in the session's sandbox and return its combined stdout/stderr and exit code.",
+  inputSchema: z.object({
+    cmd: z.string().min(1).describe("The shell command to run."),
+    timeout_ms: z
+      .number()
+      .int()
+      .min(1)
+      .max(600_000)
+      .optional()
+      .describe("Optional wall-clock timeout in milliseconds."),
+  }),
+});
+
+export class AiSdkLlm implements LlmPort {
+  async complete(req: LlmRequest): Promise<LlmResult> {
+    const model = resolveModel(req.model);
+    const messages = toModelMessages(req.messages);
+    const providerOptions = parallelToolUseOff(req.model);
+
+    let lastTransient: LlmTransientError | undefined;
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      try {
+        const result = await generateText({
+          model,
+          messages,
+          tools: { [EXEC_TOOL]: execTool },
+          providerOptions, // disables parallel tool use so the model plans sequentially
+          maxOutputTokens: req.model.maxTokens,
+          temperature: req.model.temperature,
+          maxRetries: 0, // we own the retry loop below (with our error taxonomy)
+        });
+        return {
+          content: result.text,
+          toolCall: pickSingleToolCall(result.toolCalls),
+          usage: {
+            inputTokens: result.usage.inputTokens ?? 0,
+            outputTokens: result.usage.outputTokens ?? 0,
+          },
+        };
+      } catch (err) {
+        const classified = classify(err);
+        if (classified instanceof LlmPermanentError) throw classified;
+        lastTransient = classified;
+        if (attempt < MAX_ATTEMPTS - 1) await sleep(backoffMs(attempt));
+      }
+    }
+    // Retries exhausted: hand the worker one transient error to retry at its own layer.
+    throw lastTransient ?? new LlmTransientError("llm transient failure");
+  }
+}
+
+function resolveModel(cfg: ModelConfig): LanguageModel {
+  switch (cfg.provider) {
+    case "anthropic":
+      return createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })(cfg.model);
+    case "openai":
+      return createOpenAI({ apiKey: process.env.OPENAI_API_KEY })(cfg.model);
+    default:
+      // v1 ships anthropic + openai; the others are wired identically when needed.
+      throw new LlmPermanentError(`llm provider not supported in v1: ${cfg.provider}`);
+  }
+}
+
+// Layer 1 of the v1 tool-call cap: tell the provider to plan sequentially so it never
+// emits a batch in the first place — no intent is dropped. Anthropic and OpenAI spell it
+// differently; both go through the AI SDK's per-provider providerOptions.
+function parallelToolUseOff(cfg: ModelConfig): Record<string, Record<string, boolean>> | undefined {
+  switch (cfg.provider) {
+    case "anthropic":
+      return { anthropic: { disableParallelToolUse: true } };
+    case "openai":
+      return { openai: { parallelToolCalls: false } };
+    default:
+      return undefined;
+  }
+}
+
+// Layer 2 — defensive truncation: if a provider ignores the flag above and returns a
+// batch, keep calls[0] and drop the rest so we never exceed the log's tool_calls.max(1).
+// The drop counter is the signal that it's time to lift the cap. This is only safe because
+// buildContext (Phase D) rebuilds messages from OUR event log — which recorded one call —
+// never from provider-native response objects, so the next request stays internally
+// consistent (one tool_use answered by one tool_result).
+function pickSingleToolCall(
+  toolCalls: ReadonlyArray<{ toolName: string; input: unknown }>,
+): ToolCall | undefined {
+  if (toolCalls.length === 0) return undefined;
+  if (toolCalls.length > 1) {
+    incrCounter("llm_tool_calls_dropped_total", toolCalls.length - 1);
+  }
+  const first = toolCalls[0]!;
+  if (first.toolName !== EXEC_TOOL) return undefined;
+  const input = first.input as { cmd?: unknown; timeout_ms?: unknown };
+  if (typeof input?.cmd !== "string" || input.cmd.length === 0) return undefined;
+  return typeof input.timeout_ms === "number"
+    ? { kind: "exec", cmd: input.cmd, timeout_ms: input.timeout_ms }
+    : { kind: "exec", cmd: input.cmd };
+}
+
+// ChatMessage[] → the AI SDK's ModelMessage[]. An assistant tool call and its paired tool
+// result must share a toolCallId; we reuse the tool message's idemKey as that id (the log
+// already pairs result → call by idemKey), so the reconstruction round-trips cleanly.
+function toModelMessages(messages: ChatMessage[]): ModelMessage[] {
+  const out: ModelMessage[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const m = messages[i]!;
+    switch (m.role) {
+      case "system":
+        out.push({ role: "system", content: m.content });
+        break;
+      case "user":
+        out.push({ role: "user", content: m.content });
+        break;
+      case "assistant": {
+        if (m.toolCall) {
+          const next = messages[i + 1];
+          const id = next && next.role === "tool" ? next.idemKey : `call-${i}`;
+          const parts: Array<TextPart | ToolCallPart> = [];
+          if (m.content) parts.push({ type: "text", text: m.content });
+          parts.push({ type: "tool-call", toolCallId: id, toolName: EXEC_TOOL, input: execInput(m.toolCall) });
+          out.push({ role: "assistant", content: parts });
+        } else {
+          out.push({ role: "assistant", content: m.content });
+        }
+        break;
+      }
+      case "tool":
+        out.push({
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: m.idemKey,
+              toolName: EXEC_TOOL,
+              output: { type: "text", value: m.output },
+            },
+          ],
+        });
+        break;
+    }
+  }
+  return out;
+}
+
+function execInput(tc: ToolCall): { cmd: string; timeout_ms?: number } {
+  return tc.timeout_ms !== undefined ? { cmd: tc.cmd, timeout_ms: tc.timeout_ms } : { cmd: tc.cmd };
+}
+
+// Map SDK/provider failures onto the port's two-class taxonomy. 429 / 5xx / network /
+// timeout → transient (retry). Everything else (4xx, context-length, bad request) →
+// permanent (no retry; becomes turn_failed(LLM_PERMANENT)).
+function classify(err: unknown): LlmTransientError | LlmPermanentError {
+  if (APICallError.isInstance(err)) {
+    const status = err.statusCode;
+    if (err.isRetryable || status === 429 || (status !== undefined && status >= 500)) {
+      return new LlmTransientError(err.message);
+    }
+    return new LlmPermanentError(err.message);
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  if (/timeout|timed out|ETIMEDOUT|ECONNRESET|ECONNREFUSED|EAI_AGAIN|fetch failed|network/i.test(msg)) {
+    return new LlmTransientError(msg);
+  }
+  return new LlmPermanentError(msg);
+}
+
+function backoffMs(attempt: number): number {
+  return 2 ** attempt * 200; // 200ms, 400ms, ...
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/ports/llm/src/drivers/fake.ts
+++ b/packages/ports/llm/src/drivers/fake.ts
@@ -1,0 +1,54 @@
+// packages/ports/llm/src/drivers/fake.ts — deterministic scripted driver.
+//
+// The single most-used object in every later test: hand it a script per session and it
+// replays turns one per complete() call. No network, no keys, fully deterministic.
+
+import { type LlmPort, type LlmRequest, type LlmResult, LlmTransientError } from "../port";
+
+export type FakeTurn = { content: string; toolCall?: LlmResult["toolCall"] };
+
+export class FakeLlm implements LlmPort {
+  private readonly scripts: Record<string, FakeTurn[]>;
+  private readonly cursor: Record<string, number> = {};
+  private readonly failOnce: Set<number>;
+  private readonly fired = new Set<number>();
+  private callIndex = 0;
+
+  constructor(opts: {
+    scripts: Record<string, FakeTurn[]>; // sessionId → ordered turns
+    failOnce?: number[]; // global call-indices that throw LlmTransientError ONCE, then succeed
+  }) {
+    this.scripts = opts.scripts;
+    this.failOnce = new Set(opts.failOnce ?? []);
+  }
+
+  async complete(req: LlmRequest): Promise<LlmResult> {
+    const index = this.callIndex++;
+    // Transient failure fires BEFORE consuming a script turn: the worker's retry re-calls
+    // complete() and gets the same logical turn, just on a later global index.
+    if (this.failOnce.has(index) && !this.fired.has(index)) {
+      this.fired.add(index);
+      throw new LlmTransientError(`fake transient failure at call ${index}`);
+    }
+
+    const sessionId = req.trace?.sessionId;
+    if (!sessionId) {
+      throw new Error("FakeLlm requires req.trace.sessionId to select a script");
+    }
+    const script = this.scripts[sessionId] ?? [];
+    const at = this.cursor[sessionId] ?? 0;
+    const turn = script[at];
+
+    // Script exhausted → a terminal turn with no tool call (the turn ends).
+    if (!turn) {
+      return { content: "done", usage: usageFor(req, "done") };
+    }
+    this.cursor[sessionId] = at + 1;
+    return { content: turn.content, toolCall: turn.toolCall, usage: usageFor(req, turn.content) };
+  }
+}
+
+// Deterministic, cheap: enough to assert usage flows through, never a real token count.
+function usageFor(req: LlmRequest, content: string): LlmResult["usage"] {
+  return { inputTokens: req.messages.length, outputTokens: content.length };
+}

--- a/packages/ports/llm/src/fake.test.ts
+++ b/packages/ports/llm/src/fake.test.ts
@@ -1,0 +1,73 @@
+// Unit tests for the FakeLlm — the deterministic scripted driver every later phase leans
+// on. Two guarantees: a per-session script replays one turn per complete() call, and
+// failOnce throws a transient error exactly once at a given global call index.
+
+import { describe, expect, it } from "vitest";
+import type { ModelConfig } from "@funky/db/schema";
+import { FakeLlm } from "./drivers/fake";
+import { LlmTransientError } from "./port";
+import type { ChatMessage } from "./port";
+
+const MODEL: ModelConfig = { provider: "anthropic", model: "claude-sonnet-5" };
+const MSGS: ChatMessage[] = [{ role: "user", content: "hi" }];
+
+function req(sessionId: string) {
+  return { model: MODEL, messages: MSGS, trace: { sessionId } };
+}
+
+describe("FakeLlm", () => {
+  it("replays a 3-turn script for one session, then goes terminal", async () => {
+    const llm = new FakeLlm({
+      scripts: {
+        s1: [
+          { content: "step 1", toolCall: { kind: "exec", cmd: "ls" } },
+          { content: "step 2", toolCall: { kind: "exec", cmd: "cat file" } },
+          { content: "step 3" },
+        ],
+      },
+    });
+
+    const r1 = await llm.complete(req("s1"));
+    expect(r1.content).toBe("step 1");
+    expect(r1.toolCall).toEqual({ kind: "exec", cmd: "ls" });
+
+    const r2 = await llm.complete(req("s1"));
+    expect(r2.content).toBe("step 2");
+    expect(r2.toolCall).toEqual({ kind: "exec", cmd: "cat file" });
+
+    const r3 = await llm.complete(req("s1"));
+    expect(r3.content).toBe("step 3");
+    expect(r3.toolCall).toBeUndefined();
+
+    // Script exhausted → terminal turn with no tool call, forever.
+    const r4 = await llm.complete(req("s1"));
+    expect(r4.content).toBe("done");
+    expect(r4.toolCall).toBeUndefined();
+
+    expect(r1.usage).toEqual({ inputTokens: 1, outputTokens: "step 1".length });
+  });
+
+  it("keeps a separate cursor per session", async () => {
+    const llm = new FakeLlm({
+      scripts: { a: [{ content: "a1" }, { content: "a2" }], b: [{ content: "b1" }] },
+    });
+    expect((await llm.complete(req("a"))).content).toBe("a1");
+    expect((await llm.complete(req("b"))).content).toBe("b1");
+    expect((await llm.complete(req("a"))).content).toBe("a2");
+  });
+
+  it("failOnce throws a transient error exactly once, then succeeds", async () => {
+    const llm = new FakeLlm({ scripts: { s1: [{ content: "ok" }] }, failOnce: [0] });
+
+    await expect(llm.complete(req("s1"))).rejects.toBeInstanceOf(LlmTransientError);
+
+    // The retry (call index 1) is no longer failed and delivers the first script turn.
+    const r = await llm.complete(req("s1"));
+    expect(r.content).toBe("ok");
+  });
+
+  it("requires trace.sessionId to pick a script", async () => {
+    const llm = new FakeLlm({ scripts: { s1: [{ content: "ok" }] } });
+    await expect(llm.complete({ model: MODEL, messages: MSGS })).rejects.toThrow(/sessionId/);
+  });
+});

--- a/packages/ports/llm/src/index.ts
+++ b/packages/ports/llm/src/index.ts
@@ -1,0 +1,29 @@
+// packages/ports/llm — public surface.
+// The worker (Phase E) imports the port; the entrypoint selects a driver by config.
+
+export * from "./port";
+export { FakeLlm, type FakeTurn } from "./drivers/fake";
+export { AiSdkLlm } from "./drivers/ai-sdk";
+export { getCounter, incrCounter, resetCounters } from "./metrics";
+
+import type { LlmPort } from "./port";
+import { AiSdkLlm } from "./drivers/ai-sdk";
+import type { FakeLlm } from "./drivers/fake";
+
+// Fake construction args come from test setup, not env — so the factory takes the
+// already-built driver in tests. The worker entrypoint reads FUNKY_LLM and builds the
+// ai-sdk driver from env.
+export type LlmConfig = { driver: "fake"; instance: FakeLlm } | { driver: "ai-sdk" };
+
+export function makeLlm(cfg: LlmConfig): LlmPort {
+  switch (cfg.driver) {
+    case "fake":
+      return cfg.instance;
+    case "ai-sdk":
+      return new AiSdkLlm();
+    default: {
+      const never: never = cfg;
+      throw new Error(`unknown llm driver: ${JSON.stringify(never)}`);
+    }
+  }
+}

--- a/packages/ports/llm/src/metrics.ts
+++ b/packages/ports/llm/src/metrics.ts
@@ -1,0 +1,20 @@
+// packages/ports/llm/src/metrics.ts — minimal in-process counters.
+//
+// Phase B has no metrics client yet (that arrives with the worker in Phase E). These are
+// plain process-global counters whose NAMES match what the worker will emit, so the
+// signal is captured now and re-homed later without renaming. Tests read them directly.
+
+const counters: Record<string, number> = Object.create(null);
+
+export function incrCounter(name: string, by = 1): void {
+  counters[name] = (counters[name] ?? 0) + by;
+}
+
+export function getCounter(name: string): number {
+  return counters[name] ?? 0;
+}
+
+/** Test helper: zero everything (counters are process-global). */
+export function resetCounters(): void {
+  for (const k of Object.keys(counters)) delete counters[k];
+}

--- a/packages/ports/llm/src/port.ts
+++ b/packages/ports/llm/src/port.ts
@@ -1,0 +1,43 @@
+// packages/ports/llm/src/port.ts — the LLM port (Phase B).
+//
+// A plain TypeScript interface, NOT proto/codegen: a same-process contract the worker
+// (Phase E) imports directly. Drivers are selected by config at the entrypoint; the
+// worker never imports a driver.
+
+import type { ModelConfig } from "@funky/db/schema";
+import type { ToolCall } from "@funky/sessions/events";
+
+/** Provider-neutral chat message. content is already flattened to a string here —
+ *  the LLM port does not deal in ContentBlocks (that's a log concern). */
+export type ChatMessage =
+  | { role: "system"; content: string }
+  | { role: "user"; content: string }
+  | { role: "assistant"; content: string; toolCall?: ToolCall }
+  | { role: "tool"; idemKey: string; output: string; exitCode: number };
+
+export type LlmResult = {
+  content: string;
+  toolCall?: ToolCall; // v1 cap: at most ONE (matches the log's tool_calls.max(1))
+  usage: { inputTokens: number; outputTokens: number };
+};
+
+export type LlmRequest = {
+  model: ModelConfig;
+  messages: ChatMessage[];
+  /** Opaque driver bookkeeping; providers ignore it. The fake reads `sessionId` to pick
+   *  its script — identity is NEVER inferred by parsing message content. */
+  trace?: { sessionId: string };
+};
+
+export interface LlmPort {
+  complete(req: LlmRequest): Promise<LlmResult>;
+}
+
+/** 429 / 5xx / timeout — worker retries (driver already retried 3× w/ backoff). */
+export class LlmTransientError extends Error {
+  readonly kind = "llm_transient" as const;
+}
+/** 4xx / context-length / bad request — no retry; becomes turn_failed(LLM_PERMANENT). */
+export class LlmPermanentError extends Error {
+  readonly kind = "llm_permanent" as const;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,31 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0))
 
+  packages/ports/llm:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^4.0.0
+        version: 4.0.12(zod@4.4.3)
+      '@ai-sdk/openai':
+        specifier: ^4.0.0
+        version: 4.0.11(zod@4.4.3)
+      '@funky/db':
+        specifier: workspace:*
+        version: link:../../db
+      '@funky/sessions':
+        specifier: workspace:*
+        version: link:../../sessions
+      ai:
+        specifier: ^7.0.0
+        version: 7.0.22(zod@4.4.3)
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
+    devDependencies:
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0))
+
   packages/ports/sandbox:
     dependencies:
       '@funky/db':
@@ -132,6 +157,34 @@ importers:
         version: 4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0))
 
 packages:
+
+  '@ai-sdk/anthropic@4.0.12':
+    resolution: {integrity: sha512-IquWNkGRSF2ulYJ6YIIUqMsNAIDeZFB3/4W92aSOtCxH1TfuVoq3qw4M4TxTxIw4As9cnkeRLe7b9LDMzPDsnA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@4.0.16':
+    resolution: {integrity: sha512-9iYxdOLquoOFk5e+02P9qfBIA+EJU0FNJvyjGxi4iXJabt2+GlbaCg7TX0sTtxOsBVkdabkatqWM6+kvp53tBg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@4.0.11':
+    resolution: {integrity: sha512-2PLnVPBsdJusgquPVYgPWd3ox4lbUFkp7DVUSmM0lQ4VISQoNxdgo6TvFAHgwQn9wJ/ckVYVRLU7+BvHc7T8ww==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.7':
+    resolution: {integrity: sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.3':
+    resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
+    engines: {node: '>=22'}
 
   '@drizzle-team/brocli@0.11.0':
     resolution: {integrity: sha512-hD3pekGiPg0WPCCGAZmusBBJsDqGUR66Y452YgQsZOnkdQ7ViEPKuyP4huUGEZQefp8g34RRodXYmJ2TbCH+tg==}
@@ -601,6 +654,10 @@ packages:
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
@@ -629,6 +686,15 @@ packages:
 
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
+  ai@7.0.22:
+    resolution: {integrity: sha512-iAXYwQtR18qN7GXwNmGVAQM4uSJOh2+nZ5RP9NtDXfH5d4tlYyYzAM133O3U+eVcyWrvNRzecN9yW58xpCdfMg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -785,6 +851,10 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
@@ -816,6 +886,9 @@ packages:
 
   jsbi@4.3.2:
     resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1121,6 +1194,37 @@ packages:
 
 snapshots:
 
+  '@ai-sdk/anthropic@4.0.12(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/gateway@4.0.16(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/openai@4.0.11(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.7(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider@4.0.3':
+    dependencies:
+      json-schema: 0.4.0
+
   '@drizzle-team/brocli@0.11.0': {}
 
   '@electric-sql/pglite@0.5.4': {}
@@ -1398,6 +1502,8 @@ snapshots:
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -1438,6 +1544,15 @@ snapshots:
       '@vitest/pretty-format': 4.1.10
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+
+  '@workflow/serde@4.1.0': {}
+
+  ai@7.0.22(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.16(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
+      zod: 4.4.3
 
   assertion-error@2.0.1: {}
 
@@ -1528,6 +1643,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
+  eventsource-parser@3.1.0: {}
+
   expect-type@1.4.0: {}
 
   fdir@6.5.0(picomatch@4.0.5):
@@ -1546,6 +1663,8 @@ snapshots:
   jiti@2.7.0: {}
 
   jsbi@4.3.2: {}
+
+  json-schema@0.4.0: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true


### PR DESCRIPTION
Part 2 of 2 for Phase B (ports). Adds the **LLM** port with its deterministic `fake` driver and the real `ai-sdk` driver.

**Stacked on #51** (`@funky/sandbox`) — base is `phase-b-sandbox`, so the diff shows only the llm package + the ai-sdk lockfile additions. Merge #51 first; GitHub will retarget this to `main` automatically.

## What's here
- **`port.ts`** — `LlmPort`, `ChatMessage`, `LlmResult`, and the `LlmTransientError` / `LlmPermanentError` taxonomy (transient → worker retries; permanent → `turn_failed(LLM_PERMANENT)`). `complete()` carries an opaque `trace?:{sessionId}` for driver bookkeeping — providers ignore it, the fake reads it; identity is never parsed from message content.
- **`drivers/fake.ts`** — deterministic scripted driver: one turn per `complete()` per session, terminal `{content:"done"}` when exhausted, `failOnce` throwing a transient error once at a given global call index then succeeding. The workhorse for every later offline test.
- **`drivers/ai-sdk.ts`** — real providers via the Vercel AI SDK (anthropic + openai). The v1 tool-call cap in two layers:
  1. **provider-side** — `disableParallelToolUse` / `parallelToolCalls:false` via `providerOptions`, so the model plans sequentially;
  2. **defensive truncation** to `calls[0]` with a `llm_tool_calls_dropped_total` counter for providers that ignore the flag.

  Single `exec` tool round-tripped to our `ToolCall`; 3× in-driver exponential backoff with `APICallError`-based transient/permanent classification.
- **`metrics.ts`** — minimal in-process counters (names match what the worker will emit) until Phase E wires a real metrics client.

## Tests
- `fake.test.ts` — 3-turn replay determinism + `failOnce` fires exactly once then succeeds.
- `ai-sdk.mock.test.ts` — mocked provider returning **3 tool calls → exactly 1 returned** and the drop counter incremented; also asserts `providerOptions` disables parallel tool use.
- `ai-sdk.test.ts` — gated real Anthropic round-trip incl. exec→ToolCall, **skipped without `ANTHROPIC_API_KEY`**.

## Notes
- Types-only dependency on `@funky/db` (`ModelConfig`) — no db client import.
- All third-party dependency churn (`ai@7`, `@ai-sdk/anthropic@4`, `@ai-sdk/openai@4`) is isolated to this PR.

## Verification
`pnpm typecheck` clean; llm tests 7 passed + 1 gated-skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)