### PR TITLE
Fix chaos-suite CI flake: drain the pull loop before expiring a lease

### DIFF
--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -42,8 +42,13 @@ export type WorkerDeps = {
 export type WorkerHandle = {
   /** Graceful: stop pulling, let in-flight turns finish, resolve when idle. */
   stop(): Promise<void>;
-  /** Ungraceful: abandon everything immediately (simulates SIGKILL). Tests use this. */
-  kill(): void;
+  /** Ungraceful: abandon everything immediately (simulates SIGKILL). Tests use this.
+   *  Resolves when the pull loop has exited. Until then, a pull() already on the wire can
+   *  still land and CLAIM a job — which the dying loop abandons with a fresh full lease —
+   *  so anything that edits leases after a kill (the chaos suite's expireLease) must await
+   *  this first. In-flight turns are NOT awaited: they can't be cancelled, and their late
+   *  writes surface as harmless ErrConflict. */
+  kill(): Promise<void>;
 };
 
 /** Mutable counters shared with health.ts. `inFlight` is the concurrency dial observed;
@@ -193,6 +198,7 @@ export function startWorker(deps: WorkerDeps): WorkerHandle {
       // makes any late write from this worker a harmless ErrConflict.
       for (const beat of heartbeats) clearInterval(beat);
       heartbeats.clear();
+      return loopDone; // settles once any in-flight pull has landed — no further claims after this
     },
   };
 }

--- a/apps/worker/test/worker.test.ts
+++ b/apps/worker/test/worker.test.ts
@@ -215,9 +215,11 @@ it("runs one enqueued turn to completion and acks the job", async () => {
 
   await startTestWorker({ llm: doneLlm() });
 
-  await waitFor(async () => (await eventTypes(sid)).at(-1) === "turn_completed", 15_000, "completed");
+  // Wait for the ACK (row gone), not the terminal event: the event is appended inside the
+  // turn BEFORE the worker acks, so asserting on the row right after the event races the
+  // delete. The job being gone is the unambiguous "fully processed" signal.
+  await waitFor(async () => !(await jobExists(jobId)), 15_000, "completed and acked");
   expect(await eventTypes(sid)).toEqual(["user_message", "assistant_message", "turn_completed"]);
-  expect(await jobExists(jobId)).toBe(false); // acked → row gone
 });
 
 it("interleaves many turns on one event loop (handle is not awaited)", async () => {
@@ -436,14 +438,14 @@ it("★ crash-resumes: worker B finishes the turn worker A abandoned, running th
   // Worker B — real sandbox — reclaims the expired lease and finishes the turn.
   await startTestWorker({ llm, sandbox: realSandbox });
 
-  await waitFor(async () => (await eventTypes(sid)).at(-1) === "turn_completed", 15_000, "B completed");
+  // Job-gone = the terminal event landed AND B acked (the event alone races the ack).
+  await waitFor(async () => !(await jobExists(jobId)), 15_000, "B completed and acked");
 
   const events = await store.readEvents(NS, sid);
   const toolResults = events.filter((e) => e.type === "tool_result");
   expect(toolResults).toHaveLength(1); // the command ran ONCE (one tool_result)
   expect((toolResults[0]!.payload as { output: string }).output).toContain("RAN");
   expect(events.at(-1)?.type).toBe("turn_completed");
-  expect(await jobExists(jobId)).toBe(false);
 });
 
 it("drains: stop() resolves only after the in-flight turn finishes", async () => {
@@ -528,8 +530,10 @@ it("kill() resolves only after an in-flight pull lands, so post-kill lease edits
   // Because kill() was awaited, this expiry cannot be raced; a fresh worker reclaims at once.
   await pool.query("update turn_jobs set lease_expires_at = now() - interval '1 second' where id=$1", [jobId]);
   await startTestWorker({ llm: doneLlm() });
-  await waitFor(async () => (await eventTypes(sid)).at(-1) === "turn_completed", 15_000, "B completed");
-  expect(await jobExists(jobId)).toBe(false);
+  // Job-gone, not the terminal event: the event lands before the ack, so asserting on the
+  // row right after seeing the event would race B's delete.
+  await waitFor(async () => !(await jobExists(jobId)), 15_000, "B completed and acked");
+  expect((await eventTypes(sid)).at(-1)).toBe("turn_completed");
 });
 
 it("wakes on NOTIFY, starting the turn well before the fallback poll", async () => {

--- a/apps/worker/test/worker.test.ts
+++ b/apps/worker/test/worker.test.ts
@@ -99,12 +99,13 @@ async function startTestWorker(opts: {
   sandbox?: SandboxDriver;
   concurrency?: number;
   heartbeatMs?: number;
+  queue?: JobQueue; // fault-injection seam (the gated-pull kill test)
 }): Promise<{ worker: WorkerHandle; metrics: ReturnType<typeof createMetrics> }> {
   const listenClient = new Client({ connectionString: connectionUri });
   await listenClient.connect();
   const metrics = createMetrics();
   const worker = startWorker({
-    queue,
+    queue: opts.queue ?? queue,
     store,
     db,
     llm: opts.llm,
@@ -115,7 +116,7 @@ async function startTestWorker(opts: {
     ...(opts.heartbeatMs !== undefined ? { heartbeatMs: opts.heartbeatMs } : {}),
   });
   cleanups.push(async () => {
-    worker.kill();
+    await worker.kill(); // await the loop's exit so no straggler pull outlives the test
     await listenClient.end();
   });
   return { worker, metrics };
@@ -428,7 +429,8 @@ it("★ crash-resumes: worker B finishes the turn worker A abandoned, running th
     15_000,
     "A appended the tool call",
   );
-  workerA.kill(); // crash A: heartbeats stop, its in-flight turn is abandoned
+  await workerA.kill(); // crash A: heartbeats stop, its in-flight turn is abandoned (awaited
+  // so a pull already on the wire lands BEFORE the expiry below — it can't re-lease the job)
   await pool.query("update turn_jobs set lease_expires_at = now() - interval '1 second' where id=$1", [jobId]);
 
   // Worker B — real sandbox — reclaims the expired lease and finishes the turn.
@@ -465,6 +467,69 @@ it("drains: stop() resolves only after the in-flight turn finishes", async () =>
   await stopP;
   expect(stopped).toBe(true);
   expect((await eventTypes(sid)).at(-1)).toBe("turn_completed");
+});
+
+/** A queue whose FIRST pull() parks before touching the database — the claim is "on the
+ *  wire" while the caller does something else (kills the worker). Later pulls pass through. */
+class GatedPullQueue extends JobQueue {
+  private parked = false;
+  constructor(
+    dbase: Db,
+    private readonly onParked: () => void,
+    private readonly gate: Promise<void>,
+  ) {
+    super(dbase);
+  }
+  override async pull() {
+    if (!this.parked) {
+      this.parked = true;
+      this.onParked();
+      await this.gate;
+    }
+    return super.pull();
+  }
+}
+
+it("kill() resolves only after an in-flight pull lands, so post-kill lease edits stick", async () => {
+  // The chaos-suite race, made deterministic: kill() cannot cancel a pull already on the
+  // wire. If that straggler executes AFTER a test's lease-expiry, it re-claims the job with
+  // a fresh 60s lease that the dead loop abandons — starving the replacement worker. The
+  // contract under test: kill()'s promise settles only once the loop (and thus any in-flight
+  // claim) is done, so `await kill()` before a lease edit makes the edit the last word.
+  const sid = await seedSession();
+  await appendUser(sid);
+  const jobId = await insertTurnJob(sid);
+
+  let parkedResolve!: () => void;
+  const parked = new Promise<void>((r) => (parkedResolve = r));
+  let release!: () => void;
+  const gate = new Promise<void>((r) => (release = r));
+  const { worker } = await startTestWorker({
+    llm: doneLlm(),
+    queue: new GatedPullQueue(db, parkedResolve, gate),
+  });
+  await parked; // the loop's first pull is now in flight, pre-claim
+
+  let killSettled = false;
+  const killP = worker.kill().then(() => (killSettled = true));
+  await sleep(80);
+  expect(killSettled).toBe(false); // the parked pull hasn't landed — kill must still be pending
+
+  // Release the pull: it claims the job (fresh 60s lease), and the dying loop abandons it
+  // between pull and dispatch. Only then does kill() settle — with the claim visible.
+  release();
+  await killP;
+  const { rows } = await pool.query<{ state: string; attempts: number }>(
+    "select state, attempts from turn_jobs where id=$1",
+    [jobId],
+  );
+  expect(rows[0]).toMatchObject({ state: "running", attempts: 1 }); // the straggler claim landed first
+
+  // Because kill() was awaited, this expiry cannot be raced; a fresh worker reclaims at once.
+  await pool.query("update turn_jobs set lease_expires_at = now() - interval '1 second' where id=$1", [jobId]);
+  await startTestWorker({ llm: doneLlm() });
+  await waitFor(async () => (await eventTypes(sid)).at(-1) === "turn_completed", 15_000, "B completed");
+  expect(await jobExists(jobId)).toBe(false);
 });
 
 it("wakes on NOTIFY, starting the turn well before the fallback poll", async () => {

--- a/tests/chaos/src/h1.kill-boundaries.test.ts
+++ b/tests/chaos/src/h1.kill-boundaries.test.ts
@@ -45,6 +45,11 @@ describe("H1 — crash at each append boundary → the log always matches", () =
       await waitFor(() => dead, 30_000, `A reaches append #${n}`);
 
       // B can only claim once A's lease expires. Don't sleep 60s — expire it directly.
+      // But drain A's pull loop first: kill() can't cancel a pull() already on the wire,
+      // and on a slow DB that straggler executes AFTER the expiry below, re-claiming the
+      // job with a fresh 60s lease that the dying loop then abandons — starving B past
+      // the waitFor. Awaiting kill() guarantees any such claim landed before the expiry.
+      await workerA.kill();
       await world.expireLease(jobId);
       await world.startWorker(); // clean worker B
 

--- a/tests/chaos/src/h4.reattach.test.ts
+++ b/tests/chaos/src/h4.reattach.test.ts
@@ -54,6 +54,10 @@ it("B attaches to A's still-running command: it finishes the turn, running the c
   workerA = a.worker;
 
   await waitFor(() => killedAt > 0, 30_000, "A killed mid-command");
+  // Drain A's pull loop before expiring — a straggler pull() landing after the expiry would
+  // re-claim the job with a fresh 60s lease and abandon it, starving B. See h1. (kill(), not
+  // stop(): A's turn is hung in the sandbox forever, and kill() only awaits the loop.)
+  await workerA.kill();
   await world.expireLease(jobId);
 
   // B — real sandbox — replays the log and exec's the same idemKey → attaches.

--- a/tests/chaos/src/h6.provision-crash.test.ts
+++ b/tests/chaos/src/h6.provision-crash.test.ts
@@ -35,6 +35,10 @@ it("crash mid-provision → second worker provisions, one event, one workdir", a
   workerA = a.worker;
 
   await waitFor(() => dead, 30_000, "A crashed mid-provision");
+  // Drain A's pull loop before expiring: a pull() already on the wire when A was killed can
+  // execute after the expiry and re-claim the job with a fresh 60s lease (which the dying
+  // loop abandons), starving B past the waitFor below. See h1 for the full story.
+  await workerA.kill();
   await world.expireLease(jobId);
 
   // B — clean store — reclaims the provision job and completes it. B flips the session to

--- a/tests/chaos/src/h7.soak.test.ts
+++ b/tests/chaos/src/h7.soak.test.ts
@@ -73,7 +73,8 @@ it("50 sessions × 3 workers × random kills → all complete, zero double-execu
     if (Date.now() - start > CAP_MS) throw new Error(`soak timed out: ${await completedCount()}/${N} completed`);
     if (rand() < 0.1) {
       const idx = Math.floor(rand() * workers.length);
-      workers[idx]!.kill(); // stop pulling, stop heartbeats, abandon in-flight
+      await workers[idx]!.kill(); // stop pulling, stop heartbeats, abandon in-flight (awaited
+      // so a straggler pull can't land after the expiry below and re-lease a job for 60s)
       // Release the dead worker's orphaned jobs promptly (don't wait out the 60s lease). Live
       // workers re-extend within 200ms, so this only permanently frees the abandoned ones.
       await pool.query("update turn_jobs set lease_expires_at = now() - interval '1 minute' where state = 'running'");

--- a/tests/chaos/src/harness.ts
+++ b/tests/chaos/src/harness.ts
@@ -184,6 +184,9 @@ export type World = {
 
   startWorker(opts?: StartWorkerOpts): Promise<RunningWorker>;
 
+  /** Backdate a job's lease so it is reclaimable NOW (instead of sleeping out LEASE_MS).
+   *  Callers must first `await kill()` on any worker that might still have a pull() on the
+   *  wire — a straggler claim landing after this expiry would re-lease the job for 60s. */
   expireLease(jobId: string): Promise<void>;
   jobState(jobId: string): Promise<string | null>;
   jobExists(jobId: string): Promise<boolean>;
@@ -297,7 +300,7 @@ export async function buildWorld(
         ...(o.heartbeatMs !== undefined ? { heartbeatMs: o.heartbeatMs } : {}),
       });
       cleanups.push(async () => {
-        worker.kill();
+        await worker.kill(); // await the loop's exit so no straggler pull outlives the test
         await listenClient.end().catch(() => {});
       });
       return { worker, metrics };


### PR DESCRIPTION
The h1/h6 timeouts on main ("timed out waiting for B ... acks") were a shutdown race: `kill()` can't cancel a `queue.pull()` already on the wire, and on a loaded runner that straggler executes after the test's `expireLease`, re-claiming the job with a fresh 60s lease that the dying loop then abandons — starving worker B past the 30s wait. `WorkerHandle.kill()` now returns the pull loop's completion promise, so awaiting it guarantees any in-flight claim has landed before a lease is backdated. The exposed tests (chaos h1/h4/h6, the h7 soak supervisor, the worker crash-resume test) and both test harnesses' cleanups now await the kill before touching leases. A new worker test pins the contract deterministically by parking a pull mid-flight through a gated queue and asserting `kill()` settles only after the claim is visible. Harness liveness only — production semantics are unchanged (an abandoned claim always self-healed after LEASE_MS; nothing ever ran twice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)