### PR TITLE
E2B sandbox driver via ComputeSDK (FUNKY_SANDBOX=e2b)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,11 @@ DATABASE_URL=postgres://funky:funky@localhost:5432/funky
 # "ai-sdk": a real model. Requires ANTHROPIC_API_KEY.
 # FUNKY_LLM=ai-sdk
 # ANTHROPIC_API_KEY=sk-ant-...
+
+# "subprocess" (default): commands run inside the worker container. No isolation, no key.
+# "e2b": an isolated E2B sandbox per session, provisioned via ComputeSDK. It outlives any
+#        single worker, and idles pause after FUNKY_E2B_SANDBOX_TIMEOUT_MS (default 30min,
+#        resumed on the next command). Requires an API key from https://e2b.dev
+# FUNKY_SANDBOX=e2b
+# E2B_API_KEY=e2b_...
+# FUNKY_E2B_SANDBOX_TIMEOUT_MS=1800000

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Spin up agent swarms on demand. Define an agent (system prompt + model), give it a sandboxed environment, send it work — Funky handles the durability and the infrastructure.
 
-> **Status: early development.** You can run an agent end-to-end today — no API key required. The sandbox has no isolation yet (see the roadmap).
+> **Status: early development.** You can run an agent end-to-end today — no API key required. The default dev sandbox has no isolation; add an E2B key for isolated per-session cloud sandboxes (see "Using a real sandbox").
 
 ## Quickstart
 
@@ -65,14 +65,13 @@ log, performs the single next step, and appends the result in one conditional-ap
 transaction. The durable record of what happened lives in the database, so a worker is a
 stateless, replaceable unit.
 
-> **Honest limit — the `subprocess` driver.** The dev sandbox runs commands **inside the
-> worker container** (no isolation — see the roadmap), so the sandbox filesystem and any
-> in-flight command are *not* durable: they live and die with that container. The headline
-> demo — kill a worker mid-command and have a replacement **re-attach to the still-running
-> command** and finish the turn — needs a sandbox that outlives the worker. That contract
-> (idempotent `exec` keyed so a command never runs twice, whatever the driver) is already
-> in the sandbox port and its conformance suite; the live demo lands with the persistent
-> provider driver (E2B via ComputeSDK), next.
+> **Honest limit — the default `subprocess` driver.** The dev sandbox runs commands
+> **inside the worker container** (no isolation), so the sandbox filesystem and any
+> in-flight command are *not* durable: they live and die with that container. The E2B
+> driver (next section) removes this limit: the sandbox outlives any single worker, a
+> running command records its output and exit code inside the sandbox itself, and the
+> idempotent `exec` contract (a command never runs twice, whatever the driver) lets a
+> replacement worker re-attach to work a dead worker started and finish the turn.
 
 ### Using a real model
 
@@ -85,6 +84,29 @@ ANTHROPIC_API_KEY=sk-ant-...
 docker compose up -d --build worker
 ```
 Now the same curl commands drive a real Claude, writing and running its own shell commands.
+
+### Using a real sandbox
+
+```bash
+# in .env
+FUNKY_SANDBOX=e2b
+E2B_API_KEY=e2b_...         # from https://e2b.dev
+```
+```bash
+docker compose up -d --build worker
+```
+Now every session provisions an isolated [E2B](https://e2b.dev) sandbox, through
+[ComputeSDK](https://computesdk.com) so further providers can slot in behind the same
+driver. The sandbox — not the worker — holds each command's output and exit code, which is
+what makes sessions survive worker death: a replacement worker re-attaches by idempotency
+key and reads the same files. Idle sandboxes pause after 30 minutes
+(`FUNKY_E2B_SANDBOX_TIMEOUT_MS`) and resume on the next command, filesystem intact.
+
+The E2B driver answers to the identical conformance suite as the subprocess driver; it
+runs against real sandboxes when a key is present:
+```bash
+E2B_API_KEY=e2b_... pnpm -F @funky/sandbox test
+```
 
 ### Tear down
 
@@ -131,7 +153,7 @@ packages/db        Drizzle schema + migrations
 - [x] Environment configs (unversioned, archive or delete) — the sandbox recipe: base image, persistent fs, egress policy
 - [x] Sessions & event log
 - [x] Agent runtime worker (the loop)
-- [x] Sandboxed execution — subprocess driver: **no isolation yet** (commands run inside the worker container); provider drivers (E2B via ComputeSDK) next
+- [x] Sandboxed execution — subprocess driver (dev default: commands run inside the worker container, no isolation) + E2B driver via ComputeSDK (isolated sandbox per session, outlives any worker)
 - [ ] SDKs (TypeScript, Python)
 
 ## Contributing

--- a/apps/worker/src/config.ts
+++ b/apps/worker/src/config.ts
@@ -3,15 +3,30 @@
 // Mirrors apps/api/src/config.ts: zod, fail-fast via process.exit(1); never boot half-configured.
 import { z } from "zod";
 
+// Compose interpolation (`${VAR:-}`) delivers an UNSET optional secret as an EMPTY
+// STRING, not as a missing variable — treat "" as absent so the zero-key path boots.
+const optionalSecret = z.preprocess(
+  (v) => (v === "" ? undefined : v),
+  z.string().min(1).optional(),
+);
+
 const EnvSchema = z
   .object({
     DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
     FUNKY_WORKER_CONCURRENCY: z.coerce.number().int().min(1).default(50),
     FUNKY_WORKER_HEALTH_PORT: z.coerce.number().int().min(1).max(65535).default(9090),
     FUNKY_LLM: z.enum(["fake", "ai-sdk"]).default("fake"),
-    FUNKY_SANDBOX: z.enum(["subprocess"]).default("subprocess"),
+    FUNKY_SANDBOX: z.enum(["subprocess", "e2b"]).default("subprocess"),
     // Required ONLY when FUNKY_LLM=ai-sdk (the fake driver makes no network calls).
-    ANTHROPIC_API_KEY: z.string().min(1).optional(),
+    ANTHROPIC_API_KEY: optionalSecret,
+    // Required ONLY when FUNKY_SANDBOX=e2b (subprocess needs no account).
+    E2B_API_KEY: optionalSecret,
+    // Idle lifetime before an e2b sandbox auto-pauses (resumed on the next command).
+    FUNKY_E2B_SANDBOX_TIMEOUT_MS: z.coerce
+      .number()
+      .int()
+      .min(60_000)
+      .default(30 * 60_000),
     DB_POOL_MAX: z.coerce.number().int().min(1).default(10),
   })
   .refine((e) => e.FUNKY_LLM !== "ai-sdk" || e.ANTHROPIC_API_KEY !== undefined, {
@@ -19,6 +34,12 @@ const EnvSchema = z
       "ANTHROPIC_API_KEY is required when FUNKY_LLM=ai-sdk. " +
       "Set it, or leave FUNKY_LLM=fake for local development.",
     path: ["ANTHROPIC_API_KEY"],
+  })
+  .refine((e) => e.FUNKY_SANDBOX !== "e2b" || e.E2B_API_KEY !== undefined, {
+    message:
+      "E2B_API_KEY is required when FUNKY_SANDBOX=e2b. " +
+      "Set it, or leave FUNKY_SANDBOX=subprocess for local development.",
+    path: ["E2B_API_KEY"],
   });
 
 export type Config = {
@@ -26,9 +47,12 @@ export type Config = {
   concurrency: number;
   healthPort: number;
   llm: "fake" | "ai-sdk";
-  sandbox: "subprocess";
+  sandbox: "subprocess" | "e2b";
   /** null = fake driver; no key needed. */
   anthropicApiKey: string | null;
+  /** null = subprocess driver; no key needed. */
+  e2bApiKey: string | null;
+  e2bSandboxTimeoutMs: number;
   dbPoolMax: number;
 };
 
@@ -50,6 +74,8 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     llm: e.FUNKY_LLM,
     sandbox: e.FUNKY_SANDBOX,
     anthropicApiKey: e.ANTHROPIC_API_KEY ?? null,
+    e2bApiKey: e.E2B_API_KEY ?? null,
+    e2bSandboxTimeoutMs: e.FUNKY_E2B_SANDBOX_TIMEOUT_MS,
     dbPoolMax: e.DB_POOL_MAX,
   };
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 import { Client, Pool } from "pg";
 import { createDb } from "@funky/db";
 import { FakeLlm, type LlmConfig, makeLlm } from "@funky/llm";
-import { makeSandbox } from "@funky/sandbox";
+import { makeSandbox, type SandboxConfig } from "@funky/sandbox";
 import { EventStore, JobQueue } from "@funky/sessions";
 import { type Config, loadConfig } from "./config";
 import { startHealthServer } from "./health";
@@ -32,7 +32,7 @@ const worker = startWorker({
   queue,
   store,
   llm: makeLlm(llmConfig(cfg)), // fake by default — no API key needed
-  sandbox: makeSandbox({ driver: cfg.sandbox }), // subprocess
+  sandbox: makeSandbox(sandboxConfig(cfg)), // subprocess by default — no account needed
   db,
   listenClient,
   concurrency: cfg.concurrency,
@@ -58,6 +58,18 @@ function llmConfig(c: Config): LlmConfig {
   return c.llm === "ai-sdk"
     ? { driver: "ai-sdk" }
     : { driver: "fake", instance: new FakeLlm({ scripts: {} }) };
+}
+
+// subprocess runs commands inside THIS container (dev default, no isolation). e2b gives
+// every session an isolated remote sandbox that outlives any single worker.
+function sandboxConfig(c: Config): SandboxConfig {
+  return c.sandbox === "e2b"
+    ? {
+        driver: "e2b",
+        apiKey: c.e2bApiKey ?? "", // non-null per the config refine; "" can't slip through the driver's key check
+        sandboxTimeoutMs: c.e2bSandboxTimeoutMs,
+      }
+    : { driver: "subprocess" };
 }
 
 // Shutdown: drain, don't kill. Stop pulling, let in-flight turns finish, then release

--- a/apps/worker/test/config.test.ts
+++ b/apps/worker/test/config.test.ts
@@ -28,8 +28,17 @@ describe("loadConfig — valid input", () => {
       llm: "fake",
       sandbox: "subprocess",
       anthropicApiKey: null,
+      e2bApiKey: null,
+      e2bSandboxTimeoutMs: 30 * 60_000,
       dbPoolMax: 10,
     });
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("treats empty-string secrets as absent (compose `${VAR:-}` sends '' for unset keys)", () => {
+    const cfg = loadConfig({ ...BASE, ANTHROPIC_API_KEY: "", E2B_API_KEY: "" });
+    expect(cfg.anthropicApiKey).toBeNull();
+    expect(cfg.e2bApiKey).toBeNull();
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
@@ -41,14 +50,19 @@ describe("loadConfig — valid input", () => {
       DB_POOL_MAX: "25",
       FUNKY_LLM: "ai-sdk",
       ANTHROPIC_API_KEY: "sk-ant-secret",
+      FUNKY_SANDBOX: "e2b",
+      E2B_API_KEY: "e2b_secret",
+      FUNKY_E2B_SANDBOX_TIMEOUT_MS: "600000",
     });
     expect(cfg).toEqual({
       databaseUrl: BASE.DATABASE_URL,
       concurrency: 8,
       healthPort: 9191,
       llm: "ai-sdk",
-      sandbox: "subprocess",
+      sandbox: "e2b",
       anthropicApiKey: "sk-ant-secret",
+      e2bApiKey: "e2b_secret",
+      e2bSandboxTimeoutMs: 600_000,
       dbPoolMax: 25,
     });
   });
@@ -59,6 +73,12 @@ describe("loadConfig — invalid input exits the process", () => {
     ["missing DATABASE_URL", {}],
     ["empty DATABASE_URL", { DATABASE_URL: "" }],
     ["ai-sdk without ANTHROPIC_API_KEY", { ...BASE, FUNKY_LLM: "ai-sdk" }],
+    ["e2b without E2B_API_KEY", { ...BASE, FUNKY_SANDBOX: "e2b" }],
+    ["e2b with empty E2B_API_KEY", { ...BASE, FUNKY_SANDBOX: "e2b", E2B_API_KEY: "" }],
+    [
+      "e2b sandbox timeout below 60s",
+      { ...BASE, FUNKY_SANDBOX: "e2b", E2B_API_KEY: "e2b_x", FUNKY_E2B_SANDBOX_TIMEOUT_MS: "1000" },
+    ],
     ["concurrency below 1", { ...BASE, FUNKY_WORKER_CONCURRENCY: "0" }],
     ["concurrency not a number", { ...BASE, FUNKY_WORKER_CONCURRENCY: "lots" }],
     ["health port out of range", { ...BASE, FUNKY_WORKER_HEALTH_PORT: "70000" }],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,8 @@ services:
       FUNKY_SANDBOX: ${FUNKY_SANDBOX:-subprocess}
       FUNKY_WORKER_CONCURRENCY: ${FUNKY_WORKER_CONCURRENCY:-10}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-} # empty unless the user sets it
+      E2B_API_KEY: ${E2B_API_KEY:-} # empty unless the user sets it
+      FUNKY_E2B_SANDBOX_TIMEOUT_MS: ${FUNKY_E2B_SANDBOX_TIMEOUT_MS:-1800000}
     depends_on:
       migrate:
         condition: service_completed_successfully

--- a/packages/ports/sandbox/package.json
+++ b/packages/ports/sandbox/package.json
@@ -12,8 +12,10 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@computesdk/e2b": "^1.7.51",
     "@funky/db": "workspace:*",
-    "@funky/sessions": "workspace:*"
+    "@funky/sessions": "workspace:*",
+    "computesdk": "^4.1.3"
   },
   "devDependencies": {
     "vitest": "^4.1.10"

--- a/packages/ports/sandbox/src/computesdk.test.ts
+++ b/packages/ports/sandbox/src/computesdk.test.ts
@@ -1,0 +1,164 @@
+// The ComputeSDK driver runs the identical conformance suite twice:
+//
+// 1. "computesdk/local-shell" — always. A fake provider whose sandbox is a temp dir and
+//    whose runCommand is a local `sh -c`, faithful to the e2b provider's error surface
+//    (it NEVER throws; transport failures come back as exitCode 127 with the message in
+//    stderr; getById returns null once destroyed). This exercises the driver's whole
+//    shell protocol — the mkdir lock, the detached runner, the poll envelope, base64
+//    file i/o, in-sandbox timeout — through a real shell, keyless, in CI.
+//
+// 2. "computesdk/e2b" — against real E2B sandboxes when a key is present (skipped
+//    otherwise), with generous timeouts: every case provisions its own remote sandbox
+//    and every poll is a network round-trip.
+//
+//      E2B_API_KEY=e2b_... pnpm -F @funky/sandbox test
+
+import { execFile, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { e2b } from "@computesdk/e2b";
+import type { CommandResult, SandboxInterface } from "computesdk";
+import { describe, it } from "vitest";
+import { type ComputeProvider, ComputeSdkDriver } from "./drivers/computesdk";
+import { runSandboxTck } from "./tck";
+
+const sh = promisify(execFile);
+
+runSandboxTck(
+  "computesdk/local-shell",
+  () => new ComputeSdkDriver({ providerName: "fake-local", provider: localShellProvider() }),
+  { timeoutMs: 20_000 },
+);
+
+const apiKey = process.env.E2B_API_KEY;
+if (apiKey) {
+  runSandboxTck(
+    "computesdk/e2b",
+    () =>
+      new ComputeSdkDriver({
+        providerName: "e2b",
+        provider: e2b({ apiKey }),
+        sandboxTimeoutMs: 5 * 60_000, // TCK sandboxes are short-lived
+      }),
+    { timeoutMs: 120_000 },
+  );
+} else {
+  describe("sandbox TCK: computesdk/e2b", () => {
+    it.skip("skipped: E2B_API_KEY is not set", () => {});
+  });
+}
+
+// ---------------------------------------------------------------------------
+// The fake provider. One Map entry per "sandbox": a temp dir that plays $HOME.
+// ---------------------------------------------------------------------------
+function localShellProvider(): ComputeProvider {
+  const roots = new Map<string, { home: string; destroyed: boolean }>();
+  const pathPrefix = timeoutShimPathPrefix();
+
+  function makeSandbox(id: string): SandboxInterface {
+    const runCommand = async (command: string): Promise<CommandResult> => {
+      const t0 = Date.now();
+      const s = roots.get(id);
+      if (!s || s.destroyed) {
+        // What the e2b provider returns once its caught transport error surfaces.
+        return { stdout: "", stderr: `sandbox ${id} not found`, exitCode: 127, durationMs: 0 };
+      }
+      try {
+        const { stdout, stderr } = await sh("sh", ["-c", command], {
+          env: { ...process.env, HOME: s.home, PATH: pathPrefix + (process.env.PATH ?? "") },
+          maxBuffer: 16 * 1024 * 1024,
+        });
+        return { stdout, stderr, exitCode: 0, durationMs: Date.now() - t0 };
+      } catch (err) {
+        const e = err as { code?: number | string; stdout?: string; stderr?: string; message?: string };
+        return {
+          stdout: e.stdout ?? "",
+          stderr: e.stderr || (e.message ?? String(err)),
+          exitCode: typeof e.code === "number" ? e.code : 127,
+          durationMs: Date.now() - t0,
+        };
+      }
+    };
+    const unused = (what: string) => async (): Promise<never> => {
+      throw new Error(`${what} is not used by the driver`);
+    };
+    return {
+      sandboxId: id,
+      provider: "fake-local",
+      runCommand,
+      getInfo: async () => ({
+        id,
+        provider: "fake-local",
+        status: "running" as const,
+        createdAt: new Date(),
+        timeout: 0,
+      }),
+      getUrl: unused("getUrl"),
+      destroy: async () => {
+        const s = roots.get(id);
+        if (s) s.destroyed = true;
+      },
+      filesystem: {
+        readFile: unused("filesystem.readFile"),
+        writeFile: unused("filesystem.writeFile"),
+        readdir: unused("filesystem.readdir"),
+        mkdir: unused("filesystem.mkdir"),
+        exists: unused("filesystem.exists"),
+        remove: unused("filesystem.remove"),
+      },
+    };
+  }
+
+  return {
+    name: "fake-local",
+    sandbox: {
+      create: async () => {
+        const id = randomUUID();
+        roots.set(id, { home: mkdtempSync(join(tmpdir(), "funky-csdk-")), destroyed: false });
+        return makeSandbox(id);
+      },
+      getById: async (id) => {
+        const s = roots.get(id);
+        return s && !s.destroyed ? makeSandbox(id) : null;
+      },
+      destroy: async (id) => {
+        const s = roots.get(id);
+        if (s) {
+          s.destroyed = true;
+          rmSync(s.home, { recursive: true, force: true });
+        }
+      },
+    },
+  };
+}
+
+// GNU timeout(1) exists on Linux (and inside E2B sandboxes); macOS lacks it. Shim it for
+// local runs so the in-sandbox timeout path is exercised everywhere: TERM the command
+// after the duration and report 124, like the real thing.
+function timeoutShimPathPrefix(): string {
+  if (spawnSync("sh", ["-c", "command -v timeout"]).status === 0) return "";
+  const bin = mkdtempSync(join(tmpdir(), "funky-timeout-shim-"));
+  const shim = join(bin, "timeout");
+  writeFileSync(
+    shim,
+    [
+      "#!/bin/sh",
+      'd="$1"; shift',
+      '"$@" &',
+      "pid=$!",
+      '( sleep "$d"; kill -TERM "$pid" 2>/dev/null ) &',
+      "w=$!",
+      'wait "$pid"',
+      "code=$?",
+      'kill "$w" 2>/dev/null',
+      '[ "$code" -eq 143 ] && exit 124',
+      'exit "$code"',
+      "",
+    ].join("\n"),
+  );
+  chmodSync(shim, 0o755);
+  return `${bin}:`;
+}

--- a/packages/ports/sandbox/src/drivers/computesdk.ts
+++ b/packages/ports/sandbox/src/drivers/computesdk.ts
@@ -1,0 +1,296 @@
+// packages/ports/sandbox/src/drivers/computesdk.ts — remote sandboxes via ComputeSDK.
+//
+// The same idemKey shell protocol as subprocess — the filesystem is the bus — except the
+// files live in a provider-hosted sandbox (E2B today) that OUTLIVES any worker. The
+// runner script stamps `exit` from inside the sandbox, so an in-flight command keeps
+// running and records its result even if the worker that started it dies; any replacement
+// worker holding the handle attaches by idemKey and reads the same files. The command
+// timeout runs in-sandbox too (`timeout(1)`, exit 124), never on a worker timer, for the
+// same reason.
+//
+// Error mapping: ComputeSDK's runCommand NEVER throws — provider/transport errors come
+// back as exitCode 127 with the message in stderr. Our wrapper scripts exit 0 on every
+// legitimate path (the user command's exit code travels via the `exit` file, never via
+// runCommand), so a non-zero WRAPPER exit means the result is unobservable → throw
+// SandboxUnavailableError, exactly the port's "no exit code ⇒ throw" rule.
+
+import * as posix from "node:path/posix";
+import {
+  type CallableCompute,
+  type ExplicitComputeConfig,
+  type SandboxInterface,
+  compute,
+} from "computesdk";
+import type { ResolvedEnv } from "@funky/db/schema";
+import {
+  type ExecEvent,
+  type Executor,
+  type SandboxDriver,
+  type SandboxHandle,
+  SandboxUnavailableError,
+} from "../port";
+
+type Manager = ReturnType<CallableCompute>;
+export type ComputeProvider = NonNullable<ExplicitComputeConfig["provider"]>;
+
+const MAX_OUTPUT_BYTES = 200_000;
+const POLL_MS = 250; // each poll is a network round-trip; slower than subprocess's 100ms
+const DEFAULT_SANDBOX_TIMEOUT_MS = 30 * 60_000;
+
+export type ComputeSdkDriverOptions = {
+  /** Provider name; becomes the handle's `driver` tag (e.g. "e2b"). */
+  providerName: string;
+  /** A ComputeSDK provider instance, e.g. e2b({ apiKey }). */
+  provider: ComputeProvider;
+  /** Idle lifetime before the provider auto-pauses the sandbox — NOT a command timeout.
+   *  A paused sandbox resumes (filesystem intact) on the next connect. */
+  sandboxTimeoutMs?: number;
+};
+
+export class ComputeSdkDriver implements SandboxDriver {
+  private readonly manager: Manager;
+  private readonly providerName: string;
+  private readonly sandboxTimeoutMs: number;
+
+  constructor(opts: ComputeSdkDriverOptions) {
+    this.manager = compute({ provider: opts.provider });
+    this.providerName = opts.providerName;
+    this.sandboxTimeoutMs = opts.sandboxTimeoutMs ?? DEFAULT_SANDBOX_TIMEOUT_MS;
+  }
+
+  async provision(_spec: ResolvedEnv, sessionId: string): Promise<SandboxHandle> {
+    // v1 parity with subprocess: spec.base_image / egress are not mapped yet — the
+    // provider boots its default template. autoPause makes the timeout a pause (disk
+    // persisted, resumed on connect) instead of a kill; that's what keeps reboot honest.
+    const sb = await this.manager.sandbox.create({
+      timeout: this.sandboxTimeoutMs,
+      metadata: { funky_session_id: sessionId },
+      autoPause: true,
+    });
+    // Resolve the workdir REMOTELY ($HOME varies by template). Markers around the path
+    // guard against login-shell noise (motd, profile echoes) polluting stdout.
+    const r = await sb.runCommand(`mkdir -p "$HOME/funky" && printf '@funky:%s@' "$HOME/funky"`);
+    const m = /@funky:([^@]+)@/.exec(r.stdout);
+    if (r.exitCode !== 0 || !m || !m[1]) {
+      await this.manager.sandbox.destroy(sb.sandboxId).catch(() => {}); // don't leak it
+      throw new Error(`sandbox workdir setup failed: ${(r.stderr || r.stdout).trim()}`);
+    }
+    return { driver: this.providerName, sandboxId: sb.sandboxId, workdir: m[1] };
+  }
+
+  // Reconnect: a paused sandbox auto-resumes with its filesystem intact, so the handle
+  // stays valid as-is. A sandbox that is fatally gone (killed, expired) cannot be rebuilt
+  // without losing the filesystem this method promises to keep — that is unavailability
+  // (the turn loop's error policy takes it from here), never a silent fresh provision.
+  async reboot(handle: SandboxHandle): Promise<SandboxHandle> {
+    const h = parseHandle(handle, this.providerName);
+    const sb = await this.manager.sandbox.getById(h.sandboxId).catch(() => null);
+    if (!sb) throw new SandboxUnavailableError(`sandbox ${h.sandboxId} is gone (cannot reboot)`);
+    return handle;
+  }
+
+  // ComputeSDK's destroy swallows provider errors (already-dead sandboxes included), so
+  // calling teardown twice never throws.
+  async teardown(handle: SandboxHandle): Promise<void> {
+    const h = parseHandle(handle, this.providerName);
+    await this.manager.sandbox.destroy(h.sandboxId);
+  }
+
+  connect(handle: SandboxHandle): Executor {
+    const h = parseHandle(handle, this.providerName);
+    return new ComputeSdkExecutor(this.manager, h.sandboxId, h.workdir);
+  }
+}
+
+class ComputeSdkExecutor implements Executor {
+  /** Cached connection, reset on failure so a later call retries fresh. */
+  private sb: Promise<SandboxInterface> | null = null;
+
+  constructor(
+    private readonly manager: Manager,
+    private readonly sandboxId: string,
+    private readonly workdir: string,
+  ) {}
+
+  // getById returns null for a dead sandbox AND for transport failures — both mean the
+  // same thing here: we cannot observe anything, so SandboxUnavailableError.
+  private sandbox(): Promise<SandboxInterface> {
+    this.sb ??= this.manager.sandbox.getById(this.sandboxId).then(
+      (sb) => {
+        if (sb) return sb;
+        this.sb = null;
+        throw new SandboxUnavailableError(`sandbox ${this.sandboxId} is gone`);
+      },
+      (err) => {
+        this.sb = null;
+        throw new SandboxUnavailableError(
+          `sandbox ${this.sandboxId} is unreachable: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      },
+    );
+    return this.sb;
+  }
+
+  exec(req: { cmd: string; idemKey: string; timeoutMs?: number }): AsyncIterable<ExecEvent> {
+    const self = this;
+    return (async function* () {
+      const sb = await self.sandbox();
+      const dir = keyDir(self.workdir, req.idemKey);
+      // One round-trip: atomic mkdir lock + (winner only) write cmd/runner + spawn
+      // detached. Losing the lock IS the attach path — the tail is identical either way.
+      const r = await sb.runCommand(startScript(self.workdir, dir, req.cmd, req.timeoutMs));
+      if (r.exitCode !== 0) throw unavailable(self.sandboxId, r);
+      yield* tail(sb, self.sandboxId, dir);
+    })();
+  }
+
+  attach(idemKey: string): AsyncIterable<ExecEvent> {
+    const self = this;
+    return (async function* () {
+      const sb = await self.sandbox();
+      const dir = keyDir(self.workdir, idemKey);
+      // Nothing recorded under this idemKey → no result to observe. `test -d` failing
+      // for transport reasons lands in the same class: unobservable.
+      const r = await sb.runCommand(`test -d ${shq(dir)}`);
+      if (r.exitCode !== 0) throw new SandboxUnavailableError(`no running command for idemKey: ${idemKey}`);
+      yield* tail(sb, self.sandboxId, dir);
+    })();
+  }
+
+  // File i/o rides runCommand + base64, not ComputeSDK's filesystem API: that API is
+  // string-typed (utf8) and would corrupt binary content. Exit 127 is the provider's
+  // caught-transport-error marker (a real shell reports a missing file as 1/2, a missing
+  // binary as 127 — base64(1) is in every base image), so 127 → unavailable.
+  async readFile(p: string): Promise<Uint8Array> {
+    const abs = this.resolveInside(p);
+    const sb = await this.sandbox();
+    // `base64 < file`, not `base64 file`: BSD base64 (macOS, where the local-shell suite
+    // runs) takes no file argument; stdin works everywhere.
+    const r = await sb.runCommand(`base64 < ${shq(abs)}`);
+    if (r.exitCode === 127) throw unavailable(this.sandboxId, r);
+    if (r.exitCode !== 0) throw new Error(`readFile ${p}: ${r.stderr.trim()}`);
+    return Buffer.from(r.stdout, "base64");
+  }
+
+  async writeFile(p: string, data: Uint8Array): Promise<void> {
+    const abs = this.resolveInside(p);
+    const sb = await this.sandbox();
+    const b64 = Buffer.from(data).toString("base64");
+    const r = await sb.runCommand(
+      `mkdir -p ${shq(posix.dirname(abs))} && printf '%s' '${b64}' | base64 -d > ${shq(abs)}`,
+    );
+    if (r.exitCode === 127) throw unavailable(this.sandboxId, r);
+    if (r.exitCode !== 0) throw new Error(`writeFile ${p}: ${r.stderr.trim()}`);
+  }
+
+  // Reject paths escaping the workdir — same rule as subprocess, POSIX flavor (these are
+  // sandbox-side paths; the host's path semantics are irrelevant).
+  private resolveInside(p: string): string {
+    const abs = posix.resolve(this.workdir, p);
+    const rel = posix.relative(this.workdir, abs);
+    if (rel === "" || rel.startsWith("..") || posix.isAbsolute(rel)) {
+      throw new Error(`path escapes the sandbox: ${p}`);
+    }
+    return abs;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The spawn, mirroring subprocess: `sh cmd > out 2>&1; echo $? > exit`, with `exit` as
+// the completion marker. The command text travels base64-encoded — no shell-quoting rules
+// to fight, any byte sequence survives. `if mkdir` is the atomic first-run lock; losing
+// it exits 0 and the caller just tails. nohup + & detaches the runner from this
+// runCommand, so it keeps going after the RPC returns.
+// ---------------------------------------------------------------------------
+function startScript(workdir: string, dir: string, cmd: string, timeoutMs?: number): string {
+  const t = timeoutMs && timeoutMs > 0 ? `timeout ${timeoutMs / 1000} ` : "";
+  const runner = [
+    `cd ${shq(workdir)}`,
+    `${t}sh ${shq(posix.join(dir, "cmd"))} > ${shq(posix.join(dir, "out"))} 2>&1`,
+    `echo $? > ${shq(posix.join(dir, "exit"))}`,
+  ].join("\n");
+  return [
+    `mkdir -p ${shq(posix.join(workdir, ".funky"))}`,
+    `if mkdir ${shq(dir)} 2>/dev/null; then`,
+    `printf '%s' '${b64(cmd)}' | base64 -d > ${shq(posix.join(dir, "cmd"))}`,
+    `printf '%s' '${b64(runner)}' | base64 -d > ${shq(posix.join(dir, "run"))}`,
+    `nohup sh ${shq(posix.join(dir, "run"))} >/dev/null 2>&1 &`,
+    `fi`,
+  ].join("\n");
+}
+
+// One poll round-trip emits a three-part envelope on stdout:
+//   line 1: exit code, or empty while still running
+//   line 2: total byte size of `out` (drives the truncated flag)
+//   rest:   base64 of out[offset .. offset+cap)
+// `exit` is read FIRST: `out` is complete before `exit` is stamped, so an exit code on
+// line 1 guarantees the slice that follows is the final one — no drain race.
+function pollScript(dir: string, offset: number, cap: number): string {
+  const out = shq(posix.join(dir, "out"));
+  const exit = shq(posix.join(dir, "exit"));
+  return [
+    `if [ -s ${exit} ]; then head -n 1 ${exit}; else echo; fi`,
+    `if [ -f ${out} ]; then wc -c < ${out}; else echo 0; fi`,
+    `if [ -f ${out} ]; then tail -c +${offset + 1} ${out} | head -c ${cap} | base64; fi`,
+  ].join("\n");
+}
+
+async function* tail(sb: SandboxInterface, sandboxId: string, dir: string): AsyncGenerator<ExecEvent> {
+  let offset = 0; // bytes of `out` already yielded; never exceeds MAX_OUTPUT_BYTES
+  for (;;) {
+    const r = await sb.runCommand(pollScript(dir, offset, MAX_OUTPUT_BYTES - offset));
+    if (r.exitCode !== 0) throw unavailable(sandboxId, r);
+
+    const lines = r.stdout.split("\n");
+    const exitRaw = (lines[0] ?? "").trim();
+    const size = Number.parseInt((lines[1] ?? "0").trim(), 10);
+    // base64(1) wraps its output; joining the remaining lines undoes the wrapping.
+    const chunk = Buffer.from(lines.slice(2).join(""), "base64");
+
+    if (chunk.length > 0) {
+      offset += chunk.length;
+      yield { kind: "stdout", data: chunk.toString("utf8") };
+    }
+    const code = exitRaw === "" ? Number.NaN : Number.parseInt(exitRaw, 10);
+    if (!Number.isNaN(code)) {
+      // `exit` stamped but unparseable falls through and polls again, like subprocess.
+      yield { kind: "exit", code, truncated: !Number.isNaN(size) && size > MAX_OUTPUT_BYTES };
+      return;
+    }
+    await sleep(POLL_MS);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers.
+// ---------------------------------------------------------------------------
+function keyDir(workdir: string, idemKey: string): string {
+  return posix.join(workdir, ".funky", idemKey);
+}
+
+function unavailable(sandboxId: string, r: { exitCode: number; stderr: string }): SandboxUnavailableError {
+  return new SandboxUnavailableError(
+    `sandbox ${sandboxId} unreachable (wrapper exit ${r.exitCode}): ${r.stderr.trim()}`,
+  );
+}
+
+function parseHandle(handle: SandboxHandle, providerName: string): { sandboxId: string; workdir: string } {
+  const { sandboxId, workdir } = handle as { sandboxId?: unknown; workdir?: unknown };
+  if (handle.driver !== providerName || typeof sandboxId !== "string" || typeof workdir !== "string") {
+    throw new Error(`not a ${providerName} sandbox handle`);
+  }
+  return { sandboxId, workdir };
+}
+
+function b64(s: string): string {
+  return Buffer.from(s, "utf8").toString("base64");
+}
+
+// Single-quote for the shell, escaping embedded single quotes.
+function shq(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/ports/sandbox/src/index.ts
+++ b/packages/ports/sandbox/src/index.ts
@@ -4,22 +4,34 @@
 export type { ExecEvent, Executor, SandboxDriver, SandboxHandle } from "./port";
 export { SandboxUnavailableError } from "./port";
 export { SubprocessDriver } from "./drivers/subprocess";
+export { ComputeSdkDriver, type ComputeSdkDriverOptions, type ComputeProvider } from "./drivers/computesdk";
 export { runSandboxTck } from "./tck";
 
-import type { SandboxDriver } from "./port";
+import { e2b } from "@computesdk/e2b";
+import { ComputeSdkDriver } from "./drivers/computesdk";
 import { SubprocessDriver } from "./drivers/subprocess";
+import type { SandboxDriver } from "./port";
 
-export type SandboxConfig = { driver: "subprocess" };
+export type SandboxConfig =
+  | { driver: "subprocess" }
+  | { driver: "e2b"; apiKey: string; sandboxTimeoutMs?: number };
 
-/** Build a driver from config. Only `subprocess` exists in v1; container / computesdk
- *  drivers slot in here later without touching callers. */
+/** Build a driver from config. `subprocess` is the zero-setup dev default (commands run
+ *  in the worker's own container); `e2b` provisions an isolated remote sandbox per
+ *  session via ComputeSDK — further providers slot in here without touching callers. */
 export function makeSandbox(cfg: SandboxConfig): SandboxDriver {
   switch (cfg.driver) {
     case "subprocess":
       return new SubprocessDriver();
+    case "e2b":
+      return new ComputeSdkDriver({
+        providerName: "e2b",
+        provider: e2b({ apiKey: cfg.apiKey }),
+        sandboxTimeoutMs: cfg.sandboxTimeoutMs,
+      });
     default: {
-      const never: never = cfg.driver;
-      throw new Error(`unknown sandbox driver: ${never}`);
+      const never: never = cfg;
+      throw new Error(`unknown sandbox driver: ${JSON.stringify(never)}`);
     }
   }
 }

--- a/packages/ports/sandbox/src/tck.ts
+++ b/packages/ports/sandbox/src/tck.ts
@@ -8,10 +8,7 @@
 //   runSandboxTck("subprocess", () => new SubprocessDriver());
 
 import { randomUUID } from "node:crypto";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it as baseIt } from "vitest";
 import { type ExecEvent, type Executor, type SandboxDriver, SandboxUnavailableError } from "./port";
 import type { ResolvedEnv } from "@funky/db/schema";
 
@@ -35,13 +32,19 @@ async function collect(it: AsyncIterable<ExecEvent>): Promise<Collected> {
   return { stdout, stderr, exit };
 }
 
-export function runSandboxTck(name: string, makeDriver: () => SandboxDriver): void {
+export function runSandboxTck(
+  name: string,
+  makeDriver: () => SandboxDriver,
+  opts?: { timeoutMs?: number }, // remote drivers provision + poll over the network
+): void {
+  const timeout = opts?.timeoutMs;
+  const it = timeout === undefined ? baseIt : (n: string, fn: () => Promise<void>) => baseIt(n, { timeout }, fn);
   describe(`sandbox TCK: ${name}`, () => {
     // Every case provisions its own sandbox (unique sessionId) and registers teardown.
     const cleanups: Array<() => Promise<void>> = [];
     afterEach(async () => {
       for (const c of cleanups.splice(0)) await c().catch(() => {});
-    });
+    }, timeout);
 
     async function sandbox(): Promise<{ driver: SandboxDriver; handle: Awaited<ReturnType<SandboxDriver["provision"]>>; exec: Executor }> {
       const driver = makeDriver();
@@ -66,11 +69,10 @@ export function runSandboxTck(name: string, makeDriver: () => SandboxDriver): vo
 
     it("3. dedupe: two concurrent execs of one idemKey run the command once", async () => {
       const { exec } = await sandbox();
-      const dir = await mkdtemp(join(tmpdir(), "funky-tck-"));
-      const marker = join(dir, "marker");
-      cleanups.push(() => rm(dir, { recursive: true, force: true }));
-
-      const cmd = `echo shared; echo $$ >> ${quote(marker)}; sleep 0.3`;
+      // The marker lives INSIDE the sandbox (commands run with cwd = the sandbox workdir)
+      // and is read back through the port — no host-filesystem assumptions, so the case
+      // holds for remote drivers too.
+      const cmd = `echo shared; echo $$ >> marker; sleep 0.3`;
       // Both start ~together; whichever wins the mkdir spawns, the other attaches. The
       // filesystem is the bus, so both iterables observe the same output either way.
       const [a, b] = await Promise.all([
@@ -83,7 +85,8 @@ export function runSandboxTck(name: string, makeDriver: () => SandboxDriver): vo
       expect(a.exit.code).toBe(0);
       expect(b.exit.code).toBe(0);
 
-      const lines = (await readFile(marker, "utf8")).trim().split("\n").filter(Boolean);
+      const marker = new TextDecoder().decode(await exec.readFile("marker"));
+      const lines = marker.trim().split("\n").filter(Boolean);
       expect(lines).toHaveLength(1); // command body executed exactly once
     });
 
@@ -148,9 +151,4 @@ export function runSandboxTck(name: string, makeDriver: () => SandboxDriver): vo
       expect(r.exit.code).toBe(124); // bash timeout convention — still a result, not an error
     });
   });
-}
-
-// Single-quote for the shell (the marker path we hand into the test command).
-function quote(s: string): string {
-  return `'${s.replace(/'/g, `'\\''`)}'`;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,12 +184,18 @@ importers:
 
   packages/ports/sandbox:
     dependencies:
+      '@computesdk/e2b':
+        specifier: ^1.7.51
+        version: 1.7.51
       '@funky/db':
         specifier: workspace:*
         version: link:../../db
       '@funky/sessions':
         specifier: workspace:*
         version: link:../../sessions
+      computesdk:
+        specifier: ^4.1.3
+        version: 4.1.3
     devDependencies:
       vitest:
         specifier: ^4.1.10
@@ -264,6 +270,29 @@ packages:
 
   '@balena/dockerignore@1.0.2':
     resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
+
+  '@bufbuild/protobuf@2.12.1':
+    resolution: {integrity: sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==}
+
+  '@computesdk/cmd@0.4.1':
+    resolution: {integrity: sha512-hhcYrwMnOpRSwWma3gkUeAVsDFG56nURwSaQx8vCepv0IuUv39bK4mMkgszolnUQrVjBDdW7b3lV+l5B2S8fRA==}
+
+  '@computesdk/e2b@1.7.51':
+    resolution: {integrity: sha512-fFDLFtPp8acJdJbdAFn8Uvbps+pvCGTf1mq84jFbNroDNim/rWa3T1C0c7iBTWufBz2An5tWqRBxIZzb+5JUPw==}
+
+  '@computesdk/provider@2.1.3':
+    resolution: {integrity: sha512-soT+eu9VdeLkDjMdHe2fWh0WoiQ1C6xlMIdw8UKlJz5ivipJE6HP6Emm05qUdpeXooWquL1o3LQtRQDMFsrTfA==}
+
+  '@connectrpc/connect-web@2.1.2':
+    resolution: {integrity: sha512-1tfaK85MU+gJjwwmL31d2rzdf0XCYX99chZf63uG89SGBUd4XuZ4ZzhGo2u79TPXOE6nLIZQ2okrpyey42PYdg==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
+      '@connectrpc/connect': 2.1.2
+
+  '@connectrpc/connect@2.1.2':
+    resolution: {integrity: sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
 
   '@drizzle-team/brocli@0.11.0':
     resolution: {integrity: sha512-hD3pekGiPg0WPCCGAZmusBBJsDqGUR66Y452YgQsZOnkdQ7ViEPKuyP4huUGEZQefp8g34RRodXYmJ2TbCH+tg==}
@@ -622,6 +651,14 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
@@ -903,6 +940,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   bare-events@2.9.1:
     resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
     peerDependencies:
@@ -952,6 +993,10 @@ packages:
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
+    engines: {node: 18 || 20 || >=22}
+
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
@@ -974,8 +1019,16 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -988,9 +1041,15 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
+
   compress-commons@6.0.2:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
     engines: {node: '>= 14'}
+
+  computesdk@4.1.3:
+    resolution: {integrity: sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1015,6 +1074,11 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  daemond@0.1.4:
+    resolution: {integrity: sha512-xiLScBiwYGGPmxfcAb24aH+FkmR/ZSd+PxOvigGpKda6OsDjE2Gj6/4oAX2N3hMWoL4atti1hYyF9dLV3FFM0A==}
+    engines: {node: '>=18.0.0'}
+    os: [linux, darwin]
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1035,6 +1099,9 @@ packages:
   docker-modem@5.0.7:
     resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
     engines: {node: '>= 8.0'}
+
+  dockerfile-ast@0.7.1:
+    resolution: {integrity: sha512-oX/A4I0EhSkGqrFv0YuvPkBUSYp1XiY8O8zAKc8Djglx8ocz+JfOr8gP0ryRMC2myqvDLagmnZaU9ot1vG2ijw==}
 
   dockerode@5.0.1:
     resolution: {integrity: sha512-avsq/xk4YPIrn0CgleX5bjT9Y8IT1p9PxrNQ++RBQ2WEyFfHCTDsT9kmyxz+H/axnjAwg8wJWEIuPGOUuNupiA==}
@@ -1164,6 +1231,10 @@ packages:
       zod:
         optional: true
 
+  e2b@2.33.0:
+    resolution: {integrity: sha512-n6W0nsJMetz8m30sLPMYfliPTW0VpuaDTUOjB0ZdYZ87li4zyX0UQqeQ5S/YPvq8EX9zEYcy3SijBxn1FGFlkQ==}
+    engines: {node: '>=20.18.1 <21 || >=22'}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -1255,6 +1326,12 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
+    engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -1284,6 +1361,10 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -1381,8 +1462,16 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
@@ -1395,6 +1484,10 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
@@ -1426,6 +1519,12 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  openapi-fetch@0.14.1:
+    resolution: {integrity: sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==}
+
+  openapi-typescript-helpers@0.0.15:
+    resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
+
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
@@ -1436,6 +1535,10 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1480,6 +1583,9 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
   postcss@8.5.16:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
@@ -1641,6 +1747,10 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
+  tar@7.5.20:
+    resolution: {integrity: sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==}
+    engines: {node: '>=18'}
+
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
@@ -1690,6 +1800,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   undici@8.7.0:
     resolution: {integrity: sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==}
@@ -1786,6 +1900,12 @@ packages:
       jsdom:
         optional: true
 
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.18.0:
+    resolution: {integrity: sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1814,6 +1934,10 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -1869,6 +1993,31 @@ snapshots:
       json-schema: 0.4.0
 
   '@balena/dockerignore@1.0.2': {}
+
+  '@bufbuild/protobuf@2.12.1': {}
+
+  '@computesdk/cmd@0.4.1': {}
+
+  '@computesdk/e2b@1.7.51':
+    dependencies:
+      '@computesdk/provider': 2.1.3
+      computesdk: 4.1.3
+      e2b: 2.33.0
+
+  '@computesdk/provider@2.1.3':
+    dependencies:
+      '@computesdk/cmd': 0.4.1
+      computesdk: 4.1.3
+      daemond: 0.1.4
+
+  '@connectrpc/connect-web@2.1.2(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.1))':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.1
+      '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.12.1)
+
+  '@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.1)':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.1
 
   '@drizzle-team/brocli@0.11.0': {}
 
@@ -2082,6 +2231,12 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@isaacs/cliui@9.0.0': {}
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -2347,6 +2502,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   bare-events@2.9.1: {}
 
   bare-fs@4.7.4:
@@ -2392,6 +2549,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
+  brace-expansion@5.0.7:
+    dependencies:
+      balanced-match: 4.0.4
+
   buffer-crc32@1.0.0: {}
 
   buffer@5.7.1:
@@ -2411,7 +2572,11 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chalk@5.6.2: {}
+
   chownr@1.1.4: {}
+
+  chownr@3.0.0: {}
 
   cliui@8.0.1:
     dependencies:
@@ -2425,6 +2590,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  compare-versions@6.1.1: {}
+
   compress-commons@6.0.2:
     dependencies:
       crc-32: 1.2.2
@@ -2432,6 +2599,11 @@ snapshots:
       is-stream: 2.0.1
       normalize-path: 3.0.0
       readable-stream: 4.7.0
+
+  computesdk@4.1.3:
+    dependencies:
+      '@computesdk/cmd': 0.4.1
+      daemond: 0.1.4
 
   convert-source-map@2.0.0: {}
 
@@ -2456,6 +2628,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  daemond@0.1.4: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -2474,6 +2648,11 @@ snapshots:
       ssh2: 1.17.0
     transitivePeerDependencies:
       - supports-color
+
+  dockerfile-ast@0.7.1:
+    dependencies:
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.18.0
 
   dockerode@5.0.1:
     dependencies:
@@ -2502,6 +2681,20 @@ snapshots:
       '@types/pg': 8.20.0
       pg: 8.22.0
       zod: 4.4.3
+
+  e2b@2.33.0:
+    dependencies:
+      '@bufbuild/protobuf': 2.12.1
+      '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.12.1)
+      '@connectrpc/connect-web': 2.1.2(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.1))
+      chalk: 5.6.2
+      compare-versions: 6.1.1
+      dockerfile-ast: 0.7.1
+      glob: 11.1.0
+      openapi-fetch: 0.14.1
+      platform: 1.3.6
+      tar: 7.5.20
+      undici: 7.28.0
 
   eastasianwidth@0.2.0: {}
 
@@ -2626,6 +2819,15 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@11.1.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.2.3
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.2
+
   graceful-fs@4.2.11: {}
 
   hono@4.12.29: {}
@@ -2647,6 +2849,10 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
 
   jiti@2.7.0: {}
 
@@ -2715,9 +2921,15 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.5.2: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.7
 
   minimatch@5.1.9:
     dependencies:
@@ -2728,6 +2940,10 @@ snapshots:
       brace-expansion: 2.1.2
 
   minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
 
   mkdirp-classic@0.5.3: {}
 
@@ -2748,6 +2964,12 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  openapi-fetch@0.14.1:
+    dependencies:
+      openapi-typescript-helpers: 0.0.15
+
+  openapi-typescript-helpers@0.0.15: {}
+
   package-json-from-dist@1.0.1: {}
 
   path-key@3.1.1: {}
@@ -2755,6 +2977,11 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
+      minipass: 7.1.3
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.2
       minipass: 7.1.3
 
   pathe@2.0.3: {}
@@ -2797,6 +3024,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
+
+  platform@1.3.6: {}
 
   postcss@8.5.16:
     dependencies:
@@ -3021,6 +3250,14 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
+  tar@7.5.20:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   teex@1.0.1:
     dependencies:
       streamx: 2.28.0
@@ -3087,6 +3324,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici@7.28.0: {}
+
   undici@8.7.0: {}
 
   util-deprecate@1.0.2: {}
@@ -3135,6 +3374,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.18.0: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -3161,6 +3404,8 @@ snapshots:
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
+
+  yallist@5.0.0: {}
 
   yaml@2.9.0: {}
 


### PR DESCRIPTION
Adds the first remote sandbox driver: the same idemKey file protocol as subprocess, but the `out`/`exit` files live inside an E2B sandbox (provisioned via ComputeSDK) that outlives any worker, so in-flight commands survive worker death and timeouts run in-sandbox via `timeout(1)`. Wrapper scripts always exit 0, making the port's error rule mechanical: a non-zero wrapper exit means the result is unobservable → `SandboxUnavailableError`; the user command's exit code travels only via the `exit` file, and `autoPause` keeps `reboot()` honest. The TCK now runs against this driver through a local-shell fake provider (keyless, in CI — real E2B runs are gated on `E2B_API_KEY`), with case 3 rewritten to stop assuming the sandbox shares the host filesystem. Wires `FUNKY_SANDBOX=e2b` + `E2B_API_KEY` through worker config, compose, and `.env.example`, and replaces the README's "not yet" sandbox section with the real recipe. Also fixes a latent compose bug: `${VAR:-}` interpolation delivers empty strings that `z.string().min(1).optional()` rejected, so empty optional secrets are now treated as absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)