### PR TITLE
Redesign environment network policies

### DIFF
--- a/apps/api/src/routes/environments.ts
+++ b/apps/api/src/routes/environments.ts
@@ -13,13 +13,14 @@ type Env = { Variables: { auth: AuthContext; requestId: string } };
 const hostnameRegex =
   /^(\*\.)?[a-z0-9]([a-z0-9\-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9\-]*[a-z0-9])?)*$/i;
 
-const egressSchema = z
-  .object({
-    allow: z
-      .array(z.string().max(255).regex(hostnameRegex, "must be a bare or wildcard-prefixed hostname"))
-      .max(100),
-  })
-  .strict();
+const allowedHostsSchema = z
+  .array(z.string().max(255).regex(hostnameRegex, "must be a bare or wildcard-prefixed hostname"))
+  .max(100);
+
+const networkSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("unrestricted") }).strict(),
+  z.object({ type: z.literal("limited"), allowed_hosts: allowedHostsSchema }).strict(),
+]);
 
 const createSchema = z
   .object({
@@ -27,7 +28,7 @@ const createSchema = z
     name: z.string().min(1).max(256),
     description: z.string().max(2048).nullish(),
     metadata: metadataSchema.optional(),
-    egress: egressSchema.optional(),
+    network: networkSchema.optional(),
   })
   .strict();
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -48,9 +48,9 @@ The UI is intentionally simpler than the API; a few fields are filled in for you
 - **Model** — the dropdown labels map to the API's `{ provider, model }` shape
   (`src/lib/models.ts`). With the default zero-key `fake` LLM any choice works; with
   `FUNKY_LLM=ai-sdk` + `ANTHROPIC_API_KEY`, pick the Claude option.
-- **Environment** — the create form asks only for name + description. There is no image
-  to pick: the sandbox runtime is the backend's concern (the dev driver runs commands in
-  the worker container), so the environment is just identity + egress policy.
+- **Environment** — the create form asks for name, description, and network access. There
+  is no image to pick: the sandbox runtime is the backend's concern (the dev driver runs
+  commands in the worker container), so the environment is just identity + network policy.
 - **Chat** — messages are `POST`ed to `/v1/sessions/:id/messages`; replies (and the
   agent's sandbox activity) arrive on `GET /v1/sessions/:id/events/stream`, which the
   event log makes durable and replayable.

--- a/apps/web/src/console/Environments.tsx
+++ b/apps/web/src/console/Environments.tsx
@@ -2,9 +2,10 @@ import { useState } from 'react'
 import { Box, Layers } from 'lucide-react'
 import { environments as envsApi } from '../lib/api'
 import type { Environment } from '../lib/types'
+import { networkPolicy, networkSummary, type NetworkMode } from '../lib/network'
 import { errMsg, slug } from '../lib/format'
 import { Avatar, Badge, Button, Checkbox, Input, Modal, Textarea } from '../ui/ui'
-import { ArchiveItem, EmptyState, Kebab, PageHeader, SelectionBar } from './parts'
+import { ArchiveItem, EmptyState, Kebab, NetworkFields, PageHeader, SelectionBar } from './parts'
 import { useSelection } from './data'
 
 export function Environments({
@@ -20,6 +21,8 @@ export function Environments({
   const [open, setOpen] = useState(false)
   const [name, setName] = useState('')
   const [desc, setDesc] = useState('')
+  const [networkMode, setNetworkMode] = useState<NetworkMode>('unrestricted')
+  const [allowedHosts, setAllowedHosts] = useState('')
   const [saving, setSaving] = useState(false)
 
   async function create() {
@@ -29,10 +32,16 @@ export function Environments({
     }
     setSaving(true)
     try {
-      await envsApi.create({ name: name.trim(), description: desc.trim() || null })
+      await envsApi.create({
+        name: name.trim(),
+        description: desc.trim() || null,
+        network: networkPolicy(networkMode, allowedHosts),
+      })
       setOpen(false)
       setName('')
       setDesc('')
+      setNetworkMode('unrestricted')
+      setAllowedHosts('')
       await reload()
     } catch (e) {
       notify(errMsg(e))
@@ -83,6 +92,7 @@ export function Environments({
                   <div className="row__sub">{slug(e.name)}</div>
                 </div>
                 <div className="row__excerpt">{e.description ?? ''}</div>
+                <Badge tone="neutral">{networkSummary(e.network)}</Badge>
                 <Badge tone="green" dot>
                   Active
                 </Badge>
@@ -116,6 +126,12 @@ export function Environments({
             placeholder="What this environment provides…"
             value={desc}
             onChange={setDesc}
+          />
+          <NetworkFields
+            mode={networkMode}
+            allowedHosts={allowedHosts}
+            onModeChange={setNetworkMode}
+            onAllowedHostsChange={setAllowedHosts}
           />
         </div>
       </Modal>

--- a/apps/web/src/console/QuickStart.tsx
+++ b/apps/web/src/console/QuickStart.tsx
@@ -2,9 +2,10 @@ import { useState } from 'react'
 import { Check } from 'lucide-react'
 import { agents as agentsApi, environments as envsApi, sessions as sessApi } from '../lib/api'
 import { DEFAULT_MODEL_LABEL, modelConfigFor } from '../lib/models'
+import { networkPolicy, networkSummary, type NetworkMode } from '../lib/network'
 import { errMsg, initials } from '../lib/format'
 import { Avatar, Badge, Button, CodeBlock, Input, Textarea } from '../ui/ui'
-import { ModelField } from './parts'
+import { ModelField, NetworkFields } from './parts'
 import { buildCurl } from './curl'
 
 const DEFAULT_PROMPT =
@@ -21,6 +22,8 @@ export function QuickStart({ onLaunch }: { onLaunch: (sessionId: string) => Prom
   const [systemPrompt, setSystemPrompt] = useState(DEFAULT_PROMPT)
   const [envName, setEnvName] = useState('basic')
   const [envDesc, setEnvDesc] = useState('default dev box')
+  const [networkMode, setNetworkMode] = useState<NetworkMode>('unrestricted')
+  const [allowedHosts, setAllowedHosts] = useState('')
   const [message, setMessage] = useState('What are the best restaurants in San Francisco right now?')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState('')
@@ -61,7 +64,11 @@ export function QuickStart({ onLaunch }: { onLaunch: (sessionId: string) => Prom
         system_prompt: systemPrompt.trim(),
         model: modelConfigFor(model),
       })
-      const env = await envsApi.create({ name: envName.trim(), description: envDesc.trim() || null })
+      const env = await envsApi.create({
+        name: envName.trim(),
+        description: envDesc.trim() || null,
+        network: networkPolicy(networkMode, allowedHosts),
+      })
       const session = await sessApi.create({ agent: agent.id, environment_id: env.id })
       const ready = await sessApi.waitReady(session.id)
       if (ready.status === 'failed') throw new Error('The session failed to provision its sandbox.')
@@ -74,7 +81,8 @@ export function QuickStart({ onLaunch }: { onLaunch: (sessionId: string) => Prom
     }
   }
 
-  const curl = buildCurl({ step, agentName, model, systemPrompt, envName, envDesc, message })
+  const network = networkPolicy(networkMode, allowedHosts)
+  const curl = buildCurl({ step, agentName, model, systemPrompt, envName, envDesc, network, message })
 
   return (
     <div className="content">
@@ -112,6 +120,12 @@ export function QuickStart({ onLaunch }: { onLaunch: (sessionId: string) => Prom
               </div>
               <Input label="Name" placeholder="basic" value={envName} onChange={setEnvName} />
               <Textarea label="Description" rows={3} placeholder="default dev box" value={envDesc} onChange={setEnvDesc} />
+              <NetworkFields
+                mode={networkMode}
+                allowedHosts={allowedHosts}
+                onModeChange={setNetworkMode}
+                onAllowedHostsChange={setAllowedHosts}
+              />
               <div className="qs-foot qs-foot--split">
                 <Button variant="secondary" size="lg" onClick={back}>
                   Back
@@ -133,6 +147,7 @@ export function QuickStart({ onLaunch }: { onLaunch: (sessionId: string) => Prom
                 <ReviewRow label="Agent" value={agentName} strong />
                 <ReviewRow label="Model" value={model} mono />
                 <ReviewRow label="Environment" value={envName} mono />
+                <ReviewRow label="Network" value={networkSummary(network)} />
                 <ReviewRow label="System prompt" value={systemPrompt} />
               </div>
               <div className="qs-foot qs-foot--split">

--- a/apps/web/src/console/console.css
+++ b/apps/web/src/console/console.css
@@ -722,6 +722,17 @@
   color: var(--text-strong);
 }
 
+.network-hosts {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.field-hint {
+  margin: 0;
+  font: 12px/1.45 var(--font-body);
+  color: var(--text-muted);
+}
+
 /* modal intro line + form */
 .modal__intro {
   font: 14px/1.5 var(--font-body);

--- a/apps/web/src/console/curl.ts
+++ b/apps/web/src/console/curl.ts
@@ -1,4 +1,5 @@
 import { modelConfigFor } from '../lib/models'
+import type { NetworkPolicy } from '../lib/types'
 
 // The Quick Start's right-hand code panel. Unlike the prototype's illustrative sample, this
 // mirrors the *real* requests the console makes (and the README quickstart), so a developer
@@ -10,6 +11,7 @@ export type CurlState = {
   systemPrompt: string
   envName: string
   envDesc: string
+  network: NetworkPolicy
   message: string
 }
 
@@ -36,7 +38,8 @@ AID=$(curl -s -X POST localhost:3000/v1/agents -H "$H" -H "$J" -d '{
     code += `\n\n# 2. an environment: where its commands run
 EID=$(curl -s -X POST localhost:3000/v1/environments -H "$H" -H "$J" -d '{
   "name": ${j(st.envName || 'basic')},
-  "description": ${j(st.envDesc || 'default dev box')}
+  "description": ${j(st.envDesc || 'default dev box')},
+  "network": ${JSON.stringify(st.network)}
 }' | jq -r .id)`
   }
 

--- a/apps/web/src/console/parts.tsx
+++ b/apps/web/src/console/parts.tsx
@@ -1,8 +1,9 @@
 import type { ReactNode } from 'react'
 import { useState } from 'react'
 import { AlertTriangle, Archive, Cpu, Layers, MessageSquare, MoreVertical, X, Zap } from 'lucide-react'
-import { Button, Select } from '../ui/ui'
+import { Button, Select, Textarea } from '../ui/ui'
 import { ANTHROPIC_ENABLED, MODEL_OPTIONS } from '../lib/models'
+import type { NetworkMode } from '../lib/network'
 import { useClickOutside } from './data'
 
 export type Tab = 'quickstart' | 'agents' | 'sessions' | 'environments'
@@ -97,6 +98,44 @@ export function ModelField({ value, onChange }: { value: string; onChange: (v: s
       options={MODEL_OPTIONS.map((m) => ({ value: m.label, label: m.label }))}
       onChange={onChange}
     />
+  )
+}
+
+export function NetworkFields({
+  mode,
+  allowedHosts,
+  onModeChange,
+  onAllowedHostsChange,
+}: {
+  mode: NetworkMode
+  allowedHosts: string
+  onModeChange: (mode: NetworkMode) => void
+  onAllowedHostsChange: (hosts: string) => void
+}) {
+  return (
+    <>
+      <Select
+        label="Network access"
+        value={mode}
+        options={[
+          { value: 'unrestricted', label: 'Unrestricted — allow all outbound traffic' },
+          { value: 'limited', label: 'Limited — only allow selected hosts' },
+        ]}
+        onChange={(value) => onModeChange(value as NetworkMode)}
+      />
+      {mode === 'limited' ? (
+        <div className="network-hosts">
+          <Textarea
+            label="Allowed hosts"
+            rows={2}
+            placeholder="api.example.com, *.example.org"
+            value={allowedHosts}
+            onChange={onAllowedHostsChange}
+          />
+          <p className="field-hint">Separate hosts with commas or new lines. Leave empty to deny all outbound access.</p>
+        </div>
+      ) : null}
+    </>
   )
 }
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -6,6 +6,7 @@ import type {
   Environment,
   ModelConfig,
   Page,
+  NetworkPolicy,
   SendMessageResult,
   Session,
   SessionEvent,
@@ -75,11 +76,12 @@ export const agents = {
 
 // ---- environments -----------------------------------------------------------
 
-// The environment is just identity + egress policy; the create form collects name +
-// description. The sandbox runtime image is the backend's concern, not a user field.
+// The environment is just identity + network policy. The sandbox runtime image is the
+// backend's concern, not a user field.
 export type CreateEnvInput = {
   name: string
   description?: string | null
+  network: NetworkPolicy
 }
 
 export const environments = {
@@ -87,6 +89,7 @@ export const environments = {
     request<Environment>('POST', '/v1/environments', {
       name: input.name,
       description: input.description ?? null,
+      network: input.network,
     }),
   list: (params?: { limit?: number; after_id?: string; include_archived?: boolean }) =>
     request<Page<Environment>>('GET', `/v1/environments${query(params)}`),

--- a/apps/web/src/lib/network.ts
+++ b/apps/web/src/lib/network.ts
@@ -1,0 +1,17 @@
+import type { NetworkPolicy } from './types'
+
+export type NetworkMode = NetworkPolicy['type']
+
+export function networkPolicy(mode: NetworkMode, allowedHosts: string): NetworkPolicy {
+  if (mode === 'unrestricted') return { type: 'unrestricted' }
+  return {
+    type: 'limited',
+    allowed_hosts: [...new Set(allowedHosts.split(/[\s,]+/).map((host) => host.trim()).filter(Boolean))],
+  }
+}
+
+export function networkSummary(policy: NetworkPolicy): string {
+  if (policy.type === 'unrestricted') return 'Unrestricted'
+  if (policy.allowed_hosts.length === 0) return 'No outbound access'
+  return `${policy.allowed_hosts.length} allowed host${policy.allowed_hosts.length === 1 ? '' : 's'}`
+}

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -33,7 +33,9 @@ export type Agent = {
   archived_at: string | null
 }
 
-export type Egress = { allow: string[] }
+export type NetworkPolicy =
+  | { type: 'unrestricted' }
+  | { type: 'limited'; allowed_hosts: string[] }
 
 export type Environment = {
   type: 'environment'
@@ -41,7 +43,7 @@ export type Environment = {
   name: string
   description: string | null
   metadata: Record<string, string>
-  egress: Egress
+  network: NetworkPolicy
   created_at: string
   updated_at: string
   archived_at: string | null

--- a/apps/worker/test/worker.test.ts
+++ b/apps/worker/test/worker.test.ts
@@ -382,7 +382,7 @@ it("★ crash-resumes: worker B finishes the turn worker A abandoned, running th
   // A provisioned subprocess sandbox both workers share (same session → same workdir).
   const sid = randomUUID();
   const handle = await realSandbox.provision(
-    { egress: { allow: [] } },
+    { network: { type: "unrestricted" } },
     sid,
   );
   await seedSession({ id: sid, status: "ready", handle });

--- a/packages/configs/src/envs-service.ts
+++ b/packages/configs/src/envs-service.ts
@@ -7,13 +7,13 @@
 import { and, desc, eq, isNull, lt } from "drizzle-orm";
 import { v7 as uuidv7 } from "uuid";
 import type { Db } from "@funky/db";
-import { envConfigs } from "@funky/db/schema";
+import { envConfigs, type NetworkPolicy } from "@funky/db/schema";
 import { ConflictError, NotFoundError } from "./errors";
 import { isUniqueViolation, jsonEq } from "./util";
 import type { CreateEnvInput, Environment, UpdateEnvInput } from "./envs-types";
 import type { AuthContext, Page } from "./types";
 
-const DEFAULT_EGRESS = { allow: [] as string[] }; // deny-all egress by default
+const DEFAULT_NETWORK: NetworkPolicy = { type: "unrestricted" };
 
 type EnvRow = typeof envConfigs.$inferSelect;
 
@@ -39,7 +39,7 @@ export class EnvsService {
           name: input.name,
           description: input.description ?? null,
           metadata: input.metadata ?? {},
-          egress: input.egress ?? DEFAULT_EGRESS,
+          network: input.network ?? DEFAULT_NETWORK,
         })
         .returning();
       return { environment: toEnvironment(row!), created: true };
@@ -61,7 +61,7 @@ export class EnvsService {
       existing.name === input.name &&
       (existing.description ?? null) === (input.description ?? null) &&
       jsonEq(existing.metadata, input.metadata ?? {}) &&
-      jsonEq(existing.egress, input.egress ?? DEFAULT_EGRESS);
+      jsonEq(existing.network, input.network ?? DEFAULT_NETWORK);
     if (!same) {
       throw new ConflictError("an environment with this id exists with a different configuration");
     }
@@ -111,7 +111,7 @@ export class EnvsService {
         ...(patch.name !== undefined && { name: patch.name }),
         ...(patch.description !== undefined && { description: patch.description }),
         ...(patch.metadata !== undefined && { metadata: patch.metadata }), // replace, not merge
-        ...(patch.egress !== undefined && { egress: patch.egress }),
+        ...(patch.network !== undefined && { network: patch.network }),
         updatedAt: new Date(),
       })
       .where(and(eq(envConfigs.id, id), eq(envConfigs.namespace, ctx.namespace)))
@@ -166,7 +166,7 @@ function toEnvironment(row: EnvRow): Environment {
     name: row.name,
     description: row.description,
     metadata: row.metadata,
-    egress: row.egress,
+    network: row.network,
     created_at: row.createdAt.toISOString(),
     updated_at: row.updatedAt.toISOString(),
     archived_at: row.archivedAt?.toISOString() ?? null,

--- a/packages/configs/src/envs-types.ts
+++ b/packages/configs/src/envs-types.ts
@@ -1,5 +1,5 @@
 // packages/configs/src/envs-types.ts
-import type { EgressPolicy } from "@funky/db/schema";
+import type { NetworkPolicy } from "@funky/db/schema";
 
 export type Environment = {
   type: "environment";
@@ -7,7 +7,7 @@ export type Environment = {
   name: string;
   description: string | null;
   metadata: Record<string, string>;
-  egress: EgressPolicy;
+  network: NetworkPolicy;
   created_at: string;
   updated_at: string;
   archived_at: string | null;
@@ -18,7 +18,7 @@ export type CreateEnvInput = {
   name: string;
   description?: string | null;
   metadata?: Record<string, string>;
-  egress?: EgressPolicy;
+  network?: NetworkPolicy;
 };
 
 export type UpdateEnvInput = Partial<Omit<CreateEnvInput, "id">>;

--- a/packages/db/migrations/20260716033912_slimy_beyonder/migration.sql
+++ b/packages/db/migrations/20260716033912_slimy_beyonder/migration.sql
@@ -1,0 +1,24 @@
+ALTER TABLE "env_configs" RENAME COLUMN "egress" TO "network";--> statement-breakpoint
+UPDATE "env_configs"
+SET "network" = CASE
+	WHEN jsonb_array_length(COALESCE("network"->'allow', '[]'::jsonb)) = 0
+		THEN '{"type":"unrestricted"}'::jsonb
+	ELSE jsonb_build_object(
+		'type', 'limited',
+		'allowed_hosts', "network"->'allow'
+	)
+END
+WHERE "network" ? 'allow';--> statement-breakpoint
+UPDATE "sessions"
+SET "resolved_env" = ("resolved_env" - 'egress') || jsonb_build_object(
+	'network', CASE
+		WHEN jsonb_array_length(COALESCE("resolved_env"->'egress'->'allow', '[]'::jsonb)) = 0
+			THEN '{"type":"unrestricted"}'::jsonb
+		ELSE jsonb_build_object(
+			'type', 'limited',
+			'allowed_hosts', "resolved_env"->'egress'->'allow'
+		)
+	END
+)
+WHERE "resolved_env" ? 'egress';--> statement-breakpoint
+ALTER TABLE "env_configs" ALTER COLUMN "network" SET DEFAULT '{"type":"unrestricted"}';

--- a/packages/db/migrations/20260716033912_slimy_beyonder/snapshot.json
+++ b/packages/db/migrations/20260716033912_slimy_beyonder/snapshot.json
@@ -1,0 +1,1072 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "2a69d621-88c2-4e0c-86a2-490861716e20",
+  "prevIds": [
+    "b8c06055-5a7c-4168-8b67-67cf7baef66c"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "agent_config_versions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "agent_configs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "env_configs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "session_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "sessions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "turn_jobs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "agent_config_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "system_prompt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "model",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "tool_policy",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "1",
+      "generated": null,
+      "identity": null,
+      "name": "latest_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{\"type\":\"unrestricted\"}'",
+      "generated": null,
+      "identity": null,
+      "name": "network",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seq",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "agent_config_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "agent_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "env_config_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resolved_env",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "sandbox_handle",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'provisioning'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'turn'",
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'queued'",
+      "generated": null,
+      "identity": null,
+      "name": "state",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "run_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "attempts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "5",
+      "generated": null,
+      "identity": null,
+      "name": "max_attempts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "lease_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_configs_ns_name",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_configs_ns",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "env_configs_ns_name",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "env_configs_ns",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_ns",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "run_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"state\" = 'queued'",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "turn_jobs_queued",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"state\" IN ('queued', 'running')",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "turn_jobs_active_session",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "agent_config_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "agent_configs",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "agent_config_versions_agent_config_id_agent_configs_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "session_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "sessions",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "session_events_session_id_sessions_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "agent_config_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "agent_configs",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "sessions_agent_config_id_agent_configs_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "env_config_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "env_configs",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "sessions_env_config_id_env_configs_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "session_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "sessions",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "turn_jobs_session_id_sessions_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "columns": [
+        "agent_config_id",
+        "version"
+      ],
+      "nameExplicit": false,
+      "name": "agent_config_versions_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "columns": [
+        "session_id",
+        "seq"
+      ],
+      "nameExplicit": false,
+      "name": "session_events_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "agent_configs_pkey",
+      "schema": "public",
+      "table": "agent_configs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "env_configs_pkey",
+      "schema": "public",
+      "table": "env_configs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pkey",
+      "schema": "public",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "turn_jobs_pkey",
+      "schema": "public",
+      "table": "turn_jobs",
+      "entityType": "pks"
+    }
+  ],
+  "renames": [
+    "public.env_configs.egress->public.env_configs.network"
+  ]
+}

--- a/packages/db/schema/envs.ts
+++ b/packages/db/schema/envs.ts
@@ -1,6 +1,6 @@
 // packages/db/schema/envs.ts
 // Environment config = the reusable, template-like recipe for a session's sandbox
-// (egress policy). One environment fans out to many sessions; each session provisions
+// (network policy). One environment fans out to many sessions; each session provisions
 // its OWN isolated sandbox (filesystem is per-session, never shared). Single table +
 // archive, NOT versioned: the config is consumed once at sandbox provision, so updates
 // only affect future sessions. When sessions land they snapshot resolved_env at
@@ -16,7 +16,9 @@ import {
   index, jsonb, pgTable, text, timestamp, uuid,
 } from "drizzle-orm/pg-core";
 
-export type EgressPolicy = { allow: string[] }; // domain allowlist; [] = deny all egress
+export type NetworkPolicy =
+  | { type: "unrestricted" }
+  | { type: "limited"; allowed_hosts: string[] };
 
 export const envConfigs = pgTable(
   "env_configs",
@@ -28,7 +30,10 @@ export const envConfigs = pgTable(
     metadata: jsonb("metadata").$type<Record<string, string>>().notNull().default({}),
 
     // ---- the recipe ----
-    egress: jsonb("egress").$type<EgressPolicy>().notNull().default({ allow: [] }),
+    network: jsonb("network")
+      .$type<NetworkPolicy>()
+      .notNull()
+      .default({ type: "unrestricted" }),
 
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/db/schema/sessions.ts
+++ b/packages/db/schema/sessions.ts
@@ -17,13 +17,13 @@ import {
   uuid,
 } from "drizzle-orm/pg-core";
 import { agentConfigs } from "./configs";
-import { envConfigs } from "./envs"; // ⚠ adjust if the env iteration named this file differently
+import { envConfigs, type NetworkPolicy } from "./envs"; // ⚠ adjust if the env iteration named this file differently
 
 /** Snapshot captured at sandbox provision; reboots rebuild from THIS, never from the
  *  (mutable) env config. template_id is driver-specific (e.g. E2B template). */
 export type ResolvedEnv = {
   template_id?: string;
-  egress: { allow: string[] };
+  network: NetworkPolicy;
 };
 
 export type SessionStatus = "provisioning" | "ready" | "failed" | "archived";

--- a/packages/db/src/schema.test.ts
+++ b/packages/db/src/schema.test.ts
@@ -158,7 +158,12 @@ describe("env_configs", () => {
       name: { type: "text", notNull: true },
       description: { type: "text", notNull: false },
       metadata: { type: "jsonb", notNull: true, hasDefault: true, default: {} },
-      egress: { type: "jsonb", notNull: true, hasDefault: true, default: { allow: [] } },
+      network: {
+        type: "jsonb",
+        notNull: true,
+        hasDefault: true,
+        default: { type: "unrestricted" },
+      },
       created_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
       updated_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
       archived_at: { type: "timestamp with time zone", notNull: false },
@@ -347,16 +352,16 @@ describe("ModelConfig", () => {
 // -------------------------------------------------------------- session types
 
 describe("session domain types", () => {
-  it("ResolvedEnv snapshots optional template and egress", () => {
+  it("ResolvedEnv snapshots optional template and network policy", () => {
     const env: ResolvedEnv = {
       template_id: "e2b-abc123",
-      egress: { allow: ["api.example.com"] },
+      network: { type: "limited", allowed_hosts: ["api.example.com"] },
     };
-    expect(env.egress.allow).toEqual(["api.example.com"]);
+    expect(env.network).toEqual({ type: "limited", allowed_hosts: ["api.example.com"] });
 
     // template_id is optional — driver-specific, absent for drivers that don't use it.
     const minimal: ResolvedEnv = {
-      egress: { allow: [] },
+      network: { type: "unrestricted" },
     };
     expect(minimal.template_id).toBeUndefined();
   });

--- a/packages/ports/sandbox/src/computesdk.test.ts
+++ b/packages/ports/sandbox/src/computesdk.test.ts
@@ -20,8 +20,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { e2b } from "@computesdk/e2b";
-import type { CommandResult, SandboxInterface } from "computesdk";
-import { describe, it } from "vitest";
+import type { CommandResult, CreateSandboxOptions, SandboxInterface } from "computesdk";
+import { describe, expect, it } from "vitest";
 import { type ComputeProvider, ComputeSdkDriver } from "./drivers/computesdk";
 import { runSandboxTck } from "./tck";
 
@@ -51,10 +51,48 @@ if (apiKey) {
   });
 }
 
+describe("ComputeSDK network policies", () => {
+  it("maps a limited policy to E2B allowOut", async () => {
+    let createOptions: CreateSandboxOptions | undefined;
+    const driver = new ComputeSdkDriver({
+      providerName: "e2b",
+      provider: localShellProvider((options) => {
+        createOptions = options;
+      }),
+    });
+
+    const handle = await driver.provision(
+      { network: { type: "limited", allowed_hosts: ["api.example.com", "*.example.org"] } },
+      randomUUID(),
+    );
+    try {
+      expect(createOptions?.network).toEqual({
+        allowOut: ["api.example.com", "*.example.org"],
+      });
+    } finally {
+      await driver.teardown(handle);
+    }
+  });
+
+  it("fails closed when a provider cannot enforce a limited policy", async () => {
+    const driver = new ComputeSdkDriver({
+      providerName: "fake-local",
+      provider: localShellProvider(),
+    });
+
+    await expect(
+      driver.provision(
+        { network: { type: "limited", allowed_hosts: ["api.example.com"] } },
+        randomUUID(),
+      ),
+    ).rejects.toThrow("fake-local does not support limited network policies");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // The fake provider. One Map entry per "sandbox": a temp dir that plays $HOME.
 // ---------------------------------------------------------------------------
-function localShellProvider(): ComputeProvider {
+function localShellProvider(onCreate?: (options?: CreateSandboxOptions) => void): ComputeProvider {
   const roots = new Map<string, { home: string; destroyed: boolean }>();
   const pathPrefix = timeoutShimPathPrefix();
 
@@ -115,7 +153,8 @@ function localShellProvider(): ComputeProvider {
   return {
     name: "fake-local",
     sandbox: {
-      create: async () => {
+      create: async (options) => {
+        onCreate?.(options);
         const id = randomUUID();
         roots.set(id, { home: mkdtempSync(join(tmpdir(), "funky-csdk-")), destroyed: false });
         return makeSandbox(id);

--- a/packages/ports/sandbox/src/drivers/computesdk.ts
+++ b/packages/ports/sandbox/src/drivers/computesdk.ts
@@ -58,14 +58,20 @@ export class ComputeSdkDriver implements SandboxDriver {
     this.sandboxTimeoutMs = opts.sandboxTimeoutMs ?? DEFAULT_SANDBOX_TIMEOUT_MS;
   }
 
-  async provision(_spec: ResolvedEnv, sessionId: string): Promise<SandboxHandle> {
-    // v1 parity with subprocess: spec.egress is not mapped yet — the provider boots its
-    // default template. autoPause makes the timeout a pause (disk
-    // persisted, resumed on connect) instead of a kill; that's what keeps reboot honest.
+  async provision(spec: ResolvedEnv, sessionId: string): Promise<SandboxHandle> {
+    if (spec.network.type === "limited" && this.providerName !== "e2b") {
+      throw new Error(`${this.providerName} does not support limited network policies`);
+    }
+
+    // autoPause makes the timeout a pause (disk persisted, resumed on connect) instead
+    // of a kill; that's what keeps reboot honest.
     const sb = await this.manager.sandbox.create({
       timeout: this.sandboxTimeoutMs,
       metadata: { funky_session_id: sessionId },
       autoPause: true,
+      ...(spec.network.type === "limited" && {
+        network: { allowOut: spec.network.allowed_hosts },
+      }),
     });
     // Resolve the workdir REMOTELY ($HOME varies by template). Markers around the path
     // guard against login-shell noise (motd, profile echoes) polluting stdout.

--- a/packages/ports/sandbox/src/drivers/subprocess.ts
+++ b/packages/ports/sandbox/src/drivers/subprocess.ts
@@ -22,7 +22,10 @@ const MAX_OUTPUT_BYTES = 200_000;
 const POLL_MS = 100;
 
 export class SubprocessDriver implements SandboxDriver {
-  async provision(_spec: ResolvedEnv, sessionId: string): Promise<SandboxHandle> {
+  async provision(spec: ResolvedEnv, sessionId: string): Promise<SandboxHandle> {
+    if (spec.network.type === "limited") {
+      throw new Error("subprocess driver does not support limited network policies");
+    }
     const workdir = path.join(ROOT, sessionId);
     await fs.mkdir(workdir, { recursive: true });
     return { driver: "subprocess", workdir };

--- a/packages/ports/sandbox/src/subprocess.test.ts
+++ b/packages/ports/sandbox/src/subprocess.test.ts
@@ -1,6 +1,18 @@
 // Runs the sandbox TCK against the subprocess driver. computesdk / container drivers
 // add their own <driver>.test.ts calling the same runSandboxTck().
+import { randomUUID } from "node:crypto";
+import { expect, it } from "vitest";
 import { SubprocessDriver } from "./drivers/subprocess";
 import { runSandboxTck } from "./tck";
 
 runSandboxTck("subprocess", () => new SubprocessDriver());
+
+it("fails closed for limited network policies", async () => {
+  const driver = new SubprocessDriver();
+  await expect(
+    driver.provision(
+      { network: { type: "limited", allowed_hosts: ["api.example.com"] } },
+      randomUUID(),
+    ),
+  ).rejects.toThrow("subprocess driver does not support limited network policies");
+});

--- a/packages/ports/sandbox/src/tck.ts
+++ b/packages/ports/sandbox/src/tck.ts
@@ -13,7 +13,7 @@ import { type ExecEvent, type Executor, type SandboxDriver, SandboxUnavailableEr
 import type { ResolvedEnv } from "@funky/db/schema";
 
 const SPEC: ResolvedEnv = {
-  egress: { allow: [] },
+  network: { type: "unrestricted" },
 };
 
 type Collected = { stdout: string; stderr: string; exit: { code: number; truncated: boolean } };

--- a/packages/sessions/src/provision.ts
+++ b/packages/sessions/src/provision.ts
@@ -35,7 +35,7 @@ export async function runProvision(job: Job, deps: TurnDeps): Promise<TurnOutcom
 
   // Snapshot the env config. template_id stays undefined for the subprocess driver.
   const resolvedEnv: ResolvedEnv = {
-    egress: env.egress,
+    network: env.network,
   };
 
   try {

--- a/packages/sessions/src/turn.test.ts
+++ b/packages/sessions/src/turn.test.ts
@@ -126,7 +126,7 @@ async function seedSession(opts: {
   let handle: SandboxHandle | null = opts.handle ?? null;
   if (!handle && opts.provision !== false) {
     handle = await sandbox.provision(
-      { egress: { allow: [] } },
+      { network: { type: "unrestricted" } },
       sessionId,
     );
     handles.push(handle);
@@ -535,7 +535,9 @@ describe("runProvision", () => {
       sandbox_handle: { driver?: string } | null;
     }>("select status, resolved_env, sandbox_handle from sessions where id = $1", [sessionId]);
     expect(rows[0]!.status).toBe("ready");
-    expect(rows[0]!.resolved_env).toMatchObject({ egress: { allow: [] } });
+    expect(rows[0]!.resolved_env).toMatchObject({
+      network: { type: "unrestricted" },
+    });
     expect(rows[0]!.sandbox_handle?.driver).toBe("subprocess");
     if (rows[0]!.sandbox_handle) handles.push(rows[0]!.sandbox_handle as SandboxHandle);
 

--- a/tests/chaos/src/harness.ts
+++ b/tests/chaos/src/harness.ts
@@ -214,7 +214,7 @@ export async function buildWorld(
   const llm = scriptedLlm({ [sessionId]: script });
 
   const resolvedEnv: ResolvedEnv = {
-    egress: { allow: [] },
+    network: { type: "unrestricted" },
   };
   // Most scenarios seed the session ALREADY provisioned — provisioning is not what they
   // test. H6 sets provisioned:false so the worker runs runProvision (and can crash in it).


### PR DESCRIPTION
## Summary

- Replace the egress allowlist with unrestricted and limited network policy variants across the API, database, session snapshots, and web client.
- Default new environments to unrestricted while migrating legacy empty allowlists to unrestricted and retaining non-empty allowlists as limited policies.
- Enforce limited policies through E2B allowOut and fail closed for sandbox providers that cannot enforce them.
- Add network controls to Quick Start and environment creation, including generated curl output and policy badges.

## Validation

- pnpm typecheck
- pnpm test (325 passed, 3 skipped)
- pnpm build and pnpm lint in apps/web