### PR TITLE
Bump CI actions to Node 24 releases (checkout v7, setup-node v7, pnpm v6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -51,9 +51,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
Every CI job currently logs a "Node.js 20 is deprecated" annotation because the v4 releases of actions/checkout, actions/setup-node, and pnpm/action-setup declare a node20 runtime that the runner force-upgrades to Node 24. This bumps all three to their current majors (checkout v7, setup-node v7, pnpm/action-setup v6), which target Node 24 natively. No workflow inputs change across these majors: node-version 22 and pnpm caching behave as before, and pnpm/action-setup keeps resolving the pnpm version from the packageManager field in package.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)