### PR TITLE
Phase G: worker in compose, zero-key demo, and ai-sdk real-model fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,13 @@
-# Copy to .env (gitignored) before `docker compose up`. Compose reads .env
-# automatically from the repo root.
+# Copy to .env. Used by BOTH `pnpm dev` (dotenv) and `docker compose up` (interpolation).
 
-# Required: the agent-service makes a real, billed call to the Anthropic Messages
-# API on each turn. The model named in a request's AgentConfig.model must be one
-# your key can call.
-ANTHROPIC_API_KEY=sk-ant-...
-DATABASE_URL=postgres://...
-FUNKY_AUTH_TOKEN=some-secret-token
+# Required. Any long random string:  openssl rand -hex 24
+FUNKY_AUTH_TOKEN=
+
+# Local development only — inside compose the services use the postgres service instead.
+DATABASE_URL=postgres://funky:funky@localhost:5432/funky
+
+# --- optional ---
+# "fake" (default): a scripted agent that runs a real command in the sandbox. No API key.
+# "ai-sdk": a real model. Requires ANTHROPIC_API_KEY.
+# FUNKY_LLM=ai-sdk
+# ANTHROPIC_API_KEY=sk-ant-...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile (repo root) — ONE image for the whole workspace.
-# Today it runs the api; when the worker exists, same image + different command
+# Runs the api by default; the worker is the SAME image with a different command
 # (the "one image, two Deployments" decision, honored from the first build).
 #
 # Honest status: this runs TypeScript via tsx — correct and fine for the compose
@@ -15,10 +15,17 @@ RUN corepack enable
 WORKDIR /app
 
 # Manifests first: dependency layers cache until a package.json/lockfile changes.
+# EVERY workspace package's manifest is needed — a frozen-lockfile install fails if any
+# package referenced by the lockfile is missing. (api → sessions → llm/sandbox/configs;
+# worker → the same graph.)
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/api/package.json apps/api/
+COPY apps/worker/package.json apps/worker/
 COPY packages/db/package.json packages/db/
 COPY packages/configs/package.json packages/configs/
+COPY packages/sessions/package.json packages/sessions/
+COPY packages/ports/llm/package.json packages/ports/llm/
+COPY packages/ports/sandbox/package.json packages/ports/sandbox/
 
 RUN pnpm install --frozen-lockfile
 
@@ -28,6 +35,5 @@ COPY . .
 ENV NODE_ENV=production
 EXPOSE 3000
 
-# Default command = api. Compose overrides this for the migrate one-shot
-# (and later, the worker).
+# Default command = api. Compose overrides this for the migrate one-shot and the worker.
 CMD ["pnpm", "-F", "api", "start:src"]

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Spin up agent swarms on demand. Define an agent (system prompt + model), give it a sandboxed environment, send it work — Funky handles the durability and the infrastructure.
 
-> **Status: early development.** The agent and environment config APIs are functional. Sessions and the agent runtime are in active development.
+> **Status: early development.** You can run an agent end-to-end today — no API key required. The sandbox has no isolation yet (see the roadmap).
 
 ## Quickstart
 
-Requires Docker.
+Requires Docker. No API key needed.
 
 ```bash
 git clone https://github.com/funkyhq/funky && cd funky
@@ -14,42 +14,84 @@ cp .env.example .env        # set FUNKY_AUTH_TOKEN to any long random string
 docker compose up --build
 ```
 
-The stack is up when `api` reports listening on port 3000. Try it:
+The stack is up when the `worker` and `api` services are healthy. Then:
 
 ```bash
 export TOKEN=<your FUNKY_AUTH_TOKEN>
+export H="Authorization: Bearer $TOKEN"
+export J="content-type: application/json"
 
-# health
-curl -s localhost:3000/healthz
+# 1. an agent: who it is and what model it uses
+AID=$(curl -s -X POST localhost:3000/v1/agents -H "$H" -H "$J" -d '{
+  "name": "shell agent",
+  "system_prompt": "You are a helpful engineer. Use the sandbox to run commands.",
+  "model": { "provider": "anthropic", "model": "claude-sonnet-5" }
+}' | jq -r .id)
 
-# create an agent
-curl -s -X POST localhost:3000/v1/agents \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "content-type: application/json" \
-  -d '{
-    "name": "data cruncher",
-    "system_prompt": "You are a data analyst.",
-    "model": { "provider": "anthropic", "model": "claude-sonnet-5" }
-  }'
+# 2. an environment: where its commands run
+EID=$(curl -s -X POST localhost:3000/v1/environments -H "$H" -H "$J" -d '{
+  "name": "basic",
+  "base_image": "funky/base:latest"
+}' | jq -r .id)
 
-# list agents
-curl -s -H "Authorization: Bearer $TOKEN" localhost:3000/v1/agents
+# 3. a session: an agent + an environment, with a sandbox and a durable event log
+SID=$(curl -s -X POST localhost:3000/v1/sessions -H "$H" -H "$J" \
+  -d "{\"agent\":\"$AID\",\"environment_id\":\"$EID\"}" | jq -r .id)
 
-# create an environment (the sandbox recipe for future sessions)
-curl -s -X POST localhost:3000/v1/environments \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "content-type: application/json" \
-  -d '{
-    "name": "python basic",
-    "base_image": "funky/base-python:3.12",
-    "egress": { "allow": ["pypi.org", "files.pythonhosted.org"] }
-  }'
+# 4. watch it think (leave this running)
+curl -N -H "$H" localhost:3000/v1/sessions/$SID/events/stream &
 
-# list environments
-curl -s -H "Authorization: Bearer $TOKEN" localhost:3000/v1/environments
+# 5. give it work
+curl -s -X POST localhost:3000/v1/sessions/$SID/messages -H "$H" -H "$J" \
+  -d '{"content":"say hello from the sandbox"}'
 ```
 
-Tear down with `docker compose down` (add `-v` to also delete the database).
+You'll see the agent provision a sandbox, decide to run a command, execute it, and report
+back:
+
+```
+event: session_provisioned
+event: assistant_message      { "tool_calls": [{ "kind": "exec", "cmd": "echo …" }] }
+event: tool_result            { "output": "hello from the funky sandbox\n", "exit_code": 0 }
+event: assistant_message      { "content": [{"type":"text","text":"I ran a command…"}] }
+event: turn_completed
+```
+
+### Durability
+
+Funky keeps each session's state in Postgres — the append-only event log is the source of
+truth, not any worker's memory. A worker holds no session state between turns: it reads the
+log, performs the single next step, and appends the result in one conditional-append
+transaction. The durable record of what happened lives in the database, so a worker is a
+stateless, replaceable unit.
+
+> **Honest limit — the `subprocess` driver.** The dev sandbox runs commands **inside the
+> worker container** (no isolation — see the roadmap), so the sandbox filesystem and any
+> in-flight command are *not* durable: they live and die with that container. The headline
+> demo — kill a worker mid-command and have a replacement **re-attach to the still-running
+> command** and finish the turn — needs a sandbox that outlives the worker. That contract
+> (idempotent `exec` keyed so a command never runs twice, whatever the driver) is already
+> in the sandbox port and its conformance suite; the live demo lands with the persistent
+> provider driver (E2B via ComputeSDK), next.
+
+### Using a real model
+
+```bash
+# in .env
+FUNKY_LLM=ai-sdk
+ANTHROPIC_API_KEY=sk-ant-...
+```
+```bash
+docker compose up -d --build worker
+```
+Now the same curl commands drive a real Claude, writing and running its own shell commands.
+
+### Tear down
+
+```bash
+docker compose down       # stop and remove the containers
+docker compose down -v    # ...and also delete the database volume
+```
 
 ## Local development
 
@@ -73,8 +115,11 @@ Useful commands: `pnpm typecheck` · `pnpm -F @funky/db generate` (new migration
 ## Layout
 
 ```
-apps/api           HTTP API (Hono)
+apps/api           HTTP API (Hono): agents, environments, sessions, SSE
+apps/worker        the agent runtime — pulls turns off the queue and drives the loop
+packages/sessions  the event log, the reducer, the turn loop, the job queue
 packages/configs   agent + environment config domain logic
+packages/ports     provider-neutral ports (llm, sandbox) + their drivers
 packages/db        Drizzle schema + migrations
 ```
 
@@ -84,9 +129,9 @@ packages/db        Drizzle schema + migrations
 
 - [x] Agent configs (versioned, archive-only) — create/update/list/archive + version history
 - [x] Environment configs (unversioned, archive or delete) — the sandbox recipe: base image, persistent fs, egress policy
-- [ ] Sessions & event log
-- [ ] Agent runtime worker (the loop)
-- [ ] Sandboxed execution
+- [x] Sessions & event log
+- [x] Agent runtime worker (the loop)
+- [x] Sandboxed execution — subprocess driver: **no isolation yet** (commands run inside the worker container); provider drivers (E2B via ComputeSDK) next
 - [ ] SDKs (TypeScript, Python)
 
 ## Contributing

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -51,8 +51,9 @@ console.log(
     `llm=${cfg.llm} sandbox=${cfg.sandbox}`,
 );
 
-// The fake driver needs no API key: with an empty script every session's turn resolves to a
-// single terminal assistant message. Real work uses FUNKY_LLM=ai-sdk.
+// The fake driver needs no API key: with no registered scripts every session runs the
+// driver's DEFAULT_SCRIPT — a real sandbox command, then a summary. Real work uses
+// FUNKY_LLM=ai-sdk.
 function llmConfig(c: Config): LlmConfig {
   return c.llm === "ai-sdk"
     ? { driver: "ai-sdk" }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
-# docker-compose.yml (repo root) — the quickstart stack: postgres + migrate + api.
+# docker-compose.yml (repo root) — the quickstart stack: postgres + migrate + api + worker.
 # Bring up:   docker compose up --build
+# Scale out:  docker compose up --build --scale worker=3
 # Tear down:  docker compose down          (-v to also wipe the database)
 
 services:
@@ -36,7 +37,12 @@ services:
       - "3000:3000"
     environment:
       DATABASE_URL: postgres://funky:funky@postgres:5432/funky
-      FUNKY_AUTH_TOKEN: ${FUNKY_AUTH_TOKEN:-dev-token-change-me-000} # reads host .env if present
+      # No default credential, ever: `:?` fails the boot with a message if it's unset.
+      FUNKY_AUTH_TOKEN: ${FUNKY_AUTH_TOKEN:?set FUNKY_AUTH_TOKEN in .env — any long random string}
+      # The api doesn't call the LLM today, but keeping its env in sync with the worker
+      # avoids "why does the worker behave differently" confusion.
+      FUNKY_LLM: ${FUNKY_LLM:-fake}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-} # empty unless the user sets it
     depends_on:
       migrate:
         condition: service_completed_successfully
@@ -47,6 +53,34 @@ services:
           "node",
           "-e",
           "fetch('http://localhost:3000/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  # The agent runtime. SAME image as the api, different command (one image, two
+  # deployments). No published ports — nothing routes to a worker; 9090 is internal-only
+  # for the healthcheck. `docker compose up --scale worker=3` works with no changes: the
+  # queue hands each job to exactly one worker.
+  worker:
+    build: .
+    command: ["pnpm", "-F", "worker", "start:src"]
+    environment:
+      DATABASE_URL: postgres://funky:funky@postgres:5432/funky # ← service name, not localhost
+      FUNKY_LLM: ${FUNKY_LLM:-fake}
+      FUNKY_SANDBOX: ${FUNKY_SANDBOX:-subprocess}
+      FUNKY_WORKER_CONCURRENCY: ${FUNKY_WORKER_CONCURRENCY:-10}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-} # empty unless the user sets it
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://localhost:9090/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
         ]
       interval: 5s
       timeout: 3s

--- a/packages/ports/llm/src/ai-sdk.mock.test.ts
+++ b/packages/ports/llm/src/ai-sdk.mock.test.ts
@@ -64,4 +64,55 @@ describe("AiSdkLlm parallel-tool-call cap", () => {
     const call = vi.mocked(generateText).mock.calls[0]![0];
     expect(call.providerOptions).toEqual({ anthropic: { disableParallelToolUse: true } });
   });
+
+  // ai@7 rejects system-role messages in `messages` ("Use the instructions option instead").
+  // The system prompt must travel as the top-level `instructions` option instead.
+  it("routes the system prompt to `instructions`, never into `messages`", async () => {
+    mockResult([]);
+
+    await new AiSdkLlm().complete({
+      model: MODEL,
+      messages: [
+        { role: "system", content: "You are a helpful engineer." },
+        { role: "user", content: "hi" },
+      ],
+    });
+
+    const call = vi.mocked(generateText).mock.calls[0]![0];
+    expect(call.instructions).toBe("You are a helpful engineer.");
+    expect(call.messages).toEqual([{ role: "user", content: "hi" }]);
+    // The regression this guards: no system-role message leaks into `messages`.
+    expect((call.messages ?? []).some((m) => m.role === "system")).toBe(false);
+  });
+
+  // Anthropic rejects a tool_use.id that isn't ^[a-zA-Z0-9_-]+$. Our idemKey
+  // (`sessionId:seq:index`) has colons, so the reconstructed history must sanitize it —
+  // identically on the assistant tool-call and its paired tool-result.
+  it("sanitizes the tool_use id (no colons) and keeps call/result paired", async () => {
+    mockResult([]);
+
+    await new AiSdkLlm().complete({
+      model: MODEL,
+      messages: [
+        { role: "user", content: "run something" },
+        { role: "assistant", content: "", toolCall: { kind: "exec", cmd: "echo hi" } },
+        { role: "tool", idemKey: "019f5e05-a667-732b-99f6-04fa6a4c38ea:3:0", output: "hi\n", exitCode: 0 },
+      ],
+    });
+
+    const call = vi.mocked(generateText).mock.calls[0]![0];
+    const PATTERN = /^[a-zA-Z0-9_-]+$/;
+    // deno-lint style narrowing kept loose: this is test-only shape inspection.
+    const assistant = (call.messages ?? []).find((m) => m.role === "assistant")!;
+    const toolMsg = (call.messages ?? []).find((m) => m.role === "tool")!;
+    const callPart = (assistant.content as Array<{ type: string; toolCallId?: string }>).find(
+      (p) => p.type === "tool-call",
+    )!;
+    const resultPart = (toolMsg.content as Array<{ type: string; toolCallId?: string }>)[0]!;
+
+    expect(callPart.toolCallId).toMatch(PATTERN);
+    expect(resultPart.toolCallId).toMatch(PATTERN);
+    expect(callPart.toolCallId).not.toContain(":");
+    expect(callPart.toolCallId).toBe(resultPart.toolCallId); // must stay paired
+  });
 });

--- a/packages/ports/llm/src/ai-sdk.test.ts
+++ b/packages/ports/llm/src/ai-sdk.test.ts
@@ -30,4 +30,21 @@ describe.skipIf(!hasKey)("AiSdkLlm (real anthropic round-trip)", () => {
     expect(typeof result.toolCall?.cmd).toBe("string");
     expect(result.toolCall?.cmd.length).toBeGreaterThan(0);
   });
+
+  // The second inference of a turn: the context now replays a prior assistant tool_use and
+  // its tool_result, keyed by our idemKey (`sessionId:seq:index`). Anthropic rejects a
+  // tool_use.id containing colons, so this round-trip only succeeds once the id is sanitized.
+  it("accepts a replayed tool_use/tool_result history (idemKey has colons)", async () => {
+    const llm = new AiSdkLlm();
+    const messages: ChatMessage[] = [
+      { role: "system", content: "You control a Linux sandbox. Use the exec tool for shell commands." },
+      { role: "user", content: "run: echo hi" },
+      { role: "assistant", content: "", toolCall: { kind: "exec", cmd: 'echo "hi"' } },
+      { role: "tool", idemKey: "019f5e05-a667-732b-99f6-04fa6a4c38ea:3:0", output: "hi\n", exitCode: 0 },
+    ];
+
+    // Before the fix this threw LLM_PERMANENT: "tool_use.id: String should match pattern…".
+    const result = await llm.complete({ model, messages });
+    expect(result.usage.inputTokens).toBeGreaterThan(0);
+  });
 });

--- a/packages/ports/llm/src/drivers/ai-sdk.ts
+++ b/packages/ports/llm/src/drivers/ai-sdk.ts
@@ -52,7 +52,7 @@ const execTool = tool({
 export class AiSdkLlm implements LlmPort {
   async complete(req: LlmRequest): Promise<LlmResult> {
     const model = resolveModel(req.model);
-    const messages = toModelMessages(req.messages);
+    const { instructions, messages } = toModelMessages(req.messages);
     const providerOptions = parallelToolUseOff(req.model);
 
     let lastTransient: LlmTransientError | undefined;
@@ -60,6 +60,7 @@ export class AiSdkLlm implements LlmPort {
       try {
         const result = await generateText({
           model,
+          instructions, // the system prompt: ai@7 forbids it inside `messages`
           messages,
           tools: { [EXEC_TOOL]: execTool },
           providerOptions, // disables parallel tool use so the model plans sequentially
@@ -135,16 +136,23 @@ function pickSingleToolCall(
     : { kind: "exec", cmd: input.cmd };
 }
 
-// ChatMessage[] → the AI SDK's ModelMessage[]. An assistant tool call and its paired tool
-// result must share a toolCallId; we reuse the tool message's idemKey as that id (the log
-// already pairs result → call by idemKey), so the reconstruction round-trips cleanly.
-function toModelMessages(messages: ChatMessage[]): ModelMessage[] {
+// ChatMessage[] → the AI SDK's top-level `instructions` (the system prompt) + ModelMessage[].
+// ai@7 forbids system-role messages inside `messages` (allowSystemInMessages defaults to
+// false → "System messages are not allowed… Use the instructions option instead"), so the
+// system prompt must travel as the separate `instructions` option. We collect every system
+// message (normally exactly one, at the head) and join them.
+//
+// An assistant tool call and its paired tool result must share a toolCallId; we reuse the
+// tool message's idemKey as that id (the log already pairs result → call by idemKey), so the
+// reconstruction round-trips cleanly.
+function toModelMessages(messages: ChatMessage[]): { instructions?: string; messages: ModelMessage[] } {
+  const systemParts: string[] = [];
   const out: ModelMessage[] = [];
   for (let i = 0; i < messages.length; i++) {
     const m = messages[i]!;
     switch (m.role) {
       case "system":
-        out.push({ role: "system", content: m.content });
+        systemParts.push(m.content);
         break;
       case "user":
         out.push({ role: "user", content: m.content });
@@ -152,7 +160,7 @@ function toModelMessages(messages: ChatMessage[]): ModelMessage[] {
       case "assistant": {
         if (m.toolCall) {
           const next = messages[i + 1];
-          const id = next && next.role === "tool" ? next.idemKey : `call-${i}`;
+          const id = next && next.role === "tool" ? toolUseId(next.idemKey) : `call-${i}`;
           const parts: Array<TextPart | ToolCallPart> = [];
           if (m.content) parts.push({ type: "text", text: m.content });
           parts.push({ type: "tool-call", toolCallId: id, toolName: EXEC_TOOL, input: execInput(m.toolCall) });
@@ -168,7 +176,7 @@ function toModelMessages(messages: ChatMessage[]): ModelMessage[] {
           content: [
             {
               type: "tool-result",
-              toolCallId: m.idemKey,
+              toolCallId: toolUseId(m.idemKey),
               toolName: EXEC_TOOL,
               output: { type: "text", value: m.output },
             },
@@ -177,7 +185,18 @@ function toModelMessages(messages: ChatMessage[]): ModelMessage[] {
         break;
     }
   }
-  return out;
+  return {
+    instructions: systemParts.length > 0 ? systemParts.join("\n\n") : undefined,
+    messages: out,
+  };
+}
+
+// Anthropic requires tool_use ids to match ^[a-zA-Z0-9_-]+$; our idemKey is
+// `sessionId:seq:index`, whose colons are rejected. Map every disallowed char to `_`.
+// Applied identically to the assistant tool-call and its paired tool-result so the two
+// still reference the same id (the pairing is by this value, within one request).
+function toolUseId(idemKey: string): string {
+  return idemKey.replace(/[^a-zA-Z0-9_-]/g, "_");
 }
 
 function execInput(tc: ToolCall): { cmd: string; timeout_ms?: number } {

--- a/packages/ports/llm/src/drivers/fake.ts
+++ b/packages/ports/llm/src/drivers/fake.ts
@@ -7,6 +7,18 @@ import { type LlmPort, type LlmRequest, type LlmResult, LlmTransientError } from
 
 export type FakeTurn = { content: string; toolCall?: LlmResult["toolCall"] };
 
+// The script used for any session with no explicit script — i.e. the zero-key demo path.
+// A fresh `docker compose up` (FUNKY_LLM=fake, no ANTHROPIC_API_KEY) drives THIS: the agent
+// runs a real command in the sandbox, then reports back. Deterministic on purpose — this is
+// a demo, not a simulation. Tests that register their own per-session script still win.
+const DEFAULT_SCRIPT: FakeTurn[] = [
+  {
+    content: "",
+    toolCall: { kind: "exec", cmd: 'echo "hello from the funky sandbox"; uname -a' },
+  },
+  { content: "I ran a command in the sandbox. It said hello, and reported the kernel." },
+];
+
 export class FakeLlm implements LlmPort {
   private readonly scripts: Record<string, FakeTurn[]>;
   private readonly cursor: Record<string, number> = {};
@@ -35,7 +47,9 @@ export class FakeLlm implements LlmPort {
     if (!sessionId) {
       throw new Error("FakeLlm requires req.trace.sessionId to select a script");
     }
-    const script = this.scripts[sessionId] ?? [];
+    // Explicit per-session script wins; otherwise an unknown session runs the DEFAULT_SCRIPT
+    // (the zero-key demo). Both are consumed in order via the same per-session cursor.
+    const script = this.scripts[sessionId] ?? DEFAULT_SCRIPT;
     const at = this.cursor[sessionId] ?? 0;
     const turn = script[at];
 

--- a/packages/ports/llm/src/fake.test.ts
+++ b/packages/ports/llm/src/fake.test.ts
@@ -66,6 +66,34 @@ describe("FakeLlm", () => {
     expect(r.content).toBe("ok");
   });
 
+  it("runs the DEFAULT_SCRIPT for a session it has no explicit script for", async () => {
+    // The zero-key demo path: no scripts registered, so any session gets the default —
+    // a real exec, then a summary turn, then terminal "done".
+    const llm = new FakeLlm({ scripts: {} });
+
+    const r1 = await llm.complete(req("unknown"));
+    expect(r1.content).toBe("");
+    expect(r1.toolCall).toEqual({ kind: "exec", cmd: 'echo "hello from the funky sandbox"; uname -a' });
+
+    const r2 = await llm.complete(req("unknown"));
+    expect(r2.content).toMatch(/ran a command in the sandbox/);
+    expect(r2.toolCall).toBeUndefined();
+
+    const r3 = await llm.complete(req("unknown"));
+    expect(r3.content).toBe("done");
+    expect(r3.toolCall).toBeUndefined();
+  });
+
+  it("an explicit per-session script still wins over the default", async () => {
+    const llm = new FakeLlm({ scripts: { s1: [{ content: "explicit" }] } });
+    expect((await llm.complete(req("s1"))).content).toBe("explicit");
+    // A different, unregistered session still gets the default's first tool turn.
+    expect((await llm.complete(req("s2"))).toolCall).toEqual({
+      kind: "exec",
+      cmd: 'echo "hello from the funky sandbox"; uname -a',
+    });
+  });
+
   it("requires trace.sessionId to pick a script", async () => {
     const llm = new FakeLlm({ scripts: { s1: [{ content: "ok" }] } });
     await expect(llm.complete({ model: MODEL, messages: MSGS })).rejects.toThrow(/sessionId/);


### PR DESCRIPTION
Adds a `worker` service to docker-compose (same image, no published ports, internal `:9090` healthcheck, `--scale worker=3`-ready), syncs `FUNKY_LLM`/`ANTHROPIC_API_KEY` onto the api, makes `FUNKY_AUTH_TOKEN` fail-fast, and fixes the Dockerfile to copy every workspace manifest so the frozen-lockfile install resolves the worker/api graph. Gives `FakeLlm` a default script so a fresh `docker compose up` runs a real sandbox command with **no API key**, and rewrites `.env.example` plus the README quickstart into the full agent → environment → session → stream → message journey — with an honest note that the subprocess sandbox is not durable across a worker restart, and a Tear down section. Also fixes two ai-sdk driver bugs the real model surfaced: the system prompt now goes through ai@7's top-level `instructions` option instead of a rejected system-role message, and the `tool_use` id (our `idemKey`, which contains colons) is sanitized to Anthropic's `^[a-zA-Z0-9_-]+$`. Verified with typecheck, the full test suite, offline mock tests, gated real Anthropic round-trips, and a live `docker compose up --build` run of the quickstart including `--scale worker=3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
