### PR TITLE
Add web console to the docker compose stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,11 @@ WORKDIR /app
 # Manifests first: dependency layers cache until a package.json/lockfile changes.
 # EVERY workspace package's manifest is needed — a frozen-lockfile install fails if any
 # package referenced by the lockfile is missing. (api → sessions → llm/sandbox/configs;
-# worker → the same graph.)
+# worker → the same graph; web is the Vite console served by the `web` compose service.)
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/api/package.json apps/api/
 COPY apps/worker/package.json apps/worker/
+COPY apps/web/package.json apps/web/
 COPY packages/db/package.json packages/db/
 COPY packages/configs/package.json packages/configs/
 COPY packages/sessions/package.json packages/sessions/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Funky
 
-The open-source runtime for AI agents that do the work, not the talking.
+The durable runtime for agent swarms.
 
-Define an agent, give it a sandboxed environment, send it work. Funky handles the durability and the infrastructure. Built for agent swarms, background agents, and long-horizon tasks.
+Define an agent, give it a sandboxed environment, send it work. Funky handles the durability and the infrastructure.
 
 ## Quickstart
 
@@ -56,6 +56,15 @@ event: tool_result            { "output": "hello from the funky sandbox\n", "exi
 event: assistant_message      { "content": [{"type":"text","text":"I ran a command…"}] }
 event: turn_completed
 ```
+
+> **Prefer a UI?** The `curl` flow above is also a few clicks in the **Funky Console** — the
+> browser dev console that ships with the stack. `docker compose up` serves it at
+> http://localhost:5173: create an agent, environment, and session, then chat with the agent
+> and watch it run commands in its sandbox — with the equivalent `curl` shown alongside. It's
+> a thin client over the same REST API (see [`apps/web`](apps/web)).
+
+<!-- TODO: insert Funky Console screenshot here -->
+![Funky Console — the same agent → environment → session → chat flow in the browser](./docs/funky-console.png)
 
 ### Durability
 
@@ -146,6 +155,7 @@ Useful commands: `pnpm typecheck` · `pnpm -F @funky/db generate` (new migration
 ```
 apps/api           HTTP API (Hono): agents, environments, sessions, SSE
 apps/worker        the agent runtime — pulls turns off the queue and drives the loop
+apps/web           browser dev console (Vite + React); `docker compose` serves it at :5173
 packages/sessions  the event log, the reducer, the turn loop, the job queue
 packages/configs   agent + environment config domain logic
 packages/ports     provider-neutral ports (llm, sandbox) + their drivers

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -24,12 +24,18 @@ no CORS to configure (the API is left untouched). Config is read from the **mono
 | `FUNKY_API_URL` | where the API listens | `http://localhost:3000` |
 | `FUNKY_AUTH_TOKEN` | bearer token; leave unset if the API runs `FUNKY_AUTH=disabled` | — |
 
-```bash
-# 1. bring up the backend (from the repo root) — see the top-level README Quickstart
-docker compose up --build
+`docker compose up --build` (from the repo root) now brings the console up **with** the
+backend — it's the `web` service, running this same dev server in a container:
 
-# 2. run the console
-pnpm -F web dev        # then open the printed URL (default http://localhost:5173)
+```bash
+docker compose up --build     # api + worker + console at http://localhost:5173
+```
+
+For local iteration with HMR, run the dev server on the host against the compose backend:
+
+```bash
+docker compose up --build     # backend only is fine too: --scale web=0
+pnpm -F web dev               # then open the printed URL (default http://localhost:5173)
 ```
 
 If the backend isn't reachable, the console shows a blocking "Backend API not reachable"

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -12,18 +12,21 @@ import react from '@vitejs/plugin-react'
 // `pnpm dev` works with zero extra setup once you've done the Quickstart:
 //   FUNKY_API_URL     where the API listens (default http://localhost:3000)
 //   FUNKY_AUTH_TOKEN  the bearer token (leave unset if the API runs FUNKY_AUTH=disabled)
+// The `web` compose service runs this SAME dev server in a container; there the root .env is
+// not present, so we also read straight from `process.env` (compose injects the vars, and
+// points FUNKY_API_URL at the `api` service instead of localhost).
 const repoRoot = fileURLToPath(new URL('../../', import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   // '' prefix → load every var (not just VITE_*); this is the Node side, not client code.
   const env = loadEnv(mode, repoRoot, '')
-  const target = env.FUNKY_API_URL || 'http://localhost:3000'
-  const token = env.FUNKY_AUTH_TOKEN
+  const target = env.FUNKY_API_URL || process.env.FUNKY_API_URL || 'http://localhost:3000'
+  const token = env.FUNKY_AUTH_TOKEN || process.env.FUNKY_AUTH_TOKEN
   // Real Claude models are only offered when the worker has a key. We expose a *boolean*
   // (never the key itself) so the model picker can gate on it. Reflects the root .env at
   // dev-server start — restart `pnpm dev` after changing it.
-  const anthropicEnabled = Boolean((env.ANTHROPIC_API_KEY || '').trim())
+  const anthropicEnabled = Boolean((env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_API_KEY || '').trim())
 
   const proxyHeaders = token ? { Authorization: `Bearer ${token}` } : undefined
   const proxy = {
@@ -39,6 +42,10 @@ export default defineConfig(({ mode }) => {
       __ANTHROPIC_ENABLED__: JSON.stringify(anthropicEnabled),
     },
     server: {
+      // Bind all interfaces + allow any Host so the container's mapped port works; harmless
+      // for local `pnpm dev`, which is still reached over localhost.
+      host: true,
+      allowedHosts: true,
       proxy: {
         '/v1': proxy,
         '/healthz': proxy,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
-# docker-compose.yml (repo root) — the quickstart stack: postgres + migrate + api + worker.
-# Bring up:   docker compose up --build
+# docker-compose.yml (repo root) — the quickstart stack: postgres + migrate + api + worker + web.
+# Bring up:   docker compose up --build          (console at http://localhost:5173)
 # Scale out:  docker compose up --build --scale worker=3
 # Tear down:  docker compose down          (-v to also wipe the database)
 
@@ -83,6 +83,36 @@ services:
           "node",
           "-e",
           "fetch('http://localhost:9090/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  # The developer console (apps/web) — a Vite + React browser UI over the API. SAME image as
+  # the api/worker, different command. It serves same-origin: the Vite server proxies `/v1`
+  # and `/healthz` to the api and injects the bearer token, so the token never reaches the
+  # browser and the api needs no CORS (it stays untouched). Quickstart-grade — this is the
+  # Vite dev server, matching the rest of the stack running from source. Open :5173 after boot.
+  web:
+    build: .
+    command: ["pnpm", "-F", "web", "dev", "--host", "--port", "5173"]
+    ports:
+      - "5173:5173"
+    environment:
+      NODE_ENV: development # the image defaults to production; the Vite dev server wants development
+      FUNKY_API_URL: http://api:3000 # ← service name, not localhost (proxy target on the compose network)
+      FUNKY_AUTH_TOKEN: ${FUNKY_AUTH_TOKEN:?set FUNKY_AUTH_TOKEN in .env — any long random string}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-} # presence flips the console's Claude model option on
+    depends_on:
+      api:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://localhost:5173/').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
         ]
       interval: 5s
       timeout: 3s


### PR DESCRIPTION
Previously `docker compose up` brought up only postgres/migrate/api/worker, because the root Dockerfile never copied `apps/web/package.json` — so the frozen install couldn't produce an image with the web deps. This copies the web manifest and adds a `web` compose service that runs the same image's Vite dev server on `:5173`, reusing its same-origin `/v1` + `/healthz` proxy and bearer-token injection (targeting `api:3000`); the Vite config is made container-friendly (bind `0.0.0.0`, allow the host, read `process.env`). Verified end-to-end: the console serves, and calls through its proxy reach the API authenticated while a direct unauthenticated call still 401s. The README is also updated — a refreshed tagline, a "Prefer a UI?" callout offering the console as an alternative to the curl quickstart (with a screenshot placeholder), and an `apps/web` layout entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)