### PR TITLE
Drop base_image and persistent_fs from environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ AID=$(curl -s -X POST localhost:3000/v1/agents -H "$H" -H "$J" -d '{
 
 # 2. an environment: where its commands run
 EID=$(curl -s -X POST localhost:3000/v1/environments -H "$H" -H "$J" -d '{
-  "name": "basic",
-  "base_image": "funky/base:latest"
+  "name": "basic"
 }' | jq -r .id)
 
 # 3. a session: an agent + an environment, with a sandbox and a durable event log

--- a/apps/api/src/routes/environments.ts
+++ b/apps/api/src/routes/environments.ts
@@ -9,20 +9,9 @@ type Env = { Variables: { auth: AuthContext; requestId: string } };
 
 // ------------------------------------------------------------ zod schemas
 
-// loose image-ref sanity (repo[:tag][@digest]); no whitespace
-const baseImageSchema = z
-  .string()
-  .min(1)
-  .max(512)
-  .regex(/^[\w][\w.\-\/:@]*$/, "must be a valid image reference");
-
 // bare or wildcard-prefixed domain, no scheme, no path
 const hostnameRegex =
   /^(\*\.)?[a-z0-9]([a-z0-9\-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9\-]*[a-z0-9])?)*$/i;
-
-const persistentFsSchema = z
-  .object({ size_gb: z.number().int().min(1).max(100) })
-  .strict();
 
 const egressSchema = z
   .object({
@@ -38,8 +27,6 @@ const createSchema = z
     name: z.string().min(1).max(256),
     description: z.string().max(2048).nullish(),
     metadata: metadataSchema.optional(),
-    base_image: baseImageSchema,
-    persistent_fs: persistentFsSchema.optional(),
     egress: egressSchema.optional(),
   })
   .strict();

--- a/apps/api/test/sessions.integration.test.ts
+++ b/apps/api/test/sessions.integration.test.ts
@@ -68,7 +68,7 @@ async function seedAgent(ctx: AuthContext = CTX): Promise<string> {
 }
 
 async function seedEnv(ctx: AuthContext = CTX): Promise<string> {
-  const { environment } = await envs.create(ctx, { name: "env", base_image: "funky/base:latest" });
+  const { environment } = await envs.create(ctx, { name: "env" });
   return environment.id;
 }
 

--- a/apps/api/test/sse.test.ts
+++ b/apps/api/test/sse.test.ts
@@ -37,8 +37,8 @@ beforeAll(async () => {
     "a",
   ]);
   await pg.pool.query(
-    "insert into env_configs (id, namespace, name, base_image) values ($1, $2, $3, $4)",
-    [envConfigId, NS, "e", "funky/base:latest"],
+    "insert into env_configs (id, namespace, name) values ($1, $2, $3)",
+    [envConfigId, NS, "e"],
   );
 }, 120_000);
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -42,9 +42,9 @@ The UI is intentionally simpler than the API; a few fields are filled in for you
 - **Model** — the dropdown labels map to the API's `{ provider, model }` shape
   (`src/lib/models.ts`). With the default zero-key `fake` LLM any choice works; with
   `FUNKY_LLM=ai-sdk` + `ANTHROPIC_API_KEY`, pick the Claude option.
-- **Environment** — the API requires a `base_image`; the console supplies
-  `funky/base:latest` (the Quickstart image) so the create form only asks for name +
-  description.
+- **Environment** — the create form asks only for name + description. There is no image
+  to pick: the sandbox runtime is the backend's concern (the dev driver runs commands in
+  the worker container), so the environment is just identity + egress policy.
 - **Chat** — messages are `POST`ed to `/v1/sessions/:id/messages`; replies (and the
   agent's sandbox activity) arrive on `GET /v1/sessions/:id/events/stream`, which the
   event log makes durable and replayable.

--- a/apps/web/src/console/Environments.tsx
+++ b/apps/web/src/console/Environments.tsx
@@ -80,9 +80,9 @@ export function Environments({
                   <div className="row__name" style={{ fontSize: 16, fontWeight: 800 }}>
                     {e.name}
                   </div>
-                  <div className="row__sub">{slug(e.name) || e.base_image}</div>
+                  <div className="row__sub">{slug(e.name)}</div>
                 </div>
-                <div className="row__excerpt">{e.description ?? e.base_image}</div>
+                <div className="row__excerpt">{e.description ?? ''}</div>
                 <Badge tone="green" dot>
                   Active
                 </Badge>

--- a/apps/web/src/console/curl.ts
+++ b/apps/web/src/console/curl.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_BASE_IMAGE } from '../lib/api'
 import { modelConfigFor } from '../lib/models'
 
 // The Quick Start's right-hand code panel. Unlike the prototype's illustrative sample, this
@@ -37,8 +36,7 @@ AID=$(curl -s -X POST localhost:3000/v1/agents -H "$H" -H "$J" -d '{
     code += `\n\n# 2. an environment: where its commands run
 EID=$(curl -s -X POST localhost:3000/v1/environments -H "$H" -H "$J" -d '{
   "name": ${j(st.envName || 'basic')},
-  "description": ${j(st.envDesc || 'default dev box')},
-  "base_image": ${j(DEFAULT_BASE_IMAGE)}
+  "description": ${j(st.envDesc || 'default dev box')}
 }' | jq -r .id)`
   }
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -75,14 +75,11 @@ export const agents = {
 
 // ---- environments -----------------------------------------------------------
 
-// The design collects only name + description; the API requires a base_image. We supply the
-// same base image the Quickstart uses so the console works without exposing that field.
-export const DEFAULT_BASE_IMAGE = 'funky/base:latest'
-
+// The environment is just identity + egress policy; the create form collects name +
+// description. The sandbox runtime image is the backend's concern, not a user field.
 export type CreateEnvInput = {
   name: string
   description?: string | null
-  base_image?: string
 }
 
 export const environments = {
@@ -90,7 +87,6 @@ export const environments = {
     request<Environment>('POST', '/v1/environments', {
       name: input.name,
       description: input.description ?? null,
-      base_image: input.base_image ?? DEFAULT_BASE_IMAGE,
     }),
   list: (params?: { limit?: number; after_id?: string; include_archived?: boolean }) =>
     request<Page<Environment>>('GET', `/v1/environments${query(params)}`),

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -33,7 +33,6 @@ export type Agent = {
   archived_at: string | null
 }
 
-export type PersistentFs = { size_gb: number }
 export type Egress = { allow: string[] }
 
 export type Environment = {
@@ -42,8 +41,6 @@ export type Environment = {
   name: string
   description: string | null
   metadata: Record<string, string>
-  base_image: string
-  persistent_fs: PersistentFs
   egress: Egress
   created_at: string
   updated_at: string

--- a/apps/worker/test/worker.test.ts
+++ b/apps/worker/test/worker.test.ts
@@ -66,8 +66,8 @@ beforeAll(async () => {
     [agentConfigId, NS, "You are a test agent.", JSON.stringify({ provider: "anthropic", model: "claude-sonnet-5" })],
   );
   await pool.query(
-    "insert into env_configs (id, namespace, name, base_image) values ($1,$2,$3,$4)",
-    [envConfigId, NS, "test-env", "funky/base:latest"],
+    "insert into env_configs (id, namespace, name) values ($1,$2,$3)",
+    [envConfigId, NS, "test-env"],
   );
 
   db = createDb(pool);
@@ -382,7 +382,7 @@ it("★ crash-resumes: worker B finishes the turn worker A abandoned, running th
   // A provisioned subprocess sandbox both workers share (same session → same workdir).
   const sid = randomUUID();
   const handle = await realSandbox.provision(
-    { base_image: "x", persistent_fs: { size_gb: 1 }, egress: { allow: [] } },
+    { egress: { allow: [] } },
     sid,
   );
   await seedSession({ id: sid, status: "ready", handle });

--- a/packages/configs/src/envs-service.ts
+++ b/packages/configs/src/envs-service.ts
@@ -13,7 +13,6 @@ import { isUniqueViolation, jsonEq } from "./util";
 import type { CreateEnvInput, Environment, UpdateEnvInput } from "./envs-types";
 import type { AuthContext, Page } from "./types";
 
-const DEFAULT_PERSISTENT_FS = { size_gb: 2 };
 const DEFAULT_EGRESS = { allow: [] as string[] }; // deny-all egress by default
 
 type EnvRow = typeof envConfigs.$inferSelect;
@@ -40,8 +39,6 @@ export class EnvsService {
           name: input.name,
           description: input.description ?? null,
           metadata: input.metadata ?? {},
-          baseImage: input.base_image,
-          persistentFs: input.persistent_fs ?? DEFAULT_PERSISTENT_FS,
           egress: input.egress ?? DEFAULT_EGRESS,
         })
         .returning();
@@ -64,8 +61,6 @@ export class EnvsService {
       existing.name === input.name &&
       (existing.description ?? null) === (input.description ?? null) &&
       jsonEq(existing.metadata, input.metadata ?? {}) &&
-      existing.baseImage === input.base_image &&
-      jsonEq(existing.persistentFs, input.persistent_fs ?? DEFAULT_PERSISTENT_FS) &&
       jsonEq(existing.egress, input.egress ?? DEFAULT_EGRESS);
     if (!same) {
       throw new ConflictError("an environment with this id exists with a different configuration");
@@ -116,8 +111,6 @@ export class EnvsService {
         ...(patch.name !== undefined && { name: patch.name }),
         ...(patch.description !== undefined && { description: patch.description }),
         ...(patch.metadata !== undefined && { metadata: patch.metadata }), // replace, not merge
-        ...(patch.base_image !== undefined && { baseImage: patch.base_image }),
-        ...(patch.persistent_fs !== undefined && { persistentFs: patch.persistent_fs }),
         ...(patch.egress !== undefined && { egress: patch.egress }),
         updatedAt: new Date(),
       })
@@ -173,8 +166,6 @@ function toEnvironment(row: EnvRow): Environment {
     name: row.name,
     description: row.description,
     metadata: row.metadata,
-    base_image: row.baseImage,
-    persistent_fs: row.persistentFs,
     egress: row.egress,
     created_at: row.createdAt.toISOString(),
     updated_at: row.updatedAt.toISOString(),

--- a/packages/configs/src/envs-types.ts
+++ b/packages/configs/src/envs-types.ts
@@ -1,5 +1,5 @@
 // packages/configs/src/envs-types.ts
-import type { EgressPolicy, PersistentFs } from "@funky/db/schema";
+import type { EgressPolicy } from "@funky/db/schema";
 
 export type Environment = {
   type: "environment";
@@ -7,8 +7,6 @@ export type Environment = {
   name: string;
   description: string | null;
   metadata: Record<string, string>;
-  base_image: string;
-  persistent_fs: PersistentFs;
   egress: EgressPolicy;
   created_at: string;
   updated_at: string;
@@ -20,8 +18,6 @@ export type CreateEnvInput = {
   name: string;
   description?: string | null;
   metadata?: Record<string, string>;
-  base_image: string;
-  persistent_fs?: PersistentFs;
   egress?: EgressPolicy;
 };
 

--- a/packages/db/migrations/20260716025451_drop_env_base_image_and_persistent_fs/migration.sql
+++ b/packages/db/migrations/20260716025451_drop_env_base_image_and_persistent_fs/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "env_configs" DROP COLUMN "base_image";--> statement-breakpoint
+ALTER TABLE "env_configs" DROP COLUMN "persistent_fs";

--- a/packages/db/migrations/20260716025451_drop_env_base_image_and_persistent_fs/snapshot.json
+++ b/packages/db/migrations/20260716025451_drop_env_base_image_and_persistent_fs/snapshot.json
@@ -1,0 +1,1070 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "b8c06055-5a7c-4168-8b67-67cf7baef66c",
+  "prevIds": [
+    "f0c96744-3ae3-4422-8968-44fe68d0149e"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "agent_config_versions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "agent_configs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "env_configs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "session_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "sessions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "turn_jobs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "agent_config_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "system_prompt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "model",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "tool_policy",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "1",
+      "generated": null,
+      "identity": null,
+      "name": "latest_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{\"allow\":[]}'",
+      "generated": null,
+      "identity": null,
+      "name": "egress",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seq",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "agent_config_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "agent_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "env_config_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resolved_env",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "sandbox_handle",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'provisioning'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'turn'",
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'queued'",
+      "generated": null,
+      "identity": null,
+      "name": "state",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "run_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "attempts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "5",
+      "generated": null,
+      "identity": null,
+      "name": "max_attempts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "lease_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_configs_ns_name",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_configs_ns",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "env_configs_ns_name",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "env_configs_ns",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_ns",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "run_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"state\" = 'queued'",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "turn_jobs_queued",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"state\" IN ('queued', 'running')",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "turn_jobs_active_session",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "agent_config_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "agent_configs",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "agent_config_versions_agent_config_id_agent_configs_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "session_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "sessions",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "session_events_session_id_sessions_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "agent_config_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "agent_configs",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "sessions_agent_config_id_agent_configs_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "env_config_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "env_configs",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "sessions_env_config_id_env_configs_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "session_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "sessions",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "turn_jobs_session_id_sessions_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "columns": [
+        "agent_config_id",
+        "version"
+      ],
+      "nameExplicit": false,
+      "name": "agent_config_versions_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "columns": [
+        "session_id",
+        "seq"
+      ],
+      "nameExplicit": false,
+      "name": "session_events_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "agent_configs_pkey",
+      "schema": "public",
+      "table": "agent_configs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "env_configs_pkey",
+      "schema": "public",
+      "table": "env_configs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pkey",
+      "schema": "public",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "turn_jobs_pkey",
+      "schema": "public",
+      "table": "turn_jobs",
+      "entityType": "pks"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db/schema/envs.ts
+++ b/packages/db/schema/envs.ts
@@ -1,14 +1,21 @@
 // packages/db/schema/envs.ts
-// Environment config = the recipe for a session's sandbox (base image, persistent
-// filesystem, egress policy). Single table + archive, NOT versioned: the config is
-// consumed once at sandbox provision, so updates only affect future sessions.
-// When sessions land they snapshot resolved_env at provision; see configs.ts.
+// Environment config = the reusable, template-like recipe for a session's sandbox
+// (egress policy). One environment fans out to many sessions; each session provisions
+// its OWN isolated sandbox (filesystem is per-session, never shared). Single table +
+// archive, NOT versioned: the config is consumed once at sandbox provision, so updates
+// only affect future sessions. When sessions land they snapshot resolved_env at
+// provision; see configs.ts.
+//
+// Deliberately NOT here: base_image and persistent_fs. Neither is honored by any driver
+// (E2B has no create-time image/disk-size param — both are template-build-time concerns;
+// subprocess runs in the worker container). The runtime image is the backend's concern;
+// per-session durable storage, if ever needed, belongs on the session as a volume
+// resource, not as a knob on the template.
 
 import {
   index, jsonb, pgTable, text, timestamp, uuid,
 } from "drizzle-orm/pg-core";
 
-export type PersistentFs = { size_gb: number };
 export type EgressPolicy = { allow: string[] }; // domain allowlist; [] = deny all egress
 
 export const envConfigs = pgTable(
@@ -21,8 +28,6 @@ export const envConfigs = pgTable(
     metadata: jsonb("metadata").$type<Record<string, string>>().notNull().default({}),
 
     // ---- the recipe ----
-    baseImage: text("base_image").notNull(),  // e.g. "funky/base-python:3.12"
-    persistentFs: jsonb("persistent_fs").$type<PersistentFs>().notNull().default({ size_gb: 2 }),
     egress: jsonb("egress").$type<EgressPolicy>().notNull().default({ allow: [] }),
 
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/db/schema/sessions.ts
+++ b/packages/db/schema/sessions.ts
@@ -22,9 +22,7 @@ import { envConfigs } from "./envs"; // ⚠ adjust if the env iteration named th
 /** Snapshot captured at sandbox provision; reboots rebuild from THIS, never from the
  *  (mutable) env config. template_id is driver-specific (e.g. E2B template). */
 export type ResolvedEnv = {
-  base_image: string;
   template_id?: string;
-  persistent_fs: { size_gb: number };
   egress: { allow: string[] };
 };
 

--- a/packages/db/src/schema.test.ts
+++ b/packages/db/src/schema.test.ts
@@ -158,8 +158,6 @@ describe("env_configs", () => {
       name: { type: "text", notNull: true },
       description: { type: "text", notNull: false },
       metadata: { type: "jsonb", notNull: true, hasDefault: true, default: {} },
-      base_image: { type: "text", notNull: true },
-      persistent_fs: { type: "jsonb", notNull: true, hasDefault: true, default: { size_gb: 2 } },
       egress: { type: "jsonb", notNull: true, hasDefault: true, default: { allow: [] } },
       created_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
       updated_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
@@ -349,19 +347,15 @@ describe("ModelConfig", () => {
 // -------------------------------------------------------------- session types
 
 describe("session domain types", () => {
-  it("ResolvedEnv snapshots base image, optional template, fs size and egress", () => {
+  it("ResolvedEnv snapshots optional template and egress", () => {
     const env: ResolvedEnv = {
-      base_image: "funky/base-python:3.12",
       template_id: "e2b-abc123",
-      persistent_fs: { size_gb: 2 },
       egress: { allow: ["api.example.com"] },
     };
-    expect(env.persistent_fs.size_gb).toBe(2);
+    expect(env.egress.allow).toEqual(["api.example.com"]);
 
     // template_id is optional — driver-specific, absent for drivers that don't use it.
     const minimal: ResolvedEnv = {
-      base_image: "funky/base:latest",
-      persistent_fs: { size_gb: 1 },
       egress: { allow: [] },
     };
     expect(minimal.template_id).toBeUndefined();

--- a/packages/ports/sandbox/src/drivers/computesdk.ts
+++ b/packages/ports/sandbox/src/drivers/computesdk.ts
@@ -59,8 +59,8 @@ export class ComputeSdkDriver implements SandboxDriver {
   }
 
   async provision(_spec: ResolvedEnv, sessionId: string): Promise<SandboxHandle> {
-    // v1 parity with subprocess: spec.base_image / egress are not mapped yet — the
-    // provider boots its default template. autoPause makes the timeout a pause (disk
+    // v1 parity with subprocess: spec.egress is not mapped yet — the provider boots its
+    // default template. autoPause makes the timeout a pause (disk
     // persisted, resumed on connect) instead of a kill; that's what keeps reboot honest.
     const sb = await this.manager.sandbox.create({
       timeout: this.sandboxTimeoutMs,

--- a/packages/ports/sandbox/src/tck.ts
+++ b/packages/ports/sandbox/src/tck.ts
@@ -13,8 +13,6 @@ import { type ExecEvent, type Executor, type SandboxDriver, SandboxUnavailableEr
 import type { ResolvedEnv } from "@funky/db/schema";
 
 const SPEC: ResolvedEnv = {
-  base_image: "funky/tck",
-  persistent_fs: { size_gb: 1 },
   egress: { allow: [] },
 };
 

--- a/packages/sessions/src/provision.ts
+++ b/packages/sessions/src/provision.ts
@@ -35,8 +35,6 @@ export async function runProvision(job: Job, deps: TurnDeps): Promise<TurnOutcom
 
   // Snapshot the env config. template_id stays undefined for the subprocess driver.
   const resolvedEnv: ResolvedEnv = {
-    base_image: env.baseImage,
-    persistent_fs: env.persistentFs,
     egress: env.egress,
   };
 

--- a/packages/sessions/src/store-queue.test.ts
+++ b/packages/sessions/src/store-queue.test.ts
@@ -62,8 +62,8 @@ beforeAll(async () => {
     "test-agent",
   ]);
   await pool.query(
-    "insert into env_configs (id, namespace, name, base_image) values ($1, $2, $3, $4)",
-    [envConfigId, NS, "test-env", "funky/base:latest"],
+    "insert into env_configs (id, namespace, name) values ($1, $2, $3)",
+    [envConfigId, NS, "test-env"],
   );
 
   db = createDb(pool);

--- a/packages/sessions/src/turn.test.ts
+++ b/packages/sessions/src/turn.test.ts
@@ -87,8 +87,8 @@ beforeEach(async () => {
     "test-agent",
   ]);
   await pool.query(
-    "insert into env_configs (id, namespace, name, base_image) values ($1,$2,$3,$4)",
-    [envConfigId, NS, "test-env", "funky/base:latest"],
+    "insert into env_configs (id, namespace, name) values ($1,$2,$3)",
+    [envConfigId, NS, "test-env"],
   );
   sessionId = randomUUID();
 });
@@ -126,7 +126,7 @@ async function seedSession(opts: {
   let handle: SandboxHandle | null = opts.handle ?? null;
   if (!handle && opts.provision !== false) {
     handle = await sandbox.provision(
-      { base_image: "x", persistent_fs: { size_gb: 1 }, egress: { allow: [] } },
+      { egress: { allow: [] } },
       sessionId,
     );
     handles.push(handle);
@@ -535,7 +535,7 @@ describe("runProvision", () => {
       sandbox_handle: { driver?: string } | null;
     }>("select status, resolved_env, sandbox_handle from sessions where id = $1", [sessionId]);
     expect(rows[0]!.status).toBe("ready");
-    expect(rows[0]!.resolved_env).toMatchObject({ base_image: "funky/base:latest" });
+    expect(rows[0]!.resolved_env).toMatchObject({ egress: { allow: [] } });
     expect(rows[0]!.sandbox_handle?.driver).toBe("subprocess");
     if (rows[0]!.sandbox_handle) handles.push(rows[0]!.sandbox_handle as SandboxHandle);
 

--- a/tests/chaos/src/harness.ts
+++ b/tests/chaos/src/harness.ts
@@ -75,8 +75,8 @@ async function startPg(): Promise<Pg> {
     [AGENT_ID, NS, "You are a chaos test agent.", JSON.stringify({ provider: "anthropic", model: "claude-sonnet-5" })],
   );
   await pool.query(
-    "insert into env_configs (id, namespace, name, base_image) values ($1,$2,$3,$4)",
-    [ENV_ID, NS, "chaos-env", "funky/base:latest"],
+    "insert into env_configs (id, namespace, name) values ($1,$2,$3)",
+    [ENV_ID, NS, "chaos-env"],
   );
 
   return { container, pool, db: createDb(pool), uri };
@@ -214,8 +214,6 @@ export async function buildWorld(
   const llm = scriptedLlm({ [sessionId]: script });
 
   const resolvedEnv: ResolvedEnv = {
-    base_image: "funky/base:latest",
-    persistent_fs: { size_gb: 1 },
     egress: { allow: [] },
   };
   // Most scenarios seed the session ALREADY provisioned — provisioning is not what they


### PR DESCRIPTION
Removes `base_image` and `persistent_fs` from the environment contract because neither was honored by any sandbox driver — E2B has no create-time image or disk-size parameter (both are template-build-time concerns) and the subprocess dev driver runs commands in the worker container, so both fields were required-but-inert. This aligns Funky's environment with Anthropic's Managed Agents environment, which is identity + networking only; the env config is now identity + `egress`, and `ResolvedEnv` retains `template_id` as the driver-side E2B-template hook. Includes a drop-column migration (drizzle-kit v1-beta layout) and updates every fixture and assertion across `db`, `configs`, `sessions`, `api`, `worker`, and `chaos`. Verified with typecheck (root + web), oxlint, and all affected suites green (301 tests; the one skip is the live-E2B test that needs a key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)