### PR TITLE
Phase D: the reducer and the turn loop (@funky/sessions)

### DIFF
--- a/packages/sessions/package.json
+++ b/packages/sessions/package.json
@@ -12,6 +12,8 @@
   },
   "dependencies": {
     "@funky/db": "workspace:*",
+    "@funky/llm": "workspace:*",
+    "@funky/sandbox": "workspace:*",
     "drizzle-orm": "^1.0.0-beta.2",
     "pg": "^8.22.0",
     "zod": "^4.0.0"

--- a/packages/sessions/src/index.ts
+++ b/packages/sessions/src/index.ts
@@ -3,7 +3,11 @@
 //   Phase C: the two Postgres-native data-access modules — the event log and the
 //   job queue. @funky/sessions is the postgres-touching domain layer; API routes
 //   and the (future) reducer still must not import @funky/db.
+//   Phase D: the reducer (pure) and the turn / provision loop the worker (Phase E) calls.
 export * from "./events";
 export { EventStore, ErrConflict } from "./store";
 export { JobQueue, onWake, LEASE_MS, HEARTBEAT_MS, POLL_INTERVAL_MS } from "./queue";
 export type { Job } from "./queue";
+export { nextAction, type Action } from "./reducer";
+export { buildContext, runTurn, type TurnDeps, type TurnOutcome } from "./turn";
+export { runProvision } from "./provision";

--- a/packages/sessions/src/provision.ts
+++ b/packages/sessions/src/provision.ts
@@ -1,0 +1,96 @@
+// packages/sessions/src/provision.ts — Phase D: sandbox provisioning.
+//
+// Provision jobs (kind: "provision") ride the same queue and run on the same worker as
+// turns. The snapshot of the env config into `resolved_env` happens HERE and is never
+// re-read from the (mutable) env config: a sandbox reboot three days later must rebuild
+// the SAME environment the session started with, not whatever the config says today. The
+// snapshot makes reboots deterministic.
+
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@funky/db";
+import { envConfigs, type ResolvedEnv, sessions } from "@funky/db/schema";
+import { makeEvent } from "./events";
+import type { Job } from "./queue";
+import { ErrConflict } from "./store";
+import type { TurnDeps, TurnOutcome } from "./turn";
+
+export async function runProvision(job: Job, deps: TurnDeps): Promise<TurnOutcome> {
+  const ns = job.namespace;
+  const sessionId = job.sessionId;
+
+  const [session] = await deps.db
+    .select()
+    .from(sessions)
+    .where(and(eq(sessions.namespace, ns), eq(sessions.id, sessionId)))
+    .limit(1);
+  if (!session) return "abandoned"; // no such session — nothing to provision
+  if (session.status !== "provisioning") return "completed"; // already provisioned; stale job
+
+  const [env] = await deps.db
+    .select()
+    .from(envConfigs)
+    .where(and(eq(envConfigs.namespace, ns), eq(envConfigs.id, session.envConfigId)))
+    .limit(1);
+  if (!env) return failProvision(deps, job, ns, sessionId, "env config not found");
+
+  // Snapshot the env config. template_id stays undefined for the subprocess driver.
+  const resolvedEnv: ResolvedEnv = {
+    base_image: env.baseImage,
+    persistent_fs: env.persistentFs,
+    egress: env.egress,
+  };
+
+  try {
+    const handle = await deps.sandbox.provision(resolvedEnv, sessionId);
+    // ONE transaction: flip the session to ready with its snapshot + handle, AND append
+    // session_provisioned. Either both land or neither does.
+    await deps.db.transaction(async (tx) => {
+      const lastSeq = await deps.store.lastSeq(ns, sessionId, tx);
+      await tx
+        .update(sessions)
+        .set({ resolvedEnv, sandboxHandle: handle, status: "ready", updatedAt: new Date() })
+        .where(and(eq(sessions.namespace, ns), eq(sessions.id, sessionId)));
+      const evt = makeEvent(
+        { sessionId, namespace: ns, seq: lastSeq + 1 },
+        "session_provisioned",
+        {},
+      );
+      await deps.store.appendEvent(ns, sessionId, lastSeq + 1, evt, tx);
+    });
+    return "completed";
+  } catch (err) {
+    if (err instanceof ErrConflict) return "conflict"; // another worker already provisioned
+    return failProvision(deps, job, ns, sessionId, err instanceof Error ? err.message : String(err));
+  }
+}
+
+// A provisioning failure retries with backoff until the last attempt, then terminates the
+// session — status 'failed' + turn_failed(SANDBOX_FATAL) in one transaction — so a session
+// whose sandbox can never come up ends with a terminal event instead of hanging forever.
+async function failProvision(
+  deps: TurnDeps,
+  job: Job,
+  ns: string,
+  sessionId: string,
+  message: string,
+): Promise<TurnOutcome> {
+  if (job.attempts < job.maxAttempts) return "retry_later";
+  try {
+    await deps.db.transaction(async (tx) => {
+      const lastSeq = await deps.store.lastSeq(ns, sessionId, tx);
+      await tx
+        .update(sessions)
+        .set({ status: "failed", updatedAt: new Date() })
+        .where(and(eq(sessions.namespace, ns), eq(sessions.id, sessionId)));
+      const evt = makeEvent({ sessionId, namespace: ns, seq: lastSeq + 1 }, "turn_failed", {
+        error_class: "SANDBOX_FATAL",
+        message,
+      });
+      await deps.store.appendEvent(ns, sessionId, lastSeq + 1, evt, tx);
+    });
+  } catch (e) {
+    if (e instanceof ErrConflict) return "conflict";
+    return "retry_later";
+  }
+  return "failed";
+}

--- a/packages/sessions/src/reducer.test.ts
+++ b/packages/sessions/src/reducer.test.ts
@@ -1,0 +1,163 @@
+// packages/sessions/src/reducer.test.ts — the pure fold. Arrays in, actions out; NO DB.
+//
+// The reducer is the heart of crash-resume: every valid log prefix must yield exactly the
+// action that produced the next event. The ★ RESUME PROPERTY test below proves that for a
+// full happy-path log by feeding it EVERY prefix — one assertion covering every crash point.
+
+import { describe, expect, it } from "vitest";
+import {
+  type ContentBlock,
+  type EventPayload,
+  type EventType,
+  type SessionEvent,
+  type ToolCall,
+  idemKeyFor,
+} from "./events";
+import { nextAction } from "./reducer";
+
+const SID = "11111111-1111-1111-1111-111111111111";
+const NS = "default";
+
+// A tiny event builder. createdAt is irrelevant to the reducer (it reads type/seq/payload).
+function ev<T extends EventType>(seq: number, type: T, payload: EventPayload<T>): SessionEvent<T> {
+  return { sessionId: SID, namespace: NS, seq, type, payload, createdAt: new Date(0) };
+}
+
+const text = (t: string): ContentBlock[] => [{ type: "text", text: t }];
+const EXEC: ToolCall = { kind: "exec", cmd: "echo hi" };
+
+const user = (seq: number) => ev(seq, "user_message", { content: text(`u${seq}`) });
+const asstTool = (seq: number) =>
+  ev(seq, "assistant_message", { content: [], tool_calls: [EXEC] });
+const asstDone = (seq: number) =>
+  ev(seq, "assistant_message", { content: text("done"), tool_calls: [] });
+const toolResult = (seq: number, forAssistantSeq: number) =>
+  ev(seq, "tool_result", {
+    idem_key: idemKeyFor(SID, forAssistantSeq, 0),
+    output: "hi",
+    exit_code: 0,
+    truncated: false,
+  });
+const completed = (seq: number) => ev(seq, "turn_completed", {});
+const failed = (seq: number) =>
+  ev(seq, "turn_failed", { error_class: "INTERNAL", message: "boom" });
+const provisioned = (seq: number) => ev(seq, "session_provisioned", {});
+
+describe("nextAction — the basic transitions", () => {
+  it("[user_message] → infer", () => {
+    expect(nextAction([user(1)], 20)).toEqual({ kind: "infer" });
+  });
+
+  it("[user, assistant(no tools)] → finish", () => {
+    expect(nextAction([user(1), asstDone(2)], 20)).toEqual({ kind: "finish" });
+  });
+
+  it("[user, assistant(tool_call)] → exec_tool with idemKey `${sessionId}:${seq}:0`", () => {
+    const action = nextAction([user(1), asstTool(2)], 20);
+    expect(action).toEqual({ kind: "exec_tool", call: EXEC, idemKey: `${SID}:2:0` });
+  });
+
+  it("[user, assistant(tool), tool_result] → infer", () => {
+    expect(nextAction([user(1), asstTool(2), toolResult(3, 2)], 20)).toEqual({ kind: "infer" });
+  });
+
+  it("[user, assistant(tool), tool_result, assistant(no tools)] → finish", () => {
+    expect(
+      nextAction([user(1), asstTool(2), toolResult(3, 2), asstDone(4)], 20),
+    ).toEqual({ kind: "finish" });
+  });
+
+  it("[..., turn_completed] → noop (stale job)", () => {
+    expect(nextAction([user(1), asstDone(2), completed(3)], 20)).toEqual({ kind: "noop" });
+  });
+
+  it("[..., turn_failed] → noop (stale job)", () => {
+    expect(nextAction([user(1), failed(2)], 20)).toEqual({ kind: "noop" });
+  });
+
+  it("session_provisioned after user_message → infer", () => {
+    // A queued user_message whose provision landed after it: still the model's turn.
+    expect(nextAction([user(1), provisioned(2)], 20)).toEqual({ kind: "infer" });
+  });
+});
+
+describe("nextAction — the iteration budget", () => {
+  it("maxIterations=2 with 2 assistant messages since the last user → fail(budget)", () => {
+    const log = [user(1), asstTool(2), toolResult(3, 2), asstTool(4), toolResult(5, 4)];
+    expect(nextAction(log, 2)).toEqual({ kind: "fail", reason: "budget" });
+  });
+
+  it("is under budget at 1 of 2 → infer", () => {
+    const log = [user(1), asstTool(2), toolResult(3, 2)];
+    expect(nextAction(log, 2)).toEqual({ kind: "infer" });
+  });
+
+  it("resets per user turn: [user, asst, tool, asst, user] → infer (count restarts)", () => {
+    const log = [user(1), asstTool(2), toolResult(3, 2), asstDone(4), user(5)];
+    expect(nextAction(log, 2)).toEqual({ kind: "infer" });
+  });
+});
+
+describe("nextAction — guards", () => {
+  it("throws on an empty log", () => {
+    expect(() => nextAction([], 20)).toThrow(/empty log/);
+  });
+
+  it("a still-pending tool call re-issues the SAME exec_tool (resume after a crash)", () => {
+    // The worker died after appending assistant(tool) but before tool_result. Replaying
+    // the identical prefix must recompute the identical idemKey → attach, never re-run.
+    const log = [user(1), asstTool(2)];
+    const a = nextAction(log, 20);
+    const b = nextAction(log, 20);
+    expect(a).toEqual(b);
+    expect(a).toEqual({ kind: "exec_tool", call: EXEC, idemKey: `${SID}:2:0` });
+  });
+});
+
+// ============================================================ ★ RESUME PROPERTY
+//
+// The single most important reducer test. A complete happy-path turn is a sequence of
+// events, each PRODUCED by an action. Feeding every prefix (length 1..N) to nextAction
+// must yield exactly the action that produced the NEXT event — which is what a worker
+// resuming from any crash point would compute. One test, every crash point.
+
+describe("★ RESUME PROPERTY", () => {
+  it("every prefix of a happy-path log yields the action that produced the next event", () => {
+    // The full log and, for each prefix length, the action that the reducer should emit —
+    // i.e. the action a worker would take to append events[length].
+    const log: SessionEvent[] = [
+      user(1),
+      asstTool(2),
+      toolResult(3, 2),
+      asstDone(4),
+      completed(5),
+    ];
+    const expectedAfterPrefix: Record<number, ReturnType<typeof nextAction>> = {
+      1: { kind: "infer" }, //          [user]                       → produce asstTool(2)
+      2: { kind: "exec_tool", call: EXEC, idemKey: `${SID}:2:0` }, // → produce toolResult(3)
+      3: { kind: "infer" }, //          [.., tool_result]            → produce asstDone(4)
+      4: { kind: "finish" }, //         [.., assistant(no tools)]    → produce turn_completed(5)
+      5: { kind: "noop" }, //           [.., turn_completed]         → terminal, stand down
+    };
+
+    for (let len = 1; len <= log.length; len++) {
+      const prefix = log.slice(0, len);
+      expect(nextAction(prefix, 20), `prefix length ${len}`).toEqual(expectedAfterPrefix[len]);
+    }
+  });
+
+  it("property: nextAction never throws on any non-empty prefix of a valid log", () => {
+    // A few structurally distinct valid logs; every non-empty prefix must produce an action.
+    const logs: SessionEvent[][] = [
+      [user(1), asstDone(2), completed(3)],
+      [user(1), asstTool(2), toolResult(3, 2), asstDone(4), completed(5)],
+      [user(1), asstTool(2), toolResult(3, 2), asstTool(4), toolResult(5, 4), failed(6)],
+      [user(1), provisioned(2), asstTool(3), toolResult(4, 3), asstDone(5), completed(6)],
+    ];
+    for (const log of logs) {
+      for (let len = 1; len <= log.length; len++) {
+        expect(() => nextAction(log.slice(0, len), 20)).not.toThrow();
+      }
+    }
+  });
+});

--- a/packages/sessions/src/reducer.ts
+++ b/packages/sessions/src/reducer.ts
@@ -1,0 +1,80 @@
+// packages/sessions/src/reducer.ts — Phase D: the pure fold. NO I/O.
+//
+// The reducer answers exactly one question: given this log, what happens next? It
+// imports nothing but ./events — no database, no ports, no clock, no randomness. It is
+// a TOTAL function: every valid log prefix yields an action, so crash-resume is not a
+// code path, it is THE code path. A worker that dies mid-turn leaves a log; a different
+// worker replays it, computes the same next action from the same prefix, and continues.
+// If you ever reach for `if (resuming) { ... }`, you have misunderstood the design.
+
+import { type EventPayload, type SessionEvent, type ToolCall, idemKeyFor } from "./events";
+
+export type Action =
+  /** Call the model with the rebuilt context. */
+  | { kind: "infer" }
+  /** Run this tool call. idemKey is DERIVED from log position — never random. */
+  | { kind: "exec_tool"; call: ToolCall; idemKey: string }
+  /** The model answered with no tool call: append turn_completed, then ack. */
+  | { kind: "finish" }
+  /** Iteration budget exhausted: append turn_failed(BUDGET), then ack. */
+  | { kind: "fail"; reason: "budget" }
+  /** The log already ends in a terminal event — this job is stale. Ack, do nothing. */
+  | { kind: "noop" };
+
+export function nextAction(events: SessionEvent[], maxIterations: number): Action {
+  if (events.length === 0) {
+    throw new Error("reducer: empty log — a turn job must have a user_message");
+  }
+
+  // 1. Already terminal? The job is a redelivery of work that finished. Stand down.
+  const last = events[events.length - 1]!;
+  if (last.type === "turn_completed" || last.type === "turn_failed") {
+    return { kind: "noop" };
+  }
+
+  const lastUser = findLastIndex(events, (e) => e.type === "user_message");
+  const lastAssistant = findLastIndex(events, (e) => e.type === "assistant_message");
+
+  // 2. No assistant reply since the user's message → the model must speak.
+  //    (Also covers session_provisioned arriving after a queued user_message.)
+  if (lastAssistant < lastUser) {
+    return { kind: "infer" };
+  }
+
+  // 3. There is an assistant message in this turn. Did it ask for a tool?
+  const assistant = events[lastAssistant] as SessionEvent<"assistant_message">;
+  const calls = assistant.payload.tool_calls; // v1: length 0 or 1
+
+  if (calls.length === 0) {
+    return { kind: "finish" }; // the model answered; the turn is over
+  }
+
+  const call = calls[0]!;
+  const idemKey = idemKeyFor(assistant.sessionId, assistant.seq, 0);
+
+  // 4. Has that call already been answered? (Results always follow their call.)
+  const answered = events
+    .slice(lastAssistant + 1)
+    .some(
+      (e) =>
+        e.type === "tool_result" &&
+        (e.payload as EventPayload<"tool_result">).idem_key === idemKey,
+    );
+
+  if (!answered) {
+    return { kind: "exec_tool", call, idemKey }; // ← resume lands here after a crash
+  }
+
+  // 5. Tool answered → budget check → back to the model.
+  const iterations = events
+    .slice(lastUser + 1)
+    .filter((e) => e.type === "assistant_message").length;
+
+  if (iterations >= maxIterations) return { kind: "fail", reason: "budget" };
+  return { kind: "infer" };
+}
+
+function findLastIndex<T>(xs: T[], p: (x: T) => boolean): number {
+  for (let i = xs.length - 1; i >= 0; i--) if (p(xs[i]!)) return i;
+  return -1;
+}

--- a/packages/sessions/src/turn.test.ts
+++ b/packages/sessions/src/turn.test.ts
@@ -1,0 +1,620 @@
+// packages/sessions/src/turn.test.ts — the turn/provision loop against fakes + real Postgres.
+//
+// Everything here is offline: FakeLlm (and a few one-off LlmPort stubs) + the subprocess
+// sandbox + a testcontainers Postgres. No API keys, no network. The two ★ tests — happy
+// path and CRASH-RESUME — are the phase: if they pass, Funky's core promise is real.
+
+import { randomUUID } from "node:crypto";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  PostgreSqlContainer,
+  type StartedPostgreSqlContainer,
+} from "@testcontainers/postgresql";
+import { Pool } from "pg";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createDb, type Db } from "@funky/db";
+import {
+  FakeLlm,
+  type LlmPort,
+  type LlmRequest,
+  type LlmResult,
+  LlmPermanentError,
+} from "@funky/llm";
+import {
+  type SandboxDriver,
+  type SandboxHandle,
+  SubprocessDriver,
+  SandboxUnavailableError,
+} from "@funky/sandbox";
+import {
+  type EventPayload,
+  type Job,
+  type SessionEvent,
+  type ToolCall,
+  buildContext,
+  EventStore,
+  makeEvent,
+  runProvision,
+  runTurn,
+  textContent,
+} from "./index";
+
+process.env.TESTCONTAINERS_RYUK_DISABLED ??= "true";
+
+const migrationsDir = fileURLToPath(new URL("../../db/migrations", import.meta.url));
+
+let container: StartedPostgreSqlContainer;
+let pool: Pool;
+let db: Db;
+let store: EventStore;
+let sandbox: SubprocessDriver;
+
+const NS = "test-ns";
+const agentConfigId = randomUUID();
+const envConfigId = randomUUID();
+
+let sessionId: string;
+const handles: SandboxHandle[] = []; // provisioned during a test → torn down after
+
+// --------------------------------------------------------------------------- setup
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer("postgres:16").start();
+  pool = new Pool({ connectionString: container.getConnectionUri() });
+  for (const dir of readdirSync(migrationsDir).sort()) {
+    await pool.query(readFileSync(join(migrationsDir, dir, "migration.sql"), "utf8"));
+  }
+  db = createDb(pool);
+  store = new EventStore(db);
+  sandbox = new SubprocessDriver();
+}, 120_000);
+
+afterAll(async () => {
+  await pool?.end();
+  await container?.stop();
+});
+
+beforeEach(async () => {
+  await pool.query("truncate table session_events, turn_jobs, sessions cascade");
+  await pool.query("delete from agent_config_versions");
+  await pool.query("delete from agent_configs");
+  await pool.query("delete from env_configs");
+  await pool.query("insert into agent_configs (id, namespace, name, latest_version) values ($1,$2,$3,1)", [
+    agentConfigId,
+    NS,
+    "test-agent",
+  ]);
+  await pool.query(
+    "insert into env_configs (id, namespace, name, base_image) values ($1,$2,$3,$4)",
+    [envConfigId, NS, "test-env", "funky/base:latest"],
+  );
+  sessionId = randomUUID();
+});
+
+afterEach(async () => {
+  while (handles.length) await sandbox.teardown(handles.pop()!);
+});
+
+// ------------------------------------------------------------------------- helpers
+
+/** Insert the pinned agent version. tool_policy carries max_iterations. */
+async function seedAgentVersion(opts: { systemPrompt?: string; maxIterations?: number } = {}) {
+  const toolPolicy =
+    opts.maxIterations !== undefined ? { max_iterations: opts.maxIterations } : {};
+  await pool.query(
+    `insert into agent_config_versions (agent_config_id, version, namespace, system_prompt, model, tool_policy)
+     values ($1, 1, $2, $3, $4, $5)`,
+    [
+      agentConfigId,
+      NS,
+      opts.systemPrompt ?? "you are a helpful agent",
+      JSON.stringify({ provider: "anthropic", model: "claude-sonnet-5" }),
+      JSON.stringify(toolPolicy),
+    ],
+  );
+}
+
+/** Insert the session row. Provisions a real subprocess sandbox unless told otherwise. */
+async function seedSession(opts: {
+  status?: string;
+  provision?: boolean;
+  handle?: SandboxHandle;
+} = {}) {
+  const status = opts.status ?? "ready";
+  let handle: SandboxHandle | null = opts.handle ?? null;
+  if (!handle && opts.provision !== false) {
+    handle = await sandbox.provision(
+      { base_image: "x", persistent_fs: { size_gb: 1 }, egress: { allow: [] } },
+      sessionId,
+    );
+    handles.push(handle);
+  }
+  await pool.query(
+    `insert into sessions (id, namespace, agent_config_id, agent_version, env_config_id, status, sandbox_handle)
+     values ($1,$2,$3,1,$4,$5,$6)`,
+    [sessionId, NS, agentConfigId, envConfigId, status, handle ? JSON.stringify(handle) : null],
+  );
+}
+
+/** Seed a session's opening user_message at seq 1. */
+async function seedUserMessage(text = "hello") {
+  const evt = makeEvent({ sessionId, namespace: NS, seq: 1 }, "user_message", {
+    content: textContent(text),
+  });
+  await store.appendEvent(NS, sessionId, 1, evt);
+}
+
+function job(overrides: Partial<Job> = {}): Job {
+  return {
+    id: randomUUID(),
+    namespace: NS,
+    sessionId,
+    kind: "turn",
+    attempts: 1,
+    maxAttempts: 5,
+    ...overrides,
+  };
+}
+
+function deps(llm: LlmPort, sb: SandboxDriver = sandbox) {
+  return { store, llm, sandbox: sb, db };
+}
+
+async function log() {
+  return store.readEvents(NS, sessionId);
+}
+
+/** An LlmPort that returns the same scripted turns to every call (order = the script). */
+function scriptLlm(turns: Array<{ content: string; toolCall?: LlmResult["toolCall"] }>): FakeLlm {
+  return new FakeLlm({ scripts: { [sessionId]: turns } });
+}
+
+const exec = (cmd: string): ToolCall => ({ kind: "exec", cmd });
+
+// ================================================================= ★ HAPPY PATH
+
+describe("runTurn — the happy path", () => {
+  it("★ drives infer → exec → infer → complete and records the full log", async () => {
+    await seedAgentVersion();
+    await seedSession();
+    await seedUserMessage();
+
+    const llm = scriptLlm([{ content: "", toolCall: exec("echo hi") }, { content: "done" }]);
+    const outcome = await runTurn(job(), deps(llm));
+    expect(outcome).toBe("completed");
+
+    const events = await log();
+    expect(events.map((e) => e.type)).toEqual([
+      "user_message",
+      "assistant_message",
+      "tool_result",
+      "assistant_message",
+      "turn_completed",
+    ]);
+
+    const asstTool = events[1] as SessionEvent<"assistant_message">;
+    expect(asstTool.payload.tool_calls).toEqual([exec("echo hi")]);
+
+    const result = events[2] as SessionEvent<"tool_result">;
+    expect(result.payload.exit_code).toBe(0);
+    expect(result.payload.output).toContain("hi");
+    expect(result.payload.idem_key).toBe(`${sessionId}:2:0`);
+  });
+
+  it("a non-zero exit is a RESULT: the loop continues and the turn still completes", async () => {
+    await seedAgentVersion();
+    await seedSession();
+    await seedUserMessage();
+
+    const llm = scriptLlm([{ content: "", toolCall: exec("exit 3") }, { content: "acknowledged" }]);
+    const outcome = await runTurn(job(), deps(llm));
+    expect(outcome).toBe("completed");
+
+    const events = await log();
+    const result = events.find((e) => e.type === "tool_result") as SessionEvent<"tool_result">;
+    expect(result.payload.exit_code).toBe(3); // failure surfaced as a result, not thrown
+    // The model got to respond after the failure, and the turn reached a terminal event.
+    expect(events.at(-1)!.type).toBe("turn_completed");
+    expect(events.filter((e) => e.type === "assistant_message")).toHaveLength(2);
+  });
+});
+
+// ================================================================= budget
+
+describe("runTurn — iteration budget", () => {
+  it("maxIterations=2 with an LLM that always calls a tool → turn_failed(BUDGET)", async () => {
+    await seedAgentVersion({ maxIterations: 2 });
+    await seedSession();
+    await seedUserMessage();
+
+    const alwaysTool: LlmPort = {
+      async complete(): Promise<LlmResult> {
+        return { content: "", toolCall: exec("echo loop"), usage: { inputTokens: 1, outputTokens: 1 } };
+      },
+    };
+    const outcome = await runTurn(job(), deps(alwaysTool));
+    expect(outcome).toBe("failed");
+
+    const events = await log();
+    const last = events.at(-1) as SessionEvent<"turn_failed">;
+    expect(last.type).toBe("turn_failed");
+    expect(last.payload.error_class).toBe("BUDGET");
+    // exactly 2 assistant messages before the budget stopped it
+    expect(events.filter((e) => e.type === "assistant_message")).toHaveLength(2);
+  });
+});
+
+// ================================================================= error policy
+
+describe("runTurn — error policy", () => {
+  it("LlmPermanentError → turn_failed(LLM_PERMANENT), outcome 'failed'", async () => {
+    await seedAgentVersion();
+    await seedSession();
+    await seedUserMessage();
+
+    const permanent: LlmPort = {
+      async complete(): Promise<LlmResult> {
+        throw new LlmPermanentError("400 bad request");
+      },
+    };
+    const outcome = await runTurn(job(), deps(permanent));
+    expect(outcome).toBe("failed");
+
+    const last = (await log()).at(-1) as SessionEvent<"turn_failed">;
+    expect(last.type).toBe("turn_failed");
+    expect(last.payload.error_class).toBe("LLM_PERMANENT");
+  });
+
+  it("LlmTransientError escaping the driver → 'retry_later', NO events appended", async () => {
+    await seedAgentVersion();
+    await seedSession();
+    await seedUserMessage();
+
+    // failOnce at global call-index 0: the very first complete() throws transient.
+    const llm = new FakeLlm({ scripts: { [sessionId]: [{ content: "done" }] }, failOnce: [0] });
+    const outcome = await runTurn(job(), deps(llm));
+    expect(outcome).toBe("retry_later");
+
+    // Only the pre-seeded user_message exists — a transient failure records nothing.
+    expect((await log()).map((e) => e.type)).toEqual(["user_message"]);
+  });
+
+  it("last-attempt escalation: sandbox unobservable on the final attempt → turn_failed(SANDBOX_FATAL)", async () => {
+    await seedAgentVersion();
+    // A handle pointing at a workdir that does not exist → exec throws SandboxUnavailable.
+    // reboot is a subprocess no-op, so the retry throws again and the error escalates.
+    await seedSession({
+      provision: false,
+      handle: { driver: "subprocess", workdir: "/tmp/funky/does-not-exist-" + randomUUID() },
+    });
+    await seedUserMessage();
+
+    const llm = scriptLlm([{ content: "", toolCall: exec("echo hi") }]);
+    const outcome = await runTurn(job({ attempts: 5, maxAttempts: 5 }), deps(llm));
+    expect(outcome).toBe("failed"); // never a silent hang: the session gets a terminal event
+
+    const events = await log();
+    const last = events.at(-1) as SessionEvent<"turn_failed">;
+    expect(last.type).toBe("turn_failed");
+    expect(last.payload.error_class).toBe("SANDBOX_FATAL");
+    // The assistant tool call was recorded before the sandbox failure.
+    expect(events.some((e) => e.type === "assistant_message")).toBe(true);
+  });
+
+  it("non-final sandbox failure → 'retry_later' (no terminal event, the queue backs off)", async () => {
+    await seedAgentVersion();
+    await seedSession({
+      provision: false,
+      handle: { driver: "subprocess", workdir: "/tmp/funky/does-not-exist-" + randomUUID() },
+    });
+    await seedUserMessage();
+
+    const llm = scriptLlm([{ content: "", toolCall: exec("echo hi") }]);
+    const outcome = await runTurn(job({ attempts: 1, maxAttempts: 5 }), deps(llm));
+    expect(outcome).toBe("retry_later");
+
+    const events = await log();
+    // assistant recorded, but NO terminal event — a later attempt replays and retries.
+    expect(events.some((e) => e.type === "turn_failed")).toBe(false);
+    expect(events.some((e) => e.type === "assistant_message")).toBe(true);
+  });
+});
+
+// ================================================================= conflict
+
+describe("runTurn — ErrConflict", () => {
+  it("a competing worker taking the seq → 'conflict', no further appends by us", async () => {
+    await seedAgentVersion();
+    await seedSession();
+    await seedUserMessage();
+
+    // This LLM simulates another worker: during complete() it writes the seq (2) that
+    // runTurn is about to write, so runTurn's own append loses the (session_id, seq) race.
+    const racyLlm: LlmPort = {
+      async complete(): Promise<LlmResult> {
+        const seq = (await store.lastSeq(NS, sessionId)) + 1;
+        const evt = makeEvent({ sessionId, namespace: NS, seq }, "assistant_message", {
+          content: textContent("other worker"),
+          tool_calls: [],
+        });
+        await store.appendEvent(NS, sessionId, seq, evt);
+        return { content: "mine", usage: { inputTokens: 1, outputTokens: 1 } };
+      },
+    };
+
+    const outcome = await runTurn(job(), deps(racyLlm));
+    expect(outcome).toBe("conflict");
+
+    // Exactly the user_message + the competing worker's assistant. Nothing from us.
+    const events = await log();
+    expect(events.map((e) => e.type)).toEqual(["user_message", "assistant_message"]);
+    expect((events[1] as SessionEvent<"assistant_message">).payload.content).toEqual(
+      textContent("other worker"),
+    );
+  });
+});
+
+// ================================================================= session gate
+
+describe("runTurn — session status gate", () => {
+  it("status 'provisioning' → 'retry_later' without ever touching the LLM", async () => {
+    await seedAgentVersion();
+    await seedSession({ status: "provisioning", provision: false });
+    await seedUserMessage();
+
+    let called = false;
+    const spy: LlmPort = {
+      async complete(): Promise<LlmResult> {
+        called = true;
+        return { content: "x", usage: { inputTokens: 0, outputTokens: 0 } };
+      },
+    };
+    expect(await runTurn(job(), deps(spy))).toBe("retry_later");
+    expect(called).toBe(false);
+    expect((await log()).map((e) => e.type)).toEqual(["user_message"]);
+  });
+
+  it("status 'archived' → 'abandoned'", async () => {
+    await seedAgentVersion();
+    await seedSession({ status: "archived", provision: false });
+    await seedUserMessage();
+    expect(await runTurn(job(), deps(scriptLlm([])))).toBe("abandoned");
+  });
+});
+
+// ================================================================= ★ CRASH-RESUME
+
+describe("★ CRASH-RESUME", () => {
+  it("crashing right after the assistant tool call runs the command exactly once", async () => {
+    await seedAgentVersion();
+    await seedSession();
+    await seedUserMessage();
+
+    // A store that persists the assistant_message (durable), then throws to simulate the
+    // worker dying before it could run the tool. The row survives; the process does not.
+    class CrashAfterAssistantStore extends EventStore {
+      crashed = false;
+      override async appendEvent(
+        ns: string,
+        sid: string,
+        seq: number,
+        event: Omit<SessionEvent, "createdAt">,
+        tx?: Parameters<EventStore["appendEvent"]>[4],
+      ): Promise<void> {
+        await super.appendEvent(ns, sid, seq, event, tx);
+        const isToolCall =
+          event.type === "assistant_message" &&
+          (event.payload as EventPayload<"assistant_message">).tool_calls.length > 0;
+        if (isToolCall && !this.crashed) {
+          this.crashed = true;
+          throw new Error("simulated crash after assistant_message");
+        }
+      }
+    }
+
+    // The command appends one line to a marker file inside the sandbox. If it ever ran
+    // twice, the file would have two lines.
+    const cmd = "echo ran >> marker.txt";
+
+    // A STATELESS LLM: it decides purely from the rebuilt context — call the tool until a
+    // tool_result is present, then answer. This is what a real provider does, and it is the
+    // whole point of resume: a fresh worker rebuilds the same context and gets the same
+    // decision, with no cursor/state carried across the crash.
+    const resumeLlm: LlmPort = {
+      async complete(req: LlmRequest): Promise<LlmResult> {
+        const answered = req.messages.some((m) => m.role === "tool");
+        if (answered) return { content: "done", usage: { inputTokens: 0, outputTokens: 0 } };
+        return { content: "", toolCall: exec(cmd), usage: { inputTokens: 0, outputTokens: 0 } };
+      },
+    };
+
+    // Attempt 1: crash-injecting store — the assistant_message row commits, then the
+    // "process" dies before the tool ever runs.
+    const crashStore = new CrashAfterAssistantStore(db);
+    const outcome1 = await runTurn(job(), {
+      store: crashStore,
+      llm: resumeLlm,
+      sandbox,
+      db,
+    });
+    expect(outcome1).toBe("retry_later"); // the crash was caught; nothing terminal yet
+
+    // The assistant tool call is durably recorded; no tool_result yet.
+    const mid = await log();
+    expect(mid.map((e) => e.type)).toEqual(["user_message", "assistant_message"]);
+
+    // Attempt 2: a completely fresh worker (real store) resumes from the log alone.
+    const outcome2 = await runTurn(job(), deps(resumeLlm));
+    expect(outcome2).toBe("completed");
+
+    const events = await log();
+    // Exactly ONE tool_result, and the turn completed.
+    expect(events.filter((e) => e.type === "tool_result")).toHaveLength(1);
+    expect(events.at(-1)!.type).toBe("turn_completed");
+
+    // The side effect happened exactly once.
+    const handle = handles[0]!;
+    const marker = await sandbox.connect(handle).readFile("marker.txt");
+    const lines = Buffer.from(marker).toString("utf8").trim().split("\n");
+    expect(lines).toEqual(["ran"]);
+  });
+});
+
+// ================================================================= buildContext
+
+describe("buildContext", () => {
+  const sys = "SYSTEM-PROMPT";
+  const evt = <T extends SessionEvent["type"]>(
+    seq: number,
+    type: T,
+    payload: EventPayload<T>,
+  ): SessionEvent<T> =>
+    ({ sessionId, namespace: NS, seq, type, payload, createdAt: new Date(0) }) as SessionEvent<T>;
+
+  it("skips turn_completed / turn_failed / session_provisioned (bookkeeping, not conversation)", () => {
+    const events: SessionEvent[] = [
+      evt(1, "session_provisioned", {}),
+      evt(2, "user_message", { content: textContent("hi") }),
+      evt(3, "assistant_message", { content: textContent("on it"), tool_calls: [exec("ls")] }),
+      evt(4, "tool_result", { idem_key: `${sessionId}:3:0`, output: "files", exit_code: 0, truncated: false }),
+      evt(5, "assistant_message", { content: textContent("done"), tool_calls: [] }),
+      evt(6, "turn_completed", {}),
+    ];
+    const messages = buildContext(events, sys);
+    expect(messages.map((m) => m.role)).toEqual(["system", "user", "assistant", "tool", "assistant"]);
+    expect(messages[0]).toEqual({ role: "system", content: sys });
+    // the tool-calling assistant carries its toolCall; the tool message pairs by idemKey
+    expect(messages[2]).toMatchObject({ role: "assistant", toolCall: exec("ls") });
+    expect(messages[3]).toEqual({ role: "tool", idemKey: `${sessionId}:3:0`, output: "files", exitCode: 0 });
+  });
+
+  it("the system prompt comes from the PINNED agent version, not the agent's latest", async () => {
+    // Seed v1 with a distinctive prompt, then bump the agent to v2 with a different prompt.
+    // The session pins v1; buildContext (via runTurn) must use v1's prompt.
+    await seedAgentVersion({ systemPrompt: "PINNED-V1-PROMPT" });
+    await pool.query(
+      `insert into agent_config_versions (agent_config_id, version, namespace, system_prompt, model, tool_policy)
+       values ($1, 2, $2, $3, $4, '{}')`,
+      [agentConfigId, NS, "LATEST-V2-PROMPT", JSON.stringify({ provider: "anthropic", model: "m" })],
+    );
+    await pool.query("update agent_configs set latest_version = 2 where id = $1", [agentConfigId]);
+    await seedSession(); // agent_version pinned to 1 by seedSession
+    await seedUserMessage();
+
+    let seenSystem: string | undefined;
+    const capture: LlmPort = {
+      async complete(req: LlmRequest): Promise<LlmResult> {
+        seenSystem = req.messages.find((m) => m.role === "system")?.content;
+        return { content: "done", usage: { inputTokens: 0, outputTokens: 0 } };
+      },
+    };
+    await runTurn(job(), deps(capture));
+    expect(seenSystem).toBe("PINNED-V1-PROMPT");
+  });
+});
+
+// ================================================================= provision
+
+describe("runProvision", () => {
+  it("provisions the sandbox, snapshots resolved_env, flips to ready, appends session_provisioned", async () => {
+    await seedAgentVersion();
+    await pool.query(
+      `insert into sessions (id, namespace, agent_config_id, agent_version, env_config_id, status)
+       values ($1,$2,$3,1,$4,'provisioning')`,
+      [sessionId, NS, agentConfigId, envConfigId],
+    );
+
+    const outcome = await runProvision(job({ kind: "provision" }), deps(scriptLlm([])));
+    expect(outcome).toBe("completed");
+
+    const { rows } = await pool.query<{
+      status: string;
+      resolved_env: unknown;
+      sandbox_handle: { driver?: string } | null;
+    }>("select status, resolved_env, sandbox_handle from sessions where id = $1", [sessionId]);
+    expect(rows[0]!.status).toBe("ready");
+    expect(rows[0]!.resolved_env).toMatchObject({ base_image: "funky/base:latest" });
+    expect(rows[0]!.sandbox_handle?.driver).toBe("subprocess");
+    if (rows[0]!.sandbox_handle) handles.push(rows[0]!.sandbox_handle as SandboxHandle);
+
+    const events = await log();
+    expect(events.map((e) => e.type)).toEqual(["session_provisioned"]);
+  });
+
+  it("a session that is already ready → 'completed' with no new event (stale job)", async () => {
+    await seedAgentVersion();
+    await seedSession({ status: "ready" });
+    expect(await runProvision(job({ kind: "provision" }), deps(scriptLlm([])))).toBe("completed");
+    expect(await log()).toEqual([]); // nothing appended
+  });
+
+  it("last-attempt provision failure → session 'failed' + turn_failed(SANDBOX_FATAL)", async () => {
+    await seedAgentVersion();
+    await pool.query(
+      `insert into sessions (id, namespace, agent_config_id, agent_version, env_config_id, status)
+       values ($1,$2,$3,1,$4,'provisioning')`,
+      [sessionId, NS, agentConfigId, envConfigId],
+    );
+
+    const brokenSandbox: SandboxDriver = {
+      async provision(): Promise<SandboxHandle> {
+        throw new SandboxUnavailableError("cannot reach the sandbox host");
+      },
+      async reboot(h) {
+        return h;
+      },
+      async teardown() {},
+      connect() {
+        throw new Error("unreachable");
+      },
+    };
+
+    const outcome = await runProvision(
+      job({ kind: "provision", attempts: 5, maxAttempts: 5 }),
+      deps(scriptLlm([]), brokenSandbox),
+    );
+    expect(outcome).toBe("failed");
+
+    const { rows } = await pool.query<{ status: string }>(
+      "select status from sessions where id = $1",
+      [sessionId],
+    );
+    expect(rows[0]!.status).toBe("failed");
+    const last = (await log()).at(-1) as SessionEvent<"turn_failed">;
+    expect(last.payload.error_class).toBe("SANDBOX_FATAL");
+  });
+
+  it("non-final provision failure → 'retry_later', session stays 'provisioning'", async () => {
+    await seedAgentVersion();
+    await pool.query(
+      `insert into sessions (id, namespace, agent_config_id, agent_version, env_config_id, status)
+       values ($1,$2,$3,1,$4,'provisioning')`,
+      [sessionId, NS, agentConfigId, envConfigId],
+    );
+    const brokenSandbox: SandboxDriver = {
+      async provision(): Promise<SandboxHandle> {
+        throw new SandboxUnavailableError("transient host hiccup");
+      },
+      async reboot(h) {
+        return h;
+      },
+      async teardown() {},
+      connect() {
+        throw new Error("unreachable");
+      },
+    };
+    const outcome = await runProvision(
+      job({ kind: "provision", attempts: 1, maxAttempts: 5 }),
+      deps(scriptLlm([]), brokenSandbox),
+    );
+    expect(outcome).toBe("retry_later");
+    const { rows } = await pool.query<{ status: string }>(
+      "select status from sessions where id = $1",
+      [sessionId],
+    );
+    expect(rows[0]!.status).toBe("provisioning"); // untouched; a later attempt retries
+    expect(await log()).toEqual([]);
+  });
+});

--- a/packages/sessions/src/turn.ts
+++ b/packages/sessions/src/turn.ts
@@ -1,0 +1,284 @@
+// packages/sessions/src/turn.ts — Phase D: the turn loop.
+//
+// runTurn performs the single next Action the reducer computes, appends its result to the
+// log, and repeats — reading the log ONCE and keeping it current in memory thereafter.
+// buildContext is the ONLY source of provider messages: it rebuilds the conversation from
+// our log every inference, so the invariant "every assistant tool_use is answered by a
+// matching tool_result" holds even across crashes and the driver's v1 one-call cap. Raw
+// provider response objects are never cached or replayed.
+
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@funky/db";
+import { agentConfigVersions, sessions } from "@funky/db/schema";
+import type { ChatMessage, LlmPort } from "@funky/llm";
+import { LlmPermanentError, LlmTransientError } from "@funky/llm";
+import type { Executor, SandboxDriver, SandboxHandle } from "@funky/sandbox";
+import { SandboxUnavailableError } from "@funky/sandbox";
+import {
+  type EventPayload,
+  type EventType,
+  type SessionEvent,
+  type ToolCall,
+  makeEvent,
+  plainText,
+  textContent,
+} from "./events";
+import type { Job } from "./queue";
+import { nextAction } from "./reducer";
+import { ErrConflict, EventStore } from "./store";
+
+// ---------------------------------------------------------------------------
+// buildContext — log → provider messages
+// ---------------------------------------------------------------------------
+/** Rebuild the provider message list from the log. The system prompt comes from the
+ *  PINNED agent version on the session row, never the agent's current latest. Bookkeeping
+ *  events (turn_completed / turn_failed / session_provisioned) are skipped — they are not
+ *  conversation. This is the sole producer of ChatMessage[]; never replay a raw response. */
+export function buildContext(events: SessionEvent[], systemPrompt: string): ChatMessage[] {
+  const messages: ChatMessage[] = [{ role: "system", content: systemPrompt }];
+  for (const e of events) {
+    switch (e.type) {
+      case "user_message": {
+        const p = e.payload as EventPayload<"user_message">;
+        messages.push({ role: "user", content: plainText(p.content) });
+        break;
+      }
+      case "assistant_message": {
+        const p = e.payload as EventPayload<"assistant_message">;
+        messages.push({
+          role: "assistant",
+          content: plainText(p.content),
+          // v1 cap: at most one call; buildContext mirrors what the log recorded.
+          ...(p.tool_calls[0] ? { toolCall: p.tool_calls[0] } : {}),
+        });
+        break;
+      }
+      case "tool_result": {
+        const p = e.payload as EventPayload<"tool_result">;
+        messages.push({ role: "tool", idemKey: p.idem_key, output: p.output, exitCode: p.exit_code });
+        break;
+      }
+      // turn_completed / turn_failed / session_provisioned → skipped (bookkeeping).
+    }
+  }
+  return messages;
+}
+
+// ---------------------------------------------------------------------------
+// runTurn — perform the action, append, repeat
+// ---------------------------------------------------------------------------
+export type TurnDeps = {
+  store: EventStore;
+  llm: LlmPort;
+  sandbox: SandboxDriver;
+  db: Db; // for reading session + agent version rows
+};
+
+export type TurnOutcome =
+  | "completed" // the agent finished → worker ACKs
+  | "failed" // turn_failed appended → worker ACKs (a recorded failure IS a success from
+  //           the queue's perspective; the user sees the failure event)
+  | "conflict" // another worker owns this turn → worker ACKs silently
+  | "abandoned" // session archived/failed → worker ACKs
+  | "retry_later"; // sandbox still provisioning, or a transient failure → worker NACKs
+
+export async function runTurn(job: Job, deps: TurnDeps): Promise<TurnOutcome> {
+  const ns = job.namespace;
+  const sessionId = job.sessionId;
+  // The queue already incremented attempts on claim; this is the last delivery once it
+  // reaches maxAttempts. On the last attempt a would-be retry_later must instead be
+  // recorded as a terminal turn_failed, so a broken sandbox never hangs the session.
+  const lastAttempt = job.attempts >= job.maxAttempts;
+
+  // 1. Session gate.
+  const session = await loadSession(deps.db, ns, sessionId);
+  if (!session) return "abandoned"; // no such session in this namespace — nothing to drive
+  if (session.status === "provisioning") return "retry_later"; // backoff waits; do NOT block
+  if (session.status === "failed" || session.status === "archived") return "abandoned";
+
+  // 2. The PINNED agent version → system prompt, model, iteration budget.
+  const version = await loadAgentVersion(deps.db, session.agentConfigId, session.agentVersion);
+  if (!version) return "abandoned"; // pinned version vanished — nothing coherent to run
+  const systemPrompt = version.systemPrompt;
+  const model = version.model;
+  const maxIterations = readMaxIterations(version.toolPolicy);
+
+  // 3. The log IS the state. Read once; keep it current in memory (never re-read per loop).
+  const events = await deps.store.readEvents(ns, sessionId);
+  let handle = (session.sandboxHandle ?? null) as SandboxHandle | null;
+
+  // Append at lastSeq+1 and mirror the row into `events` so the loop reflects reality
+  // without another DB round-trip. A lost (session_id, seq) race surfaces as ErrConflict.
+  const append = async <T extends EventType>(type: T, payload: EventPayload<T>): Promise<void> => {
+    const seq = (events.at(-1)?.seq ?? 0) + 1;
+    const evt = makeEvent({ sessionId, namespace: ns, seq }, type, payload);
+    await deps.store.appendEvent(ns, sessionId, seq, evt);
+    events.push({ ...evt, createdAt: new Date() });
+  };
+
+  // Record a terminal failure. If even this append loses the seq race, another worker
+  // owns the turn → conflict; a non-conflict failure means we could not record it → retry.
+  const terminalFail = async (
+    errorClass: "LLM_PERMANENT" | "SANDBOX_FATAL" | "INTERNAL",
+    message: string,
+  ): Promise<TurnOutcome> => {
+    try {
+      await append("turn_failed", { error_class: errorClass, message });
+    } catch (e) {
+      if (e instanceof ErrConflict) return "conflict";
+      return "retry_later";
+    }
+    return "failed";
+  };
+
+  // Run one exec. Non-zero exit / timeout(124) / OOM(137) are RESULTS (they carry an exit
+  // code) and are returned, never thrown. Only an unobservable command throws.
+  const runExec = async (executor: Executor, call: ToolCall, idemKey: string) => {
+    const req = {
+      cmd: call.cmd,
+      idemKey,
+      ...(call.timeout_ms !== undefined ? { timeoutMs: call.timeout_ms } : {}),
+    };
+    let output = "";
+    let exitCode = 0;
+    let truncated = false;
+    let sawExit = false;
+    for await (const ev of executor.exec(req)) {
+      if (ev.kind === "exit") {
+        exitCode = ev.code;
+        truncated = ev.truncated;
+        sawExit = true;
+      } else {
+        output += ev.data; // stdout / stderr both fold into combined output
+      }
+    }
+    // A stream that ends without an exit event is unobservable, not a zero exit.
+    if (!sawExit) throw new SandboxUnavailableError("exec stream ended without an exit event");
+    return { output, exitCode, truncated };
+  };
+
+  // Exec with a single reboot on an unobservable sandbox. The same idemKey re-attaches to
+  // a still-running command or re-runs it safely, so nothing runs twice. A second failure
+  // propagates to the error policy below.
+  const execWithReboot = async (call: ToolCall, idemKey: string) => {
+    if (!handle) throw new SandboxUnavailableError("session has no sandbox handle");
+    try {
+      return await runExec(deps.sandbox.connect(handle), call, idemKey);
+    } catch (err) {
+      if (!(err instanceof SandboxUnavailableError)) throw err;
+      handle = await deps.sandbox.reboot(handle); // persistent FS survives the reboot
+      await persistHandle(deps.db, ns, sessionId, handle);
+      return await runExec(deps.sandbox.connect(handle), call, idemKey);
+    }
+  };
+
+  try {
+    for (;;) {
+      const action = nextAction(events, maxIterations);
+      switch (action.kind) {
+        case "noop":
+          return "completed"; // redelivery of finished work — silent ack
+        case "finish":
+          await append("turn_completed", {});
+          return "completed";
+        case "fail":
+          await append("turn_failed", {
+            error_class: "BUDGET",
+            message: `iteration budget exhausted (max_iterations=${maxIterations})`,
+          });
+          return "failed";
+        case "infer": {
+          const result = await deps.llm.complete({
+            model,
+            messages: buildContext(events, systemPrompt),
+            trace: { sessionId },
+          });
+          await append("assistant_message", {
+            content: textContent(result.content),
+            tool_calls: result.toolCall ? [result.toolCall] : [],
+            usage: {
+              input_tokens: result.usage.inputTokens,
+              output_tokens: result.usage.outputTokens,
+            },
+          });
+          break;
+        }
+        case "exec_tool": {
+          const res = await execWithReboot(action.call, action.idemKey);
+          await append("tool_result", {
+            idem_key: action.idemKey,
+            output: res.output,
+            exit_code: res.exitCode, // a non-zero exit is a result the model reacts to
+            truncated: res.truncated,
+          });
+          break;
+        }
+      }
+    }
+  } catch (err) {
+    // Error policy. A command that ran and failed never reaches here — that's a result.
+    if (err instanceof ErrConflict) return "conflict"; // someone else owns this turn
+    if (err instanceof LlmPermanentError) return terminalFail("LLM_PERMANENT", err.message);
+    if (err instanceof LlmTransientError) {
+      // Escaped the driver's retries. Append nothing; the queue's backoff replays the log.
+      return lastAttempt ? terminalFail("INTERNAL", `llm transient: ${err.message}`) : "retry_later";
+    }
+    if (err instanceof SandboxUnavailableError) {
+      return lastAttempt ? terminalFail("SANDBOX_FATAL", err.message) : "retry_later";
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return lastAttempt ? terminalFail("INTERNAL", message) : "retry_later";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Row access — every query scoped by namespace.
+// ---------------------------------------------------------------------------
+type SessionRow = typeof sessions.$inferSelect;
+type VersionRow = typeof agentConfigVersions.$inferSelect;
+
+async function loadSession(db: Db, ns: string, sessionId: string): Promise<SessionRow | undefined> {
+  const [row] = await db
+    .select()
+    .from(sessions)
+    .where(and(eq(sessions.namespace, ns), eq(sessions.id, sessionId)))
+    .limit(1);
+  return row;
+}
+
+async function loadAgentVersion(
+  db: Db,
+  agentConfigId: string,
+  version: number,
+): Promise<VersionRow | undefined> {
+  const [row] = await db
+    .select()
+    .from(agentConfigVersions)
+    .where(
+      and(
+        eq(agentConfigVersions.agentConfigId, agentConfigId),
+        eq(agentConfigVersions.version, version),
+      ),
+    )
+    .limit(1);
+  return row;
+}
+
+async function persistHandle(
+  db: Db,
+  ns: string,
+  sessionId: string,
+  handle: SandboxHandle,
+): Promise<void> {
+  await db
+    .update(sessions)
+    .set({ sandboxHandle: handle, updatedAt: new Date() })
+    .where(and(eq(sessions.namespace, ns), eq(sessions.id, sessionId)));
+}
+
+/** The spigot that stops a buggy agent looping forever against a paid LLM API.
+ *  `tool_policy.max_iterations`, default 20. */
+function readMaxIterations(toolPolicy: Record<string, unknown>): number {
+  const v = toolPolicy["max_iterations"];
+  return typeof v === "number" && Number.isInteger(v) && v > 0 ? v : 20;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,12 @@ importers:
       '@funky/db':
         specifier: workspace:*
         version: link:../db
+      '@funky/llm':
+        specifier: workspace:*
+        version: link:../ports/llm
+      '@funky/sandbox':
+        specifier: workspace:*
+        version: link:../ports/sandbox
       drizzle-orm:
         specifier: ^1.0.0-beta.2
         version: 1.0.0-rc.4-5d5b77c(@electric-sql/pglite@0.5.4)(@types/pg@8.20.0)(pg@8.22.0)(zod@4.4.3)


### PR DESCRIPTION
Adds the heart of Funky in `@funky/sessions`: a pure `reducer.ts` that folds the event log to the single next action (with exec idem-keys derived from log position), a `turn.ts` with `buildContext` (the sole source of provider messages, system prompt pinned from the session's agent version) and `runTurn` (read the log once, perform the action, append, repeat) implementing the full error policy, and `provision.ts` that snapshots the env config and readies the sandbox in one transaction. Because every step is a log row before the next begins, crash-resume is the normal code path rather than a special case — the error policy also guarantees every turn ends in a terminal event or a live retry, so a session never hangs. Wires `@funky/llm` and `@funky/sandbox` into the package and exports the new surface. Tests cover the pure reducer (including the resume property over every log prefix) and the turn/provision loop against `FakeLlm` + the subprocess sandbox + testcontainers Postgres, including the crash-resume proof that a command runs exactly once. Full workspace suite and typecheck are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)