### PR TITLE
Add local docker sandbox driver and make it the default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,10 +12,16 @@ DATABASE_URL=postgres://funky:funky@localhost:5432/funky
 # FUNKY_LLM=ai-sdk
 # ANTHROPIC_API_KEY=sk-ant-...
 
-# "subprocess" (default): commands run inside the worker container. No isolation, no key.
+# "docker" (default): a real, isolated container per session on the local Docker daemon. No
+#           cloud account. `docker compose up` builds the base image (docker/sandbox.Dockerfile)
+#           and mounts the daemon socket into the worker automatically — nothing to set.
+#           Running the worker OUTSIDE compose (`pnpm -F worker dev`) needs the image built
+#           first: docker build -f docker/sandbox.Dockerfile -t funky-sandbox:trixie docker/
+# FUNKY_DOCKER_IMAGE=funky-sandbox:trixie   # override the base image if you like
+#
 # "e2b": an isolated E2B sandbox per session, provisioned via ComputeSDK. It outlives any
-#        single worker, and idles pause after FUNKY_E2B_SANDBOX_TIMEOUT_MS (default 30min,
-#        resumed on the next command). Requires an API key from https://e2b.dev
+#        single worker AND any single host, and idles pause after FUNKY_E2B_SANDBOX_TIMEOUT_MS
+#        (default 30min, resumed on the next command). Requires an API key from https://e2b.dev
 # FUNKY_SANDBOX=e2b
 # E2B_API_KEY=e2b_...
 # FUNKY_E2B_SANDBOX_TIMEOUT_MS=1800000

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,12 @@
 
 FROM node:22-slim
 
+# The Docker CLI (client only, no daemon) — the worker's default `docker` sandbox driver
+# shells out to it, talking to the HOST daemon through a mounted /var/run/docker.sock (see
+# docker-compose.yml). Grabbed from the official multi-arch `docker` image; the api never
+# uses it, but this is the one shared image (api + worker), so it lives here.
+COPY --from=docker:cli /usr/local/bin/docker /usr/local/bin/docker
+
 ENV PNPM_HOME=/pnpm
 ENV PATH=$PNPM_HOME:$PATH
 RUN corepack enable

--- a/README.md
+++ b/README.md
@@ -82,13 +82,18 @@ time that the event log is byte-for-byte identical, that every command ran **exa
 and that the turn still ends in a terminal event. It is required on `main`: a red chaos run
 blocks the release.
 
-> **Honest limit — the default `subprocess` driver.** The dev sandbox runs commands
-> **inside the worker container** (no isolation), so the sandbox filesystem and any
-> in-flight command are *not* durable: they live and die with that container. The E2B
-> driver (next section) removes this limit: the sandbox outlives any single worker, a
-> running command records its output and exit code inside the sandbox itself, and the
-> idempotent `exec` contract (a command never runs twice, whatever the driver) lets a
-> replacement worker re-attach to work a dead worker started and finish the turn.
+> **Honest limits — the default `docker` driver.** Each session gets its own isolated
+> container on the local Docker daemon (real filesystem, process, and host-network
+> isolation). The container outlives the worker *process*, and because a running command
+> records its output and exit code inside the container itself, a replacement worker
+> re-attaches by idempotency key and finishes the turn — the idempotent `exec` contract
+> guarantees a command never runs twice, whatever the driver. Two honest caveats: the
+> container lives on **one Docker host**, so re-attach works within that host but not across
+> a multi-host worker fleet (that's what the **E2B** driver is for); and a plain container is
+> shared-kernel, so for untrusted workloads you'd run it under gVisor/Kata or use E2B's
+> microVMs. (There is also an in-process `subprocess` driver with no isolation — it is not a
+> production option; it exists only so the offline test suites, including the chaos warranty
+> above, run fast and daemon-free.)
 
 ### Using a real model
 
@@ -102,7 +107,37 @@ docker compose up -d --build worker
 ```
 Now the same curl commands drive a real Claude, writing and running its own shell commands.
 
-### Using a real sandbox
+### The default sandbox (`docker`)
+
+Out of the box, every session gets its own isolated container on the local Docker daemon —
+no cloud account, nothing to configure. `docker compose up` does it all: it builds the
+[base image](docker/sandbox.Dockerfile), mounts the daemon socket into the worker, and the
+worker runs `docker run` per session and executes commands inside via `docker exec`
+(docker-out-of-docker — the sandbox containers are siblings of the stack on your host).
+
+The base image is `debian:trixie-slim` (glibc + GNU coreutils, so agent-driven
+`pip`/`npm`/`apt install` stays on the happy path) with `git`, `curl`, `python3`, and `node`
+preinstalled and a non-root `agent` user. Swap it with `FUNKY_DOCKER_IMAGE`.
+
+> **Security note.** The default mounts `/var/run/docker.sock` into the worker, granting it
+> host-daemon access, and sandbox containers are shared-kernel. That's fine for local or
+> trusted use; for untrusted workloads use `FUNKY_SANDBOX=e2b` (remote microVMs) or run the
+> sandbox containers under a gVisor/Kata runtime.
+
+Running the worker **outside compose** (`pnpm -F worker dev`) uses your host's Docker
+directly; build the image once first:
+```bash
+docker build -f docker/sandbox.Dockerfile -t funky-sandbox:trixie docker/
+```
+
+The docker driver reuses the same [ComputeSDK](https://computesdk.com)-based idemKey
+protocol as E2B and answers to the **identical conformance suite** as every other driver;
+its cases run whenever a Docker daemon is reachable:
+```bash
+pnpm -F @funky/sandbox test        # runs the docker TCK against a live daemon (else skips)
+```
+
+### Using a remote sandbox (E2B)
 
 ```bash
 # in .env
@@ -116,8 +151,9 @@ Now every session provisions an isolated [E2B](https://e2b.dev) sandbox, through
 [ComputeSDK](https://computesdk.com) so further providers can slot in behind the same
 driver. The sandbox — not the worker — holds each command's output and exit code, which is
 what makes sessions survive worker death: a replacement worker re-attaches by idempotency
-key and reads the same files. Idle sandboxes pause after 30 minutes
-(`FUNKY_E2B_SANDBOX_TIMEOUT_MS`) and resume on the next command, filesystem intact.
+key and reads the same files. Unlike the docker driver this is reachable from **any** worker
+host, not just one. Idle sandboxes pause after 30 minutes (`FUNKY_E2B_SANDBOX_TIMEOUT_MS`)
+and resume on the next command, filesystem intact.
 
 The E2B driver answers to the identical conformance suite as the subprocess driver; it
 runs against real sandboxes when a key is present:

--- a/apps/worker/src/config.ts
+++ b/apps/worker/src/config.ts
@@ -16,11 +16,16 @@ const EnvSchema = z
     FUNKY_WORKER_CONCURRENCY: z.coerce.number().int().min(1).default(50),
     FUNKY_WORKER_HEALTH_PORT: z.coerce.number().int().min(1).max(65535).default(9090),
     FUNKY_LLM: z.enum(["fake", "ai-sdk"]).default("fake"),
-    FUNKY_SANDBOX: z.enum(["subprocess", "e2b"]).default("subprocess"),
+    // docker (default): an isolated container per session on the local daemon — no account.
+    // e2b: an isolated remote sandbox per session. (The in-process subprocess driver still
+    // exists for the offline test suites, but is not a production sandbox option.)
+    FUNKY_SANDBOX: z.enum(["docker", "e2b"]).default("docker"),
     // Required ONLY when FUNKY_LLM=ai-sdk (the fake driver makes no network calls).
     ANTHROPIC_API_KEY: optionalSecret,
-    // Required ONLY when FUNKY_SANDBOX=e2b (subprocess needs no account).
+    // Required ONLY when FUNKY_SANDBOX=e2b (docker needs no account).
     E2B_API_KEY: optionalSecret,
+    // Base image for the docker driver (built from docker/sandbox.Dockerfile).
+    FUNKY_DOCKER_IMAGE: z.string().min(1).default("funky-sandbox:trixie"),
     // Idle lifetime before an e2b sandbox auto-pauses (resumed on the next command).
     FUNKY_E2B_SANDBOX_TIMEOUT_MS: z.coerce
       .number()
@@ -38,7 +43,7 @@ const EnvSchema = z
   .refine((e) => e.FUNKY_SANDBOX !== "e2b" || e.E2B_API_KEY !== undefined, {
     message:
       "E2B_API_KEY is required when FUNKY_SANDBOX=e2b. " +
-      "Set it, or leave FUNKY_SANDBOX=subprocess for local development.",
+      "Set it, or leave FUNKY_SANDBOX=docker for local development.",
     path: ["E2B_API_KEY"],
   });
 
@@ -47,12 +52,14 @@ export type Config = {
   concurrency: number;
   healthPort: number;
   llm: "fake" | "ai-sdk";
-  sandbox: "subprocess" | "e2b";
+  sandbox: "docker" | "e2b";
   /** null = fake driver; no key needed. */
   anthropicApiKey: string | null;
-  /** null = subprocess driver; no key needed. */
+  /** null = docker driver; no key needed. */
   e2bApiKey: string | null;
   e2bSandboxTimeoutMs: number;
+  /** Base image for the docker driver. */
+  dockerImage: string;
   dbPoolMax: number;
 };
 
@@ -76,6 +83,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     anthropicApiKey: e.ANTHROPIC_API_KEY ?? null,
     e2bApiKey: e.E2B_API_KEY ?? null,
     e2bSandboxTimeoutMs: e.FUNKY_E2B_SANDBOX_TIMEOUT_MS,
+    dockerImage: e.FUNKY_DOCKER_IMAGE,
     dbPoolMax: e.DB_POOL_MAX,
   };
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -32,7 +32,7 @@ const worker = startWorker({
   queue,
   store,
   llm: makeLlm(llmConfig(cfg)), // fake by default — no API key needed
-  sandbox: makeSandbox(sandboxConfig(cfg)), // subprocess by default — no account needed
+  sandbox: makeSandbox(sandboxConfig(cfg)), // docker by default — isolated, no account needed
   db,
   listenClient,
   concurrency: cfg.concurrency,
@@ -60,16 +60,20 @@ function llmConfig(c: Config): LlmConfig {
     : { driver: "fake", instance: new FakeLlm({ scripts: {} }) };
 }
 
-// subprocess runs commands inside THIS container (dev default, no isolation). e2b gives
-// every session an isolated remote sandbox that outlives any single worker.
+// docker (default) gives every session a real, isolated container from a base image on the
+// local daemon — no account. e2b gives every session an isolated remote sandbox that
+// outlives any single worker (and any single host).
 function sandboxConfig(c: Config): SandboxConfig {
-  return c.sandbox === "e2b"
-    ? {
+  switch (c.sandbox) {
+    case "e2b":
+      return {
         driver: "e2b",
         apiKey: c.e2bApiKey ?? "", // non-null per the config refine; "" can't slip through the driver's key check
         sandboxTimeoutMs: c.e2bSandboxTimeoutMs,
-      }
-    : { driver: "subprocess" };
+      };
+    default:
+      return { driver: "docker", image: c.dockerImage };
+  }
 }
 
 // Shutdown: drain, don't kill. Stop pulling, let in-flight turns finish, then release

--- a/apps/worker/test/config.test.ts
+++ b/apps/worker/test/config.test.ts
@@ -26,11 +26,21 @@ describe("loadConfig — valid input", () => {
       concurrency: 50,
       healthPort: 9090,
       llm: "fake",
-      sandbox: "subprocess",
+      sandbox: "docker",
       anthropicApiKey: null,
       e2bApiKey: null,
       e2bSandboxTimeoutMs: 30 * 60_000,
+      dockerImage: "funky-sandbox:trixie",
       dbPoolMax: 10,
+    });
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("defaults the docker driver's image and lets FUNKY_DOCKER_IMAGE override it", () => {
+    expect(loadConfig(BASE).dockerImage).toBe("funky-sandbox:trixie");
+    expect(loadConfig({ ...BASE, FUNKY_DOCKER_IMAGE: "my-sandbox:latest" })).toMatchObject({
+      sandbox: "docker",
+      dockerImage: "my-sandbox:latest",
     });
     expect(exitSpy).not.toHaveBeenCalled();
   });
@@ -63,6 +73,7 @@ describe("loadConfig — valid input", () => {
       anthropicApiKey: "sk-ant-secret",
       e2bApiKey: "e2b_secret",
       e2bSandboxTimeoutMs: 600_000,
+      dockerImage: "funky-sandbox:trixie",
       dbPoolMax: 25,
     });
   });
@@ -83,7 +94,8 @@ describe("loadConfig — invalid input exits the process", () => {
     ["concurrency not a number", { ...BASE, FUNKY_WORKER_CONCURRENCY: "lots" }],
     ["health port out of range", { ...BASE, FUNKY_WORKER_HEALTH_PORT: "70000" }],
     ["unknown FUNKY_LLM", { ...BASE, FUNKY_LLM: "gpt" }],
-    ["unknown FUNKY_SANDBOX", { ...BASE, FUNKY_SANDBOX: "docker" }],
+    ["unknown FUNKY_SANDBOX", { ...BASE, FUNKY_SANDBOX: "podman" }],
+    ["subprocess is not a production sandbox option", { ...BASE, FUNKY_SANDBOX: "subprocess" }],
     ["DB_POOL_MAX below 1", { ...BASE, DB_POOL_MAX: "0" }],
   ])("exits on %s", (_label, env) => {
     expect(() => loadConfig(env as NodeJS.ProcessEnv)).toThrow("process.exit(1)");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,17 @@ services:
       postgres:
         condition: service_healthy
 
+  # One-shot: builds the base image the `docker` sandbox driver starts each session from,
+  # tagging it on the SAME daemon the worker reaches through the mounted socket below. It
+  # only builds+tags, so it runs `true` and exits; the worker waits for it to complete.
+  sandbox-image:
+    build:
+      context: docker
+      dockerfile: sandbox.Dockerfile
+    image: ${FUNKY_DOCKER_IMAGE:-funky-sandbox:trixie}
+    command: ["true"]
+    restart: "no"
+
   api:
     build: .
     ports:
@@ -65,16 +76,26 @@ services:
   worker:
     build: .
     command: ["pnpm", "-F", "worker", "start:src"]
+    # The default `docker` sandbox driver spawns each session's container as a SIBLING on the
+    # host daemon (docker-out-of-docker) via this socket — the worker's `docker` CLI (baked
+    # into the image) talks to it. NOTE: this grants the worker host-daemon access, and
+    # sandbox containers share the host kernel — fine for local/trusted use; for untrusted
+    # workloads prefer FUNKY_SANDBOX=e2b (remote) or run the containers under gVisor/Kata.
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     environment:
       DATABASE_URL: postgres://funky:funky@postgres:5432/funky # ← service name, not localhost
       FUNKY_LLM: ${FUNKY_LLM:-fake}
-      FUNKY_SANDBOX: ${FUNKY_SANDBOX:-subprocess}
+      FUNKY_SANDBOX: ${FUNKY_SANDBOX:-docker}
+      FUNKY_DOCKER_IMAGE: ${FUNKY_DOCKER_IMAGE:-funky-sandbox:trixie} # built by the sandbox-image service
       FUNKY_WORKER_CONCURRENCY: ${FUNKY_WORKER_CONCURRENCY:-10}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-} # empty unless the user sets it
       E2B_API_KEY: ${E2B_API_KEY:-} # empty unless the user sets it
       FUNKY_E2B_SANDBOX_TIMEOUT_MS: ${FUNKY_E2B_SANDBOX_TIMEOUT_MS:-1800000}
     depends_on:
       migrate:
+        condition: service_completed_successfully
+      sandbox-image: # the base image must exist on the daemon before the first session runs
         condition: service_completed_successfully
     healthcheck:
       test:

--- a/docker/sandbox.Dockerfile
+++ b/docker/sandbox.Dockerfile
@@ -1,0 +1,39 @@
+# docker/sandbox.Dockerfile — the base image for the `docker` sandbox driver.
+#
+# One container per session is started from this image (`docker run -d`), and the agent's
+# commands run inside it via `docker exec`. Build + tag it on the host the worker's Docker
+# daemon uses:
+#
+#   docker build -f docker/sandbox.Dockerfile -t funky-sandbox:trixie docker/
+#
+# then point the worker at it:  FUNKY_SANDBOX=docker  FUNKY_DOCKER_IMAGE=funky-sandbox:trixie
+#
+# Why debian:trixie-slim, not alpine: the idemKey shell protocol (see drivers/computesdk.ts)
+# depends on GNU-coreutils semantics — `timeout <secs> CMD`, `base64` line-wrapping,
+# `tail -c +N`, `nohup` — which is exactly what E2B's Debian-based template provides, so the
+# docker and e2b drivers run identical semantics. glibc (not musl) also keeps agent-driven
+# `pip`/`npm`/`apt install` on the happy path where prebuilt binaries just work.
+FROM debian:trixie-slim
+
+# ca-certificates so https works out of the box; curl+git because an agent reaches for them
+# on command one; python3+node so the two commonest agent runtimes are ready without an
+# apt/nvm detour. Kept intentionally lean — anything else the agent installs on demand.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        python3 \
+        nodejs \
+        npm \
+    && rm -rf /var/lib/apt/lists/*
+
+# Non-root by default. The worker reaches the daemon through a mounted socket (≈ host root
+# already) — don't compound that by running the agent's commands as root inside the box too.
+RUN useradd --create-home --shell /bin/bash agent
+USER agent
+WORKDIR /home/agent
+
+# The driver overrides this with `sleep infinity` at `docker run`, but a sane default keeps
+# the image runnable on its own for debugging (`docker run --rm -it funky-sandbox:trixie`).
+CMD ["sleep", "infinity"]

--- a/packages/ports/sandbox/src/docker.test.ts
+++ b/packages/ports/sandbox/src/docker.test.ts
@@ -1,0 +1,43 @@
+// Runs the sandbox TCK against the docker driver — the SAME suite subprocess and e2b run,
+// so the container path is held to the identical idemKey contract.
+//
+// The TCK block is skipped unless a Docker daemon is reachable (guarded like the e2b block
+// is on its API key), and uses a small, auto-pullable image by default so CI needs no
+// prebuilt funky-sandbox image:
+//
+//   FUNKY_DOCKER_TEST_IMAGE=funky-sandbox:trixie pnpm -F @funky/sandbox test
+//
+// It needs only GNU coreutils + /bin/sh, which debian:trixie-slim (the base of the real
+// sandbox image) provides.
+
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { ComputeSdkDriver } from "./drivers/computesdk";
+import { dockerProvider } from "./drivers/docker";
+import { runSandboxTck } from "./tck";
+
+const dockerAvailable = spawnSync("docker", ["info"], { stdio: "ignore" }).status === 0;
+const TEST_IMAGE = process.env.FUNKY_DOCKER_TEST_IMAGE ?? "debian:trixie-slim";
+
+if (dockerAvailable) {
+  runSandboxTck(
+    "docker",
+    () => new ComputeSdkDriver({ providerName: "docker", provider: dockerProvider({ image: TEST_IMAGE }) }),
+    { timeoutMs: 60_000 }, // provision pulls the image on first run; every poll forks `docker exec`
+  );
+} else {
+  describe("sandbox TCK: docker", () => {
+    it.skip("skipped: no reachable Docker daemon (`docker info` failed)", () => {});
+  });
+}
+
+// Needs no daemon: provision rejects a limited policy before it ever touches Docker.
+describe("docker network policies", () => {
+  it("fails closed for limited network policies", async () => {
+    const driver = new ComputeSdkDriver({ providerName: "docker", provider: dockerProvider({ image: TEST_IMAGE }) });
+    await expect(
+      driver.provision({ network: { type: "limited", allowed_hosts: ["api.example.com"] } }, randomUUID()),
+    ).rejects.toThrow("docker does not support limited network policies");
+  });
+});

--- a/packages/ports/sandbox/src/drivers/docker.ts
+++ b/packages/ports/sandbox/src/drivers/docker.ts
@@ -1,0 +1,134 @@
+// packages/ports/sandbox/src/drivers/docker.ts — local containers via the Docker daemon.
+//
+// A "real" local sandbox: every session gets its OWN container (`docker run -d` from a
+// curated base image), and commands run inside it via `docker exec` — real filesystem,
+// process, and (host-)network isolation, unlike the subprocess driver that shares the
+// worker's own container.
+//
+// This is deliberately NOT a from-scratch SandboxDriver. The whole idemKey shell protocol
+// — the mkdir first-run lock, the detached runner that stamps `exit` from inside the
+// sandbox, the poll envelope, base64 file i/o, the in-sandbox `timeout(1)` — already lives
+// in ComputeSdkDriver, which is provider-generic. So the Docker driver is just a ComputeSDK
+// *provider* whose runCommand shells out to `docker exec`. Plug it into ComputeSdkDriver and
+// the container path inherits the identical, TCK-verified semantics as E2B, for free.
+//
+// Durability: because the container runs on the host daemon (a sibling of the worker, via a
+// mounted docker socket) it OUTLIVES the worker process — any worker holding the handle
+// re-execs by container id and re-attaches to the same `exit` files. This is real re-attach,
+// but only WITHIN a single Docker host: a container is unreachable from another host's
+// daemon. Cross-host worker fleets need host affinity or the remote (E2B) driver.
+//
+// Error mapping mirrors the E2B provider exactly, because ComputeSdkDriver depends on it:
+// runCommand NEVER throws — a dead container / unreachable daemon comes back as exitCode 127
+// with the message in stderr (the port's "no exit code ⇒ unavailable" rule), while a
+// non-zero exit from a command that actually RAN is passed through untouched.
+
+import { execFile } from "node:child_process";
+import type { CommandResult, CreateSandboxOptions, SandboxInterface } from "computesdk";
+import type { ComputeProvider } from "./computesdk";
+
+export type DockerProviderOptions = {
+  /** Base image every session container is started from (e.g. "funky-sandbox:trixie"). */
+  image: string;
+  /** Docker binary; override for a custom path or a `podman` shim. Defaults to "docker". */
+  docker?: string;
+};
+
+// docker exec / start / run write these to stderr when the daemon is unreachable or the
+// container is gone — i.e. the result is UNOBSERVABLE. Distinguishes a transport failure
+// (→ exit 127, ComputeSdkDriver throws SandboxUnavailableError) from a command that ran and
+// exited non-zero (passed through). Our wrapper scripts never emit these strings themselves.
+const DAEMON_ERROR =
+  /Error response from daemon|No such container|is not running|Cannot connect to the Docker daemon|dial unix|Is the docker daemon running/i;
+
+/** A ComputeSDK provider whose "sandboxes" are containers on the local Docker daemon.
+ *  Pass to ComputeSdkDriver: `new ComputeSdkDriver({ providerName: "docker", provider })`. */
+export function dockerProvider(opts: DockerProviderOptions): ComputeProvider {
+  const docker = opts.docker ?? "docker";
+  const image = opts.image;
+
+  function makeSandbox(id: string): SandboxInterface {
+    // The only method ComputeSdkDriver calls. `docker exec … sh -c <script>` runs the
+    // protocol scripts inside the container; a daemon/container failure becomes exit 127.
+    const runCommand = async (command: string): Promise<CommandResult> => {
+      const t0 = Date.now();
+      const r = await run(docker, ["exec", id, "sh", "-c", command]);
+      if (r.code !== 0 && DAEMON_ERROR.test(r.stderr)) {
+        return { stdout: "", stderr: r.stderr.trim(), exitCode: 127, durationMs: Date.now() - t0 };
+      }
+      return { stdout: r.stdout, stderr: r.stderr, exitCode: r.code, durationMs: Date.now() - t0 };
+    };
+    const unused = (what: string) => async (): Promise<never> => {
+      throw new Error(`${what} is not used by the Docker driver`);
+    };
+    return {
+      sandboxId: id,
+      provider: "docker",
+      runCommand,
+      getInfo: async () => ({ id, provider: "docker", status: "running" as const, createdAt: new Date(), timeout: 0 }),
+      getUrl: unused("getUrl"),
+      destroy: async () => {
+        await run(docker, ["rm", "-f", id]);
+      },
+      // The driver does file i/o through runCommand + base64 (binary-safe), never this API.
+      filesystem: {
+        readFile: unused("filesystem.readFile"),
+        writeFile: unused("filesystem.writeFile"),
+        readdir: unused("filesystem.readdir"),
+        mkdir: unused("filesystem.mkdir"),
+        exists: unused("filesystem.exists"),
+        remove: unused("filesystem.remove"),
+      },
+    };
+  }
+
+  return {
+    name: "docker",
+    sandbox: {
+      // `sleep infinity` (overriding the image CMD) keeps the container alive so later
+      // `docker exec`s have something to attach to. --init reaps the detached nohup runners
+      // the protocol spawns. autoPause/timeout options don't map to Docker — a container
+      // just runs until teardown — so they're ignored; the label aids `docker ps` triage.
+      create: async (options?: CreateSandboxOptions): Promise<SandboxInterface> => {
+        const session = options?.metadata?.funky_session_id;
+        const args = ["run", "-d", "--init"];
+        if (session) args.push("--label", `funky.session=${session}`);
+        args.push(image, "sleep", "infinity");
+        const r = await run(docker, args);
+        const id = r.stdout.trim();
+        if (r.code !== 0 || !id) {
+          throw new Error(`docker run failed: ${(r.stderr || r.stdout).trim() || `exit ${r.code}`}`);
+        }
+        return makeSandbox(id);
+      },
+      // `docker start` is idempotent on a running container AND resumes a stopped one with
+      // its filesystem intact — so a container that was paused (or survived a daemon
+      // restart) "auto-resumes" here, exactly the semantics ComputeSdkDriver.reboot expects.
+      // A missing container → non-zero → null (the driver reads that as unavailable).
+      getById: async (id: string): Promise<SandboxInterface | null> => {
+        const r = await run(docker, ["start", id]);
+        return r.code === 0 ? makeSandbox(id) : null;
+      },
+      // rm -f removes a running or stopped container; run() never rejects and rm -f on a
+      // missing container is a no-op error we swallow, so teardown stays idempotent.
+      destroy: async (id: string): Promise<void> => {
+        await run(docker, ["rm", "-f", id]);
+      },
+    },
+  };
+}
+
+// Run a docker subcommand, always resolving with the captured streams + exit code — never
+// rejecting. A spawn failure (docker binary absent) surfaces as code 127, so it flows
+// through the same "unobservable ⇒ 127" path as a dead daemon. maxBuffer is generous: a
+// single poll can carry up to ~200KB of base64-wrapped output.
+function run(bin: string, args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((resolve) => {
+    execFile(bin, args, { maxBuffer: 64 * 1024 * 1024 }, (err, stdout, stderr) => {
+      // On a non-zero exit, err.code is the numeric exit code. On a spawn failure (docker
+      // binary absent) it's a string errno like "ENOENT" → map to 127 (unobservable).
+      const code = err ? (typeof err.code === "number" ? err.code : 127) : 0;
+      resolve({ stdout: stdout ?? "", stderr: (stderr || (err ? String(err) : "")) ?? "", code });
+    });
+  });
+}

--- a/packages/ports/sandbox/src/index.ts
+++ b/packages/ports/sandbox/src/index.ts
@@ -3,26 +3,36 @@
 
 export type { ExecEvent, Executor, SandboxDriver, SandboxHandle } from "./port";
 export { SandboxUnavailableError } from "./port";
+// SubprocessDriver is NOT a production sandbox option (see makeSandbox / SandboxConfig): it
+// runs commands in the worker's own container with no isolation. It stays exported purely as
+// the fast, offline in-process driver the test suites — including the chaos warranty — run
+// against; production sandboxes are `docker` (local containers) or `e2b` (remote).
 export { SubprocessDriver } from "./drivers/subprocess";
 export { ComputeSdkDriver, type ComputeSdkDriverOptions, type ComputeProvider } from "./drivers/computesdk";
+export { dockerProvider, type DockerProviderOptions } from "./drivers/docker";
 export { runSandboxTck } from "./tck";
 
 import { e2b } from "@computesdk/e2b";
 import { ComputeSdkDriver } from "./drivers/computesdk";
-import { SubprocessDriver } from "./drivers/subprocess";
+import { dockerProvider } from "./drivers/docker";
 import type { SandboxDriver } from "./port";
 
 export type SandboxConfig =
-  | { driver: "subprocess" }
+  | { driver: "docker"; image: string }
   | { driver: "e2b"; apiKey: string; sandboxTimeoutMs?: number };
 
-/** Build a driver from config. `subprocess` is the zero-setup dev default (commands run
- *  in the worker's own container); `e2b` provisions an isolated remote sandbox per
- *  session via ComputeSDK — further providers slot in here without touching callers. */
+/** Build a production driver from config. `docker` (the zero-account default) gives each
+ *  session a real, isolated container from a base image on the local daemon; `e2b`
+ *  provisions an isolated remote sandbox per session via ComputeSDK. Both share
+ *  ComputeSdkDriver's idemKey protocol — further providers slot in here without touching
+ *  callers. (The in-process SubprocessDriver is test-only; it is not selectable here.) */
 export function makeSandbox(cfg: SandboxConfig): SandboxDriver {
   switch (cfg.driver) {
-    case "subprocess":
-      return new SubprocessDriver();
+    case "docker":
+      return new ComputeSdkDriver({
+        providerName: "docker",
+        provider: dockerProvider({ image: cfg.image }),
+      });
     case "e2b":
       return new ComputeSdkDriver({
         providerName: "e2b",

--- a/packages/sessions/src/provision.ts
+++ b/packages/sessions/src/provision.ts
@@ -33,7 +33,8 @@ export async function runProvision(job: Job, deps: TurnDeps): Promise<TurnOutcom
     .limit(1);
   if (!env) return failProvision(deps, job, ns, sessionId, "env config not found");
 
-  // Snapshot the env config. template_id stays undefined for the subprocess driver.
+  // Snapshot the env config. template_id stays undefined here; only the e2b driver reads it
+  // (as its template hook) — the docker driver's base image is worker config, not per-env.
   const resolvedEnv: ResolvedEnv = {
     network: env.network,
   };


### PR DESCRIPTION
Adds a real per-session container sandbox on the local Docker daemon (`packages/ports/sandbox/src/drivers/docker.ts` + curated `debian:trixie-slim` base image in `docker/sandbox.Dockerfile`), implemented as a ComputeSDK provider so it reuses `ComputeSdkDriver`'s TCK-verified idemKey protocol via `docker run`/`docker exec`, and verified by the full sandbox TCK against real containers (`docker.test.ts`). Makes `docker` the zero-config default: the compose stack builds the base image and mounts the host daemon socket into the worker (docker-out-of-docker) with the Docker CLI baked into the shared image, wired through `FUNKY_SANDBOX`/`FUNKY_DOCKER_IMAGE`. Removes `subprocess` as a selectable production driver (`FUNKY_SANDBOX` is now `docker|e2b`) but keeps `SubprocessDriver` as the fast offline in-process driver the unit and chaos-warranty suites rely on. README and `.env.example` are reframed around docker-as-default, with an explicit security note about the socket mount and shared-kernel containers. Caveat: the driver and curated image are verified end-to-end against real containers, but the stack-level compose docker-out-of-docker path (image pull + socket mount) was not run in my environment — CI on ubuntu-latest exercises the image build and docker TCK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)