### PR TITLE
Phase E: the worker (apps/worker)

### DIFF
--- a/apps/worker/.gitignore
+++ b/apps/worker/.gitignore
@@ -1,0 +1,31 @@
+# dev
+.yarn/
+!.yarn/releases
+.vscode/*
+!.vscode/launch.json
+!.vscode/*.code-snippets
+.idea/workspace.xml
+.idea/usage.statistics.xml
+.idea/shelf
+
+# deps
+node_modules/
+
+# build
+dist/
+
+# env
+.env
+.env.production
+
+# logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# misc
+.DS_Store

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.build.json",
+    "start": "node dist/index.js",
+    "start:src": "tsx src/index.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@funky/db": "workspace:*",
+    "@funky/llm": "workspace:*",
+    "@funky/sandbox": "workspace:*",
+    "@funky/sessions": "workspace:*",
+    "dotenv": "^17.2.0",
+    "pg": "^8.16.0",
+    "uuid": "^13.0.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@testcontainers/postgresql": "^12.0.4",
+    "@types/node": "^22.0.0",
+    "@types/pg": "^8.11.0",
+    "tsx": "^4.7.1",
+    "typescript": "^5.8.3",
+    "vitest": "^4.1.10"
+  }
+}

--- a/apps/worker/src/config.ts
+++ b/apps/worker/src/config.ts
@@ -1,0 +1,55 @@
+// apps/worker/src/config.ts
+// The only place process.env is read. dotenv is loaded by index.ts (entrypoint), not here.
+// Mirrors apps/api/src/config.ts: zod, fail-fast via process.exit(1); never boot half-configured.
+import { z } from "zod";
+
+const EnvSchema = z
+  .object({
+    DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
+    FUNKY_WORKER_CONCURRENCY: z.coerce.number().int().min(1).default(50),
+    FUNKY_WORKER_HEALTH_PORT: z.coerce.number().int().min(1).max(65535).default(9090),
+    FUNKY_LLM: z.enum(["fake", "ai-sdk"]).default("fake"),
+    FUNKY_SANDBOX: z.enum(["subprocess"]).default("subprocess"),
+    // Required ONLY when FUNKY_LLM=ai-sdk (the fake driver makes no network calls).
+    ANTHROPIC_API_KEY: z.string().min(1).optional(),
+    DB_POOL_MAX: z.coerce.number().int().min(1).default(10),
+  })
+  .refine((e) => e.FUNKY_LLM !== "ai-sdk" || e.ANTHROPIC_API_KEY !== undefined, {
+    message:
+      "ANTHROPIC_API_KEY is required when FUNKY_LLM=ai-sdk. " +
+      "Set it, or leave FUNKY_LLM=fake for local development.",
+    path: ["ANTHROPIC_API_KEY"],
+  });
+
+export type Config = {
+  databaseUrl: string;
+  concurrency: number;
+  healthPort: number;
+  llm: "fake" | "ai-sdk";
+  sandbox: "subprocess";
+  /** null = fake driver; no key needed. */
+  anthropicApiKey: string | null;
+  dbPoolMax: number;
+};
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
+  const parsed = EnvSchema.safeParse(env);
+  if (!parsed.success) {
+    // Fail fast with a readable message; never boot half-configured.
+    const issues = parsed.error.issues
+      .map((i) => `  - ${i.path.join(".") || "env"}: ${i.message}`)
+      .join("\n");
+    console.error(`funky-worker: invalid configuration:\n${issues}`);
+    process.exit(1);
+  }
+  const e = parsed.data;
+  return {
+    databaseUrl: e.DATABASE_URL,
+    concurrency: e.FUNKY_WORKER_CONCURRENCY,
+    healthPort: e.FUNKY_WORKER_HEALTH_PORT,
+    llm: e.FUNKY_LLM,
+    sandbox: e.FUNKY_SANDBOX,
+    anthropicApiKey: e.ANTHROPIC_API_KEY ?? null,
+    dbPoolMax: e.DB_POOL_MAX,
+  };
+}

--- a/apps/worker/src/health.ts
+++ b/apps/worker/src/health.ts
@@ -1,0 +1,108 @@
+// apps/worker/src/health.ts — Phase E: liveness probe + Prometheus metrics.
+//
+// Plain node:http — NO Hono. This is plumbing, not an API. There is no readiness concept
+// for a worker: nothing routes to it, so /healthz is liveness only (a SELECT 1).
+
+import { createServer, type ServerResponse } from "node:http";
+import type { Metrics } from "./worker";
+
+export type QueueDepth = { queued: number; running: number; dead: number };
+
+export type HealthDeps = {
+  port: number;
+  ping: () => Promise<unknown>; // SELECT 1 — liveness only
+  metrics: Metrics;
+  depth: () => Promise<QueueDepth>; // queue.depth() — the autoscaling signal
+};
+
+export type HealthServer = {
+  readonly port: number;
+  close(): Promise<void>;
+};
+
+export function startHealthServer(deps: HealthDeps): Promise<HealthServer> {
+  const server = createServer((req, res) => {
+    const path = (req.url ?? "/").split("?")[0];
+    if (req.method !== "GET") return sendJson(res, 405, { error: "method not allowed" });
+
+    if (path === "/healthz") {
+      deps
+        .ping()
+        .then(() => sendJson(res, 200, { status: "ok" }))
+        .catch(() => sendJson(res, 503, { status: "error" }));
+      return;
+    }
+    if (path === "/metrics") {
+      // Never let a transient depth() failure blank the worker's own counters.
+      deps
+        .depth()
+        .then((d) => sendText(res, 200, renderPrometheus(deps.metrics, d)))
+        .catch(() => sendText(res, 200, renderPrometheus(deps.metrics, null)));
+      return;
+    }
+    sendJson(res, 404, { error: "not found" });
+  });
+
+  return new Promise((resolve, reject) => {
+    const onError = (err: Error) => reject(err);
+    server.once("error", onError);
+    server.listen(deps.port, () => {
+      server.removeListener("error", onError);
+      const addr = server.address();
+      const port = addr && typeof addr === "object" ? addr.port : deps.port;
+      resolve({
+        port,
+        close: () => new Promise<void>((res) => server.close(() => res())),
+      });
+    });
+  });
+}
+
+/** Render the minimum metric set in Prometheus text format. depth === null when the
+ *  queue.depth() probe failed — the worker's own counters still render. */
+export function renderPrometheus(metrics: Metrics, depth: QueueDepth | null): string {
+  const lines: string[] = [];
+  const family = (name: string, type: string, help: string, samples: string[]) => {
+    lines.push(`# HELP ${name} ${help}`, `# TYPE ${name} ${type}`, ...samples);
+  };
+
+  family("funky_worker_turns_inflight", "gauge", "Turns currently in flight.", [
+    `funky_worker_turns_inflight ${metrics.inFlight}`,
+  ]);
+
+  family(
+    "funky_worker_jobs_total",
+    "counter",
+    "Jobs processed, by queue outcome.",
+    (Object.keys(metrics.jobs) as Array<keyof Metrics["jobs"]>).map(
+      (outcome) => `funky_worker_jobs_total{outcome="${outcome}"} ${metrics.jobs[outcome]}`,
+    ),
+  );
+
+  family(
+    "funky_worker_append_conflicts_total",
+    "counter",
+    "Conditional-append races lost to another worker (split-brain smoke detector).",
+    [`funky_worker_append_conflicts_total ${metrics.appendConflicts}`],
+  );
+
+  if (depth) {
+    family("funky_queue_depth", "gauge", "Jobs in the queue by state (autoscaling signal).", [
+      `funky_queue_depth{state="queued"} ${depth.queued}`,
+      `funky_queue_depth{state="running"} ${depth.running}`,
+      `funky_queue_depth{state="dead"} ${depth.dead}`,
+    ]);
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+function sendText(res: ServerResponse, status: number, body: string): void {
+  res.writeHead(status, { "content-type": "text/plain; version=0.0.4; charset=utf-8" });
+  res.end(body);
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,0 +1,82 @@
+// apps/worker/src/index.ts — the ONLY file that touches process.env or the network.
+import "dotenv/config"; // dev convenience; production containers inject env directly
+import { config } from "dotenv";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client, Pool } from "pg";
+import { createDb } from "@funky/db";
+import { FakeLlm, type LlmConfig, makeLlm } from "@funky/llm";
+import { makeSandbox } from "@funky/sandbox";
+import { EventStore, JobQueue } from "@funky/sessions";
+import { type Config, loadConfig } from "./config";
+import { startHealthServer } from "./health";
+import { createMetrics, startWorker } from "./worker";
+
+// repo root .env, resolved from this file's location (cwd-independent), like apps/api.
+config({ path: resolve(dirname(fileURLToPath(import.meta.url)), "../../../.env") });
+
+const cfg = loadConfig();
+
+const pool = new Pool({ connectionString: cfg.databaseUrl, max: cfg.dbPoolMax });
+const db = createDb(pool);
+const queue = new JobQueue(db);
+const store = new EventStore(db);
+const metrics = createMetrics();
+
+// DEDICATED client for LISTEN — never a pooled connection (it gets recycled and the
+// listener silently goes deaf, with no error).
+const listenClient = new Client({ connectionString: cfg.databaseUrl });
+await listenClient.connect();
+
+const worker = startWorker({
+  queue,
+  store,
+  llm: makeLlm(llmConfig(cfg)), // fake by default — no API key needed
+  sandbox: makeSandbox({ driver: cfg.sandbox }), // subprocess
+  db,
+  listenClient,
+  concurrency: cfg.concurrency,
+  metrics,
+});
+
+const health = await startHealthServer({
+  port: cfg.healthPort,
+  ping: () => pool.query("SELECT 1"),
+  metrics,
+  depth: () => queue.depth(),
+});
+
+console.log(
+  `funky-worker: concurrency=${cfg.concurrency} health=:${health.port} ` +
+    `llm=${cfg.llm} sandbox=${cfg.sandbox}`,
+);
+
+// The fake driver needs no API key: with an empty script every session's turn resolves to a
+// single terminal assistant message. Real work uses FUNKY_LLM=ai-sdk.
+function llmConfig(c: Config): LlmConfig {
+  return c.llm === "ai-sdk"
+    ? { driver: "ai-sdk" }
+    : { driver: "fake", instance: new FakeLlm({ scripts: {} }) };
+}
+
+// Shutdown: drain, don't kill. Stop pulling, let in-flight turns finish, then release
+// resources. Draining is an optimization, not a correctness requirement — a SIGKILLed
+// worker simply leaves its leases to expire and another worker resumes from the log.
+let shuttingDown = false;
+async function shutdown(sig: string): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`funky-worker: ${sig} received, draining`);
+  // safety net: if drain hasn't finished in 120s, exit anyway.
+  setTimeout(() => process.exit(1), 120_000).unref();
+  await worker.stop();
+  await health.close();
+  await listenClient.end();
+  await pool.end();
+  process.exit(0);
+}
+
+process.on("SIGTERM", () => void shutdown("SIGTERM"));
+process.on("SIGINT", () => void shutdown("SIGINT"));
+// handle(job) is not awaited, so an unexpected throw must be logged, never fatal.
+process.on("unhandledRejection", (reason) => console.error("[worker] unhandledRejection", reason));

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -1,0 +1,198 @@
+// apps/worker/src/worker.ts — Phase E: the turn loop.
+//
+// A worker is a `while (!draining)` loop around the queue. It calls out and takes work; it
+// has no routes and nothing can address it. All the intelligence lives in @funky/sessions
+// (runTurn / runProvision) — this file is pure lifecycle: pull, concurrency, heartbeat,
+// drain. It holds NO in-memory session state: every meaningful step of a turn is already a
+// row in session_events before the next begins, so killing a worker mid-turn loses nothing.
+//
+// startWorker returns handles rather than doing work at import time, so the loop is
+// startable and stoppable in-process (the Phase H chaos suite runs workers inside vitest
+// and kills them at arbitrary points).
+
+import type { Client } from "pg";
+import type { Db } from "@funky/db";
+import type { LlmPort } from "@funky/llm";
+import type { SandboxDriver } from "@funky/sandbox";
+import {
+  type EventStore,
+  HEARTBEAT_MS,
+  type Job,
+  type JobQueue,
+  POLL_INTERVAL_MS,
+  onWake,
+  runProvision,
+  runTurn,
+  type TurnOutcome,
+} from "@funky/sessions";
+
+export type WorkerDeps = {
+  queue: JobQueue;
+  store: EventStore;
+  llm: LlmPort;
+  sandbox: SandboxDriver;
+  db: Db;
+  listenClient: Client; // DEDICATED client for LISTEN (never from the pool)
+  concurrency: number; // FUNKY_WORKER_CONCURRENCY
+  metrics: Metrics; // counters; see health.ts
+  /** Test seam: override the heartbeat interval. Defaults to HEARTBEAT_MS (15s). */
+  heartbeatMs?: number;
+};
+
+export type WorkerHandle = {
+  /** Graceful: stop pulling, let in-flight turns finish, resolve when idle. */
+  stop(): Promise<void>;
+  /** Ungraceful: abandon everything immediately (simulates SIGKILL). Tests use this. */
+  kill(): void;
+};
+
+/** Mutable counters shared with health.ts. `inFlight` is the concurrency dial observed;
+ *  `jobs` is incremented by queue outcome; `appendConflicts` is the split-brain detector. */
+export type Metrics = {
+  inFlight: number;
+  jobs: Record<TurnOutcome, number>;
+  appendConflicts: number;
+};
+
+export function createMetrics(): Metrics {
+  return {
+    inFlight: 0,
+    jobs: { completed: 0, failed: 0, conflict: 0, abandoned: 0, retry_later: 0 },
+    appendConflicts: 0,
+  };
+}
+
+const log = (...args: unknown[]) => console.error("[worker]", ...args);
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+export function startWorker(deps: WorkerDeps): WorkerHandle {
+  const { queue, metrics, concurrency } = deps;
+  const heartbeatMs = deps.heartbeatMs ?? HEARTBEAT_MS;
+  // The subset the domain loop needs. runTurn/runProvision must not touch the queue or the
+  // listen client — those are lifecycle concerns owned here.
+  const turnDeps = { store: deps.store, llm: deps.llm, sandbox: deps.sandbox, db: deps.db };
+
+  let inFlight = 0;
+  let draining = false;
+  let killed = false;
+  const heartbeats = new Set<ReturnType<typeof setInterval>>();
+
+  // --- wake coordination: idle until a NOTIFY or the fallback poll, whichever is first ---
+  let woken = false;
+  let wakeResolve: (() => void) | null = null;
+  const signalWake = () => {
+    woken = true;
+    const r = wakeResolve;
+    wakeResolve = null;
+    r?.();
+  };
+  // Dedicated client, never a pooled one (a recycled connection goes silently deaf).
+  void onWake(deps.listenClient, signalWake).catch((err) => log("listen failed", err));
+
+  const waitForWakeOrTimeout = (ms: number): Promise<void> => {
+    if (woken) {
+      woken = false;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        wakeResolve = null;
+        resolve();
+      }, ms);
+      timer.unref?.();
+      wakeResolve = () => {
+        clearTimeout(timer);
+        woken = false;
+        resolve();
+      };
+    });
+  };
+
+  const setInFlight = (n: number) => {
+    inFlight = n;
+    metrics.inFlight = n;
+  };
+
+  // handle(job) is NOT awaited by the loop — that is the whole point. The heartbeat pushes
+  // the lease out every heartbeatMs while the turn runs; if it fails and the job is stolen,
+  // nothing breaks — the conditional append (ErrConflict) stops the loser from writing.
+  const handle = async (job: Job): Promise<void> => {
+    const beat = setInterval(() => {
+      queue.extendLease(job.id).catch((err) => log("heartbeat failed", job.id, err));
+    }, heartbeatMs);
+    heartbeats.add(beat);
+    try {
+      const outcome: TurnOutcome =
+        job.kind === "provision" ? await runProvision(job, turnDeps) : await runTurn(job, turnDeps);
+      if (killed) return; // abandoned by kill(): leave the lease to expire; another worker resumes
+      metrics.jobs[outcome] += 1;
+      switch (outcome) {
+        case "completed":
+        case "failed": // a recorded turn_failed IS a completed piece of work — ack, never nack
+        case "abandoned":
+          await queue.ack(job.id);
+          break;
+        case "conflict":
+          metrics.appendConflicts += 1; // another worker owns it — count it, do NOT log an error
+          await queue.ack(job.id);
+          break;
+        case "retry_later":
+          await queue.nack(job.id); // backoff; the queue owns retry scheduling
+          break;
+      }
+    } catch (err) {
+      if (killed) return;
+      log("turn threw (nacking)", job.id, err); // runTurn shouldn't throw, but be safe
+      await queue.nack(job.id).catch((e) => log("nack failed", job.id, e));
+    } finally {
+      clearInterval(beat);
+      heartbeats.delete(beat);
+    }
+  };
+
+  const run = async (): Promise<void> => {
+    for (;;) {
+      if (draining || killed) return;
+      if (inFlight >= concurrency) {
+        await sleep(50); // backpressure: only pull when under the limit
+        continue;
+      }
+      let job: Job | null;
+      try {
+        job = await queue.pull();
+      } catch (err) {
+        log("pull failed", err);
+        await sleep(POLL_INTERVAL_MS);
+        continue;
+      }
+      if (!job) {
+        await waitForWakeOrTimeout(POLL_INTERVAL_MS);
+        continue;
+      }
+      if (draining || killed) return; // shutting down between pull and dispatch — let the lease expire
+      setInFlight(inFlight + 1);
+      void handle(job).finally(() => setInFlight(inFlight - 1));
+    }
+  };
+  const loopDone = run();
+
+  return {
+    async stop() {
+      draining = true;
+      signalWake(); // break any in-progress idle wait so the loop exits promptly
+      await loopDone; // no more pulls
+      // In-flight turns keep their leases alive via heartbeat while they finish.
+      while (inFlight > 0) await sleep(25);
+    },
+    kill() {
+      killed = true;
+      draining = true;
+      signalWake();
+      // Stop heartbeats so the abandoned jobs' leases expire and another worker reclaims
+      // them. In-flight turn promises can't be force-cancelled, but the conditional append
+      // makes any late write from this worker a harmless ErrConflict.
+      for (const beat of heartbeats) clearInterval(beat);
+      heartbeats.clear();
+    },
+  };
+}

--- a/apps/worker/test/config.test.ts
+++ b/apps/worker/test/config.test.ts
@@ -1,0 +1,73 @@
+// loadConfig(env) is the single place env is parsed. It fails fast via process.exit(1);
+// tests stub exit so the failure path is observable. Mirrors apps/api/test/config.test.ts.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadConfig } from "../src/config";
+
+const BASE = { DATABASE_URL: "postgres://funky:funky@localhost:5432/funky" };
+
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new Error(`process.exit(${code})`);
+  }) as never);
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("loadConfig — valid input", () => {
+  it("applies defaults for a minimal environment", () => {
+    const cfg = loadConfig(BASE);
+    expect(cfg).toEqual({
+      databaseUrl: BASE.DATABASE_URL,
+      concurrency: 50,
+      healthPort: 9090,
+      llm: "fake",
+      sandbox: "subprocess",
+      anthropicApiKey: null,
+      dbPoolMax: 10,
+    });
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("parses a fully-specified environment", () => {
+    const cfg = loadConfig({
+      ...BASE,
+      FUNKY_WORKER_CONCURRENCY: "8",
+      FUNKY_WORKER_HEALTH_PORT: "9191",
+      DB_POOL_MAX: "25",
+      FUNKY_LLM: "ai-sdk",
+      ANTHROPIC_API_KEY: "sk-ant-secret",
+    });
+    expect(cfg).toEqual({
+      databaseUrl: BASE.DATABASE_URL,
+      concurrency: 8,
+      healthPort: 9191,
+      llm: "ai-sdk",
+      sandbox: "subprocess",
+      anthropicApiKey: "sk-ant-secret",
+      dbPoolMax: 25,
+    });
+  });
+});
+
+describe("loadConfig — invalid input exits the process", () => {
+  it.each([
+    ["missing DATABASE_URL", {}],
+    ["empty DATABASE_URL", { DATABASE_URL: "" }],
+    ["ai-sdk without ANTHROPIC_API_KEY", { ...BASE, FUNKY_LLM: "ai-sdk" }],
+    ["concurrency below 1", { ...BASE, FUNKY_WORKER_CONCURRENCY: "0" }],
+    ["concurrency not a number", { ...BASE, FUNKY_WORKER_CONCURRENCY: "lots" }],
+    ["health port out of range", { ...BASE, FUNKY_WORKER_HEALTH_PORT: "70000" }],
+    ["unknown FUNKY_LLM", { ...BASE, FUNKY_LLM: "gpt" }],
+    ["unknown FUNKY_SANDBOX", { ...BASE, FUNKY_SANDBOX: "docker" }],
+    ["DB_POOL_MAX below 1", { ...BASE, DB_POOL_MAX: "0" }],
+  ])("exits on %s", (_label, env) => {
+    expect(() => loadConfig(env as NodeJS.ProcessEnv)).toThrow("process.exit(1)");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/apps/worker/test/health.test.ts
+++ b/apps/worker/test/health.test.ts
@@ -1,0 +1,95 @@
+// health.ts is plumbing: a plain node:http server + a pure Prometheus renderer. No DB here
+// — the renderer is exercised directly, and the server with fake ping/depth probes.
+import { afterEach, describe, expect, it } from "vitest";
+import { type HealthServer, renderPrometheus, startHealthServer } from "../src/health";
+import { createMetrics } from "../src/worker";
+
+const okDepth = async () => ({ queued: 0, running: 0, dead: 0 });
+
+describe("renderPrometheus", () => {
+  it("emits every required metric family", () => {
+    const m = createMetrics();
+    m.inFlight = 3;
+    m.jobs.completed = 10;
+    m.jobs.retry_later = 2;
+    m.appendConflicts = 1;
+    const out = renderPrometheus(m, { queued: 4, running: 3, dead: 0 });
+
+    expect(out).toContain("# TYPE funky_worker_turns_inflight gauge");
+    expect(out).toContain("funky_worker_turns_inflight 3");
+    expect(out).toContain("# TYPE funky_worker_jobs_total counter");
+    expect(out).toContain('funky_worker_jobs_total{outcome="completed"} 10');
+    expect(out).toContain('funky_worker_jobs_total{outcome="retry_later"} 2');
+    expect(out).toContain('funky_worker_jobs_total{outcome="conflict"} 0');
+    expect(out).toContain("funky_worker_append_conflicts_total 1");
+    expect(out).toContain('funky_queue_depth{state="queued"} 4');
+    expect(out).toContain('funky_queue_depth{state="running"} 3');
+  });
+
+  it("omits queue depth when the probe is unavailable", () => {
+    const out = renderPrometheus(createMetrics(), null);
+    expect(out).not.toContain("funky_queue_depth");
+    expect(out).toContain("funky_worker_turns_inflight 0");
+  });
+});
+
+describe("health server", () => {
+  let server: HealthServer | undefined;
+  afterEach(async () => {
+    await server?.close();
+    server = undefined;
+  });
+
+  it("returns 200 {status:ok} on /healthz when ping resolves", async () => {
+    server = await startHealthServer({
+      port: 0,
+      ping: async () => 1,
+      metrics: createMetrics(),
+      depth: okDepth,
+    });
+    const res = await fetch(`http://localhost:${server.port}/healthz`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "ok" });
+  });
+
+  it("returns 503 on /healthz when ping rejects", async () => {
+    server = await startHealthServer({
+      port: 0,
+      ping: async () => {
+        throw new Error("db down");
+      },
+      metrics: createMetrics(),
+      depth: okDepth,
+    });
+    const res = await fetch(`http://localhost:${server.port}/healthz`);
+    expect(res.status).toBe(503);
+  });
+
+  it("serves /metrics as Prometheus text", async () => {
+    const m = createMetrics();
+    m.inFlight = 2;
+    server = await startHealthServer({
+      port: 0,
+      ping: async () => 1,
+      metrics: m,
+      depth: async () => ({ queued: 5, running: 2, dead: 1 }),
+    });
+    const res = await fetch(`http://localhost:${server.port}/metrics`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/plain");
+    const body = await res.text();
+    expect(body).toContain("funky_worker_turns_inflight 2");
+    expect(body).toContain('funky_queue_depth{state="dead"} 1');
+  });
+
+  it("404s unknown paths", async () => {
+    server = await startHealthServer({
+      port: 0,
+      ping: async () => 1,
+      metrics: createMetrics(),
+      depth: okDepth,
+    });
+    const res = await fetch(`http://localhost:${server.port}/nope`);
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/worker/test/worker.test.ts
+++ b/apps/worker/test/worker.test.ts
@@ -1,0 +1,484 @@
+// apps/worker/test/worker.test.ts — Phase E integration tests.
+//
+// The worker's whole job is lifecycle over a REAL Postgres queue: FOR UPDATE SKIP LOCKED
+// claims, LISTEN/NOTIFY wake-ups, lease heartbeats, crash-resume via the conditional append.
+// None of that is observable on a single-connection engine, so these run against
+// testcontainers Postgres with the real subprocess sandbox and scripted LLMs.
+//
+// One container serves the file; each test truncates the log + queue and stops any worker
+// it started (pull()/depth() are global — a leaked worker would steal the next test's jobs).
+
+import { randomUUID } from "node:crypto";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  PostgreSqlContainer,
+  type StartedPostgreSqlContainer,
+} from "@testcontainers/postgresql";
+import { Client, Pool } from "pg";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDb, type Db } from "@funky/db";
+import type { JobKind } from "@funky/db/schema";
+import type { LlmPort } from "@funky/llm";
+import { FakeLlm } from "@funky/llm";
+import { type SandboxDriver, SubprocessDriver } from "@funky/sandbox";
+import { EventStore, JobQueue, makeEvent, textContent } from "@funky/sessions";
+import { createMetrics, startWorker, type WorkerHandle } from "../src/worker";
+
+// testcontainers' Ryuk reaper pulls its own image; disable it and rely on afterAll.
+process.env.TESTCONTAINERS_RYUK_DISABLED ??= "true";
+
+const migrationsDir = fileURLToPath(new URL("../../../packages/db/migrations", import.meta.url));
+
+let container: StartedPostgreSqlContainer;
+let connectionUri: string;
+let pool: Pool;
+let db: Db;
+let store: EventStore;
+let queue: JobQueue;
+
+const realSandbox: SandboxDriver = new SubprocessDriver();
+
+const NS = "test-ns";
+const agentConfigId = randomUUID();
+const envConfigId = randomUUID();
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer("postgres:16").start();
+  connectionUri = container.getConnectionUri();
+  pool = new Pool({ connectionString: connectionUri, max: 20 });
+
+  for (const dir of readdirSync(migrationsDir).sort()) {
+    await pool.query(readFileSync(join(migrationsDir, dir, "migration.sql"), "utf8"));
+  }
+  await pool.query("insert into agent_configs (id, namespace, name) values ($1,$2,$3)", [
+    agentConfigId,
+    NS,
+    "test-agent",
+  ]);
+  // runTurn reads the PINNED agent version for the system prompt + model + budget.
+  await pool.query(
+    `insert into agent_config_versions (agent_config_id, version, namespace, system_prompt, model)
+     values ($1, 1, $2, $3, $4::jsonb)`,
+    [agentConfigId, NS, "You are a test agent.", JSON.stringify({ provider: "anthropic", model: "claude-sonnet-5" })],
+  );
+  await pool.query(
+    "insert into env_configs (id, namespace, name, base_image) values ($1,$2,$3,$4)",
+    [envConfigId, NS, "test-env", "funky/base:latest"],
+  );
+
+  db = createDb(pool);
+  store = new EventStore(db);
+  queue = new JobQueue(db);
+}, 180_000);
+
+afterAll(async () => {
+  await pool?.end();
+  await container?.stop();
+});
+
+// Workers started in a test register a cleanup here; afterEach kills them before truncating.
+const cleanups: Array<() => Promise<void> | void> = [];
+
+beforeEach(async () => {
+  await pool.query("truncate table session_events, turn_jobs, sessions cascade");
+});
+
+afterEach(async () => {
+  for (const c of cleanups.splice(0)) await c();
+  await sleep(25); // let any in-flight pull settle before the next truncate
+});
+
+// ------------------------------------------------------------------- helpers
+
+async function startTestWorker(opts: {
+  llm: LlmPort;
+  sandbox?: SandboxDriver;
+  concurrency?: number;
+  heartbeatMs?: number;
+}): Promise<{ worker: WorkerHandle; metrics: ReturnType<typeof createMetrics> }> {
+  const listenClient = new Client({ connectionString: connectionUri });
+  await listenClient.connect();
+  const metrics = createMetrics();
+  const worker = startWorker({
+    queue,
+    store,
+    db,
+    llm: opts.llm,
+    sandbox: opts.sandbox ?? realSandbox,
+    listenClient,
+    concurrency: opts.concurrency ?? 50,
+    metrics,
+    ...(opts.heartbeatMs !== undefined ? { heartbeatMs: opts.heartbeatMs } : {}),
+  });
+  cleanups.push(async () => {
+    worker.kill();
+    await listenClient.end();
+  });
+  return { worker, metrics };
+}
+
+async function seedSession(opts: { id?: string; status?: string; handle?: unknown } = {}): Promise<string> {
+  const id = opts.id ?? randomUUID();
+  await pool.query(
+    `insert into sessions (id, namespace, agent_config_id, agent_version, env_config_id, status, sandbox_handle)
+     values ($1,$2,$3,$4,$5,$6,$7)`,
+    [id, NS, agentConfigId, 1, envConfigId, opts.status ?? "ready", opts.handle ? JSON.stringify(opts.handle) : null],
+  );
+  return id;
+}
+
+async function appendUser(sessionId: string): Promise<void> {
+  await store.appendEvent(
+    NS,
+    sessionId,
+    1,
+    makeEvent({ sessionId, namespace: NS, seq: 1 }, "user_message", { content: textContent("hi") }),
+  );
+}
+
+async function insertTurnJob(sessionId: string, kind: JobKind = "turn"): Promise<string> {
+  const id = randomUUID();
+  await pool.query("insert into turn_jobs (id, namespace, session_id, kind) values ($1,$2,$3,$4)", [
+    id,
+    NS,
+    sessionId,
+    kind,
+  ]);
+  return id;
+}
+
+async function jobExists(id: string): Promise<boolean> {
+  const { rows } = await pool.query("select 1 from turn_jobs where id=$1", [id]);
+  return rows.length > 0;
+}
+
+async function eventTypes(sessionId: string): Promise<string[]> {
+  return (await store.readEvents(NS, sessionId)).map((e) => e.type);
+}
+
+async function waitFor(
+  cond: () => boolean | Promise<boolean>,
+  timeoutMs = 15_000,
+  label = "condition",
+): Promise<void> {
+  const start = Date.now();
+  for (;;) {
+    if (await cond()) return;
+    if (Date.now() - start > timeoutMs) throw new Error(`timed out waiting for ${label}`);
+    await sleep(10);
+  }
+}
+
+async function depthZero(): Promise<boolean> {
+  const d = await queue.depth();
+  return d.queued + d.running === 0;
+}
+
+/** A no-tool-call LLM: one complete() → the turn ends. Optional per-call latency. */
+function doneLlm(delayMs = 0): LlmPort {
+  return {
+    async complete() {
+      if (delayMs) await sleep(delayMs);
+      return { content: "done", usage: { inputTokens: 1, outputTokens: 1 } };
+    },
+  };
+}
+
+/** An LLM whose complete() blocks until release() is called (keeps a turn in-flight). */
+function deferredLlm(): { llm: LlmPort; release: () => void } {
+  let release!: () => void;
+  const gate = new Promise<void>((r) => {
+    release = r;
+  });
+  return {
+    llm: {
+      async complete() {
+        await gate;
+        return { content: "done", usage: { inputTokens: 1, outputTokens: 1 } };
+      },
+    },
+    release,
+  };
+}
+
+// ==================================================================== tests
+
+it("runs one enqueued turn to completion and acks the job", async () => {
+  const sid = await seedSession();
+  await appendUser(sid);
+  const jobId = await insertTurnJob(sid);
+
+  await startTestWorker({ llm: doneLlm() });
+
+  await waitFor(async () => (await eventTypes(sid)).at(-1) === "turn_completed", 15_000, "completed");
+  expect(await eventTypes(sid)).toEqual(["user_message", "assistant_message", "turn_completed"]);
+  expect(await jobExists(jobId)).toBe(false); // acked → row gone
+});
+
+it("interleaves many turns on one event loop (handle is not awaited)", async () => {
+  // 20 different sessions, a fake LLM that sleeps 200ms. Serial would be ~4s; concurrent
+  // is ~200-400ms. This is the test that catches `await handle(job)` in the loop.
+  const N = 20;
+  const jobIds: string[] = [];
+  for (let i = 0; i < N; i++) {
+    const sid = await seedSession();
+    await appendUser(sid);
+    jobIds.push(await insertTurnJob(sid));
+  }
+
+  const t0 = Date.now();
+  await startTestWorker({ llm: doneLlm(200), concurrency: 50 });
+  await waitFor(depthZero, 15_000, "all turns done");
+  const elapsed = Date.now() - t0;
+
+  expect(elapsed).toBeLessThan(2000); // NOT ~4000ms serial
+  for (const id of jobIds) expect(await jobExists(id)).toBe(false);
+});
+
+it("respects the concurrency limit (backpressure)", async () => {
+  for (let i = 0; i < 10; i++) {
+    const sid = await seedSession();
+    await appendUser(sid);
+    await insertTurnJob(sid);
+  }
+
+  const { metrics } = await startTestWorker({ llm: doneLlm(100), concurrency: 2 });
+  let maxInFlight = 0;
+  const sampler = setInterval(() => {
+    maxInFlight = Math.max(maxInFlight, metrics.inFlight);
+  }, 5);
+  await waitFor(depthZero, 15_000, "all turns done");
+  clearInterval(sampler);
+
+  expect(maxInFlight).toBeGreaterThan(0);
+  expect(maxInFlight).toBeLessThanOrEqual(2); // turns_inflight never exceeds the limit
+});
+
+it("NACKs a retry_later outcome (job stays queued with a future run_at)", async () => {
+  // A provisioning session yields retry_later — backoff waits, the job is NOT dropped.
+  const sid = await seedSession({ status: "provisioning" });
+  await appendUser(sid);
+  const jobId = await insertTurnJob(sid);
+
+  await startTestWorker({ llm: doneLlm() });
+
+  await waitFor(
+    async () => {
+      const { rows } = await pool.query(
+        "select state, lease_expires_at, attempts from turn_jobs where id=$1",
+        [jobId],
+      );
+      const r = rows[0];
+      return Boolean(r) && r.state === "queued" && r.lease_expires_at === null && r.attempts >= 1;
+    },
+    15_000,
+    "nacked",
+  );
+
+  const { rows } = await pool.query(
+    "select state, extract(epoch from (run_at - now())) as delay from turn_jobs where id=$1",
+    [jobId],
+  );
+  expect(rows[0].state).toBe("queued");
+  expect(await jobExists(jobId)).toBe(true); // still in the table — never acked
+  expect(Number(rows[0].delay)).toBeGreaterThan(0.5); // backed off into the future
+});
+
+it("ACKs a conflict silently, counts it, and logs no error", async () => {
+  const sid = await seedSession();
+  await appendUser(sid);
+  const jobId = await insertTurnJob(sid);
+
+  const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  cleanups.push(() => errSpy.mockRestore());
+
+  // The LLM races another worker: it plants the assistant_message at seq 2 before returning,
+  // so the worker's own append loses the (session_id, seq) race → ErrConflict → "conflict".
+  const conflictLlm: LlmPort = {
+    async complete(req) {
+      await pool.query(
+        "insert into session_events (session_id, seq, namespace, type, payload) values ($1, 2, $2, 'assistant_message', $3::jsonb)",
+        [req.trace?.sessionId, NS, JSON.stringify({ content: [], tool_calls: [] })],
+      );
+      return { content: "mine", usage: { inputTokens: 1, outputTokens: 1 } };
+    },
+  };
+
+  const { metrics } = await startTestWorker({ llm: conflictLlm });
+
+  await waitFor(async () => !(await jobExists(jobId)), 15_000, "acked");
+  expect(metrics.jobs.conflict).toBe(1);
+  expect(metrics.appendConflicts).toBe(1);
+  expect(errSpy).not.toHaveBeenCalled(); // a conflict is a normal event, not an error
+});
+
+it("runs a provision job: provisioning → ready + session_provisioned", async () => {
+  const sid = await seedSession({ status: "provisioning" });
+  const jobId = await insertTurnJob(sid, "provision");
+
+  await startTestWorker({ llm: doneLlm() });
+
+  await waitFor(
+    async () => {
+      const { rows } = await pool.query("select status from sessions where id=$1", [sid]);
+      return rows[0]?.status === "ready";
+    },
+    15_000,
+    "provisioned",
+  );
+
+  const { rows } = await pool.query(
+    "select status, resolved_env, sandbox_handle from sessions where id=$1",
+    [sid],
+  );
+  expect(rows[0].status).toBe("ready");
+  expect(rows[0].resolved_env).toBeTruthy();
+  expect(rows[0].sandbox_handle).toBeTruthy();
+  expect(await eventTypes(sid)).toContain("session_provisioned");
+  expect(await jobExists(jobId)).toBe(false);
+});
+
+it("keeps a long-running turn's lease fresh via the heartbeat (not stolen)", async () => {
+  const sid = await seedSession();
+  await appendUser(sid);
+  const jobId = await insertTurnJob(sid);
+
+  const { llm, release } = deferredLlm();
+  await startTestWorker({ llm, heartbeatMs: 40 }); // shrink the heartbeat so it fires in-test
+
+  // Wait until the worker has claimed the job and parked in the (blocked) inference.
+  await waitFor(
+    async () => {
+      const { rows } = await pool.query("select state from turn_jobs where id=$1", [jobId]);
+      return rows[0]?.state === "running";
+    },
+    15_000,
+    "claimed",
+  );
+
+  // Simulate a near-expired lease; the heartbeat must push it back out before it can be stolen.
+  await pool.query("update turn_jobs set lease_expires_at = now() + interval '1 second' where id=$1", [jobId]);
+  await sleep(300); // ~7 heartbeats at 40ms
+
+  expect(await queue.pull()).toBeNull(); // not reclaimable — the heartbeat kept it leased
+  const { rows } = await pool.query(
+    "select extract(epoch from (lease_expires_at - now())) as ahead from turn_jobs where id=$1",
+    [jobId],
+  );
+  expect(Number(rows[0].ahead)).toBeGreaterThan(30);
+
+  release();
+  await waitFor(async () => (await eventTypes(sid)).at(-1) === "turn_completed", 15_000, "completed");
+});
+
+it("★ crash-resumes: worker B finishes the turn worker A abandoned, running the tool once", async () => {
+  // A provisioned subprocess sandbox both workers share (same session → same workdir).
+  const sid = randomUUID();
+  const handle = await realSandbox.provision(
+    { base_image: "x", persistent_fs: { size_gb: 1 }, egress: { allow: [] } },
+    sid,
+  );
+  await seedSession({ id: sid, status: "ready", handle });
+  await appendUser(sid);
+  const jobId = await insertTurnJob(sid);
+
+  // One shared scripted LLM: the single tool turn is consumed by A; B's follow-up inference
+  // finds the script exhausted and ends the turn.
+  const llm = new FakeLlm({
+    scripts: { [sid]: [{ content: "", toolCall: { kind: "exec", cmd: "echo RAN" } }] },
+  });
+
+  // Worker A's sandbox blocks forever on exec: A appends the assistant_message (tool call)
+  // then stalls BEFORE running the command — a faithful crash right after the log entry.
+  const blockingSandbox: SandboxDriver = {
+    async provision() {
+      return { driver: "subprocess", workdir: "/tmp/funky/unused" };
+    },
+    async reboot(h) {
+      return h;
+    },
+    async teardown() {},
+    connect() {
+      return {
+        exec: () =>
+          (async function* () {
+            await new Promise<never>(() => {});
+          })(),
+        attach: () =>
+          (async function* () {
+            await new Promise<never>(() => {});
+          })(),
+        async readFile() {
+          return new Uint8Array();
+        },
+        async writeFile() {},
+      };
+    },
+  };
+
+  const { worker: workerA } = await startTestWorker({ llm, sandbox: blockingSandbox });
+
+  // A appends the assistant_message with the tool call, then hangs in exec.
+  await waitFor(
+    async () => (await eventTypes(sid)).includes("assistant_message"),
+    15_000,
+    "A appended the tool call",
+  );
+  workerA.kill(); // crash A: heartbeats stop, its in-flight turn is abandoned
+  await pool.query("update turn_jobs set lease_expires_at = now() - interval '1 second' where id=$1", [jobId]);
+
+  // Worker B — real sandbox — reclaims the expired lease and finishes the turn.
+  await startTestWorker({ llm, sandbox: realSandbox });
+
+  await waitFor(async () => (await eventTypes(sid)).at(-1) === "turn_completed", 15_000, "B completed");
+
+  const events = await store.readEvents(NS, sid);
+  const toolResults = events.filter((e) => e.type === "tool_result");
+  expect(toolResults).toHaveLength(1); // the command ran ONCE (one tool_result)
+  expect((toolResults[0]!.payload as { output: string }).output).toContain("RAN");
+  expect(events.at(-1)?.type).toBe("turn_completed");
+  expect(await jobExists(jobId)).toBe(false);
+});
+
+it("drains: stop() resolves only after the in-flight turn finishes", async () => {
+  const sid = await seedSession();
+  await appendUser(sid);
+  await insertTurnJob(sid);
+
+  const { llm, release } = deferredLlm();
+  const { worker, metrics } = await startTestWorker({ llm });
+
+  await waitFor(() => metrics.inFlight === 1, 15_000, "turn in-flight");
+
+  let stopped = false;
+  const stopP = worker.stop().then(() => {
+    stopped = true;
+  });
+  await sleep(80);
+  expect(stopped).toBe(false); // still draining: the in-flight turn hasn't finished
+
+  release();
+  await stopP;
+  expect(stopped).toBe(true);
+  expect((await eventTypes(sid)).at(-1)).toBe("turn_completed");
+});
+
+it("wakes on NOTIFY, starting the turn well before the fallback poll", async () => {
+  const sid = await seedSession();
+  await appendUser(sid);
+
+  await startTestWorker({ llm: doneLlm() });
+  await sleep(150); // let the worker settle into its idle wait (LISTEN registered, empty pull)
+
+  const t0 = Date.now();
+  const jobId = randomUUID();
+  await db.transaction((tx) => queue.enqueue(tx, { id: jobId, namespace: NS, sessionId: sid, kind: "turn" }));
+
+  await waitFor(async () => !(await jobExists(jobId)), 5000, "turn processed");
+  const elapsed = Date.now() - t0;
+  expect(elapsed).toBeLessThan(700); // NOTIFY woke it; the fallback poll is 1000ms
+});

--- a/apps/worker/tsconfig.build.json
+++ b/apps/worker/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig.json"
+}

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+    // worker.test.ts drives a real Postgres via testcontainers: the first container
+    // pull is slow, and the integration tests run turns end-to-end.
+    testTimeout: 30_000,
+    hookTimeout: 120_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,52 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
+  apps/worker:
+    dependencies:
+      '@funky/db':
+        specifier: workspace:*
+        version: link:../../packages/db
+      '@funky/llm':
+        specifier: workspace:*
+        version: link:../../packages/ports/llm
+      '@funky/sandbox':
+        specifier: workspace:*
+        version: link:../../packages/ports/sandbox
+      '@funky/sessions':
+        specifier: workspace:*
+        version: link:../../packages/sessions
+      dotenv:
+        specifier: ^17.2.0
+        version: 17.4.2
+      pg:
+        specifier: ^8.16.0
+        version: 8.22.0
+      uuid:
+        specifier: ^13.0.0
+        version: 13.0.2
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
+    devDependencies:
+      '@testcontainers/postgresql':
+        specifier: ^12.0.4
+        version: 12.0.4
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.1
+      '@types/pg':
+        specifier: ^8.11.0
+        version: 8.20.0
+      tsx:
+        specifier: ^4.7.1
+        version: 4.23.0
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+
   packages/configs:
     dependencies:
       '@funky/db':


### PR DESCRIPTION
Adds `apps/worker` — the process that pulls turn/provision jobs off the queue and runs them via `@funky/sessions`; it's a thin `while (!draining)` loop, with all the turn intelligence already living in Phase D. `worker.ts` fires `handle(job)` without awaiting so many turns interleave on one event loop under a concurrency limit, heartbeats each job's lease, and routes outcomes (ack `completed`/`failed`/`abandoned`/`conflict`, nack `retry_later`); `health.ts` serves plain-`node:http` `/healthz` and Prometheus `/metrics`; `config.ts` does fail-fast zod env parsing; and `index.ts` wires the pool, a dedicated LISTEN client, the worker, the health server, and SIGTERM/SIGINT drain. Tests cover config + health plus a testcontainers integration suite (concurrency, backpressure, retry_later, conflict, provision, heartbeat, crash-resume, drain, NOTIFY wake-up). No API, domain, or compose changes — scope is limited to the new app plus its `pnpm-lock.yaml` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)