### PR TITLE
Align Quick Start examples and trim README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,15 @@ export J="content-type: application/json"
 
 # 1. an agent: who it is and what model it uses
 AID=$(curl -s -X POST localhost:3000/v1/agents -H "$H" -H "$J" -d '{
-  "name": "shell agent",
-  "system_prompt": "You are a helpful engineer. Use the sandbox to run commands.",
+  "name": "Funky Assistant",
+  "system_prompt": "You are an autonomous research and coding agent.",
   "model": { "provider": "anthropic", "model": "claude-sonnet-5" }
 }' | jq -r .id)
 
 # 2. an environment: where its commands run
 EID=$(curl -s -X POST localhost:3000/v1/environments -H "$H" -H "$J" -d '{
-  "name": "basic"
+  "name": "basic",
+  "network": { "type": "unrestricted" }
 }' | jq -r .id)
 
 # 3. a session: an agent + an environment, with a sandbox and a durable event log
@@ -44,7 +45,7 @@ curl -N -H "$H" localhost:3000/v1/sessions/$SID/events/stream &
 
 # 5. give it work
 curl -s -X POST localhost:3000/v1/sessions/$SID/messages -H "$H" -H "$J" \
-  -d '{"content":"say hello from the sandbox"}'
+  -d '{"content":"What is the top 3 trending project on Github?"}'
 ```
 
 You'll see the agent provision a sandbox, decide to run a command, execute it, and report
@@ -52,9 +53,9 @@ back:
 
 ```
 event: session_provisioned
-event: assistant_message      { "tool_calls": [{ "kind": "exec", "cmd": "echo …" }] }
-event: tool_result            { "output": "hello from the funky sandbox\n", "exit_code": 0 }
-event: assistant_message      { "content": [{"type":"text","text":"I ran a command…"}] }
+event: assistant_message      { "tool_calls": [{ "kind": "exec", "cmd": "curl -s https://github.com/trending …" }] }
+event: tool_result            { "output": "…", "exit_code": 0 }
+event: assistant_message      { "content": [{"type":"text","text":"The top 3 trending projects are…"}] }
 event: turn_completed
 ```
 
@@ -67,35 +68,7 @@ event: turn_completed
 <!-- TODO: insert Funky Console screenshot here -->
 ![Funky Console — the same agent → environment → session → chat flow in the browser](./docs/funky-console.png)
 
-### Durability
-
-Funky keeps each session's state in Postgres — the append-only event log is the source of
-truth, not any worker's memory. A worker holds no session state between turns: it reads the
-log, performs the single next step, and appends the result in one conditional-append
-transaction. The durable record of what happened lives in the database, so a worker is a
-stateless, replaceable unit.
-
-This is not a design aspiration — it is a **tested property, proven by
-[`tests/chaos`](tests/chaos)**. That suite crashes a worker at every append boundary, hands
-one job to two workers at once, and races a slow worker against lease expiry — asserting each
-time that the event log is byte-for-byte identical, that every command ran **exactly once**,
-and that the turn still ends in a terminal event. It is required on `main`: a red chaos run
-blocks the release.
-
-> **Honest limits — the default `docker` driver.** Each session gets its own isolated
-> container on the local Docker daemon (real filesystem, process, and host-network
-> isolation). The container outlives the worker *process*, and because a running command
-> records its output and exit code inside the container itself, a replacement worker
-> re-attaches by idempotency key and finishes the turn — the idempotent `exec` contract
-> guarantees a command never runs twice, whatever the driver. Two honest caveats: the
-> container lives on **one Docker host**, so re-attach works within that host but not across
-> a multi-host worker fleet (that's what the **E2B** driver is for); and a plain container is
-> shared-kernel, so for untrusted workloads you'd run it under gVisor/Kata or use E2B's
-> microVMs. (There is also an in-process `subprocess` driver with no isolation — it is not a
-> production option; it exists only so the offline test suites, including the chaos warranty
-> above, run fast and daemon-free.)
-
-### Using a real model
+### Using a real model (e.g. sonnet-5)
 
 ```bash
 # in .env
@@ -107,37 +80,7 @@ docker compose up -d --build worker
 ```
 Now the same curl commands drive a real Claude, writing and running its own shell commands.
 
-### The default sandbox (`docker`)
-
-Out of the box, every session gets its own isolated container on the local Docker daemon —
-no cloud account, nothing to configure. `docker compose up` does it all: it builds the
-[base image](docker/sandbox.Dockerfile), mounts the daemon socket into the worker, and the
-worker runs `docker run` per session and executes commands inside via `docker exec`
-(docker-out-of-docker — the sandbox containers are siblings of the stack on your host).
-
-The base image is `debian:trixie-slim` (glibc + GNU coreutils, so agent-driven
-`pip`/`npm`/`apt install` stays on the happy path) with `git`, `curl`, `python3`, and `node`
-preinstalled and a non-root `agent` user. Swap it with `FUNKY_DOCKER_IMAGE`.
-
-> **Security note.** The default mounts `/var/run/docker.sock` into the worker, granting it
-> host-daemon access, and sandbox containers are shared-kernel. That's fine for local or
-> trusted use; for untrusted workloads use `FUNKY_SANDBOX=e2b` (remote microVMs) or run the
-> sandbox containers under a gVisor/Kata runtime.
-
-Running the worker **outside compose** (`pnpm -F worker dev`) uses your host's Docker
-directly; build the image once first:
-```bash
-docker build -f docker/sandbox.Dockerfile -t funky-sandbox:trixie docker/
-```
-
-The docker driver reuses the same [ComputeSDK](https://computesdk.com)-based idemKey
-protocol as E2B and answers to the **identical conformance suite** as every other driver;
-its cases run whenever a Docker daemon is reachable:
-```bash
-pnpm -F @funky/sandbox test        # runs the docker TCK against a live daemon (else skips)
-```
-
-### Using a remote sandbox (E2B)
+### Using a remote sandbox (e.g. E2B)
 
 ```bash
 # in .env
@@ -149,17 +92,7 @@ docker compose up -d --build worker
 ```
 Now every session provisions an isolated [E2B](https://e2b.dev) sandbox, through
 [ComputeSDK](https://computesdk.com) so further providers can slot in behind the same
-driver. The sandbox — not the worker — holds each command's output and exit code, which is
-what makes sessions survive worker death: a replacement worker re-attaches by idempotency
-key and reads the same files. Unlike the docker driver this is reachable from **any** worker
-host, not just one. Idle sandboxes pause after 30 minutes (`FUNKY_E2B_SANDBOX_TIMEOUT_MS`)
-and resume on the next command, filesystem intact.
-
-The E2B driver answers to the identical conformance suite as the subprocess driver; it
-runs against real sandboxes when a key is present:
-```bash
-E2B_API_KEY=e2b_... pnpm -F @funky/sandbox test
-```
+driver.
 
 ### Tear down
 
@@ -168,42 +101,9 @@ docker compose down       # stop and remove the containers
 docker compose down -v    # ...and also delete the database volume
 ```
 
-## Local development
-
-Requires Node 22+, pnpm, and Docker (for Postgres).
-
-```bash
-pnpm install
-
-# database
-docker run -d --name funky-pg \
-  -e POSTGRES_USER=funky -e POSTGRES_PASSWORD=funky -e POSTGRES_DB=funky \
-  -p 5432:5432 postgres:16
-pnpm -F @funky/db migrate
-
-# run the API with hot reload
-pnpm dev
-```
-
-Useful commands: `pnpm typecheck` · `pnpm -F @funky/db generate` (new migration after schema changes) · `pnpm -F @funky/db exec drizzle-kit studio` (database browser).
-
-## Layout
-
-```
-apps/api           HTTP API (Hono): agents, environments, sessions, SSE
-apps/worker        the agent runtime — pulls turns off the queue and drives the loop
-apps/web           browser dev console (Vite + React); `docker compose` serves it at :5173
-packages/sessions  the event log, the reducer, the turn loop, the job queue
-packages/configs   agent + environment config domain logic
-packages/ports     provider-neutral ports (llm, sandbox) + their drivers
-packages/db        Drizzle schema + migrations
-```
-
-`apps` are deployable processes; `packages` are libraries. Apps depend on packages, never the reverse.
-
 ## Contributing
 
-This is an early-stage, contracts-first project. The best contribution right now is feedback on the interfaces. Open an issue to discuss the protocol, a missing method, or a backend you'd want to plug in.
+This is an early-stage project. The best contribution right now is feedback on the interfaces. Open an issue to discuss the protocol, a missing method, or a backend you'd want to plug in.
 
 ## License
 

--- a/apps/web/src/console/QuickStart.tsx
+++ b/apps/web/src/console/QuickStart.tsx
@@ -1,30 +1,27 @@
 import { useState } from 'react'
 import { Check } from 'lucide-react'
 import { agents as agentsApi, environments as envsApi, sessions as sessApi } from '../lib/api'
-import { DEFAULT_MODEL_LABEL, modelConfigFor } from '../lib/models'
+import { modelConfigFor } from '../lib/models'
 import { networkPolicy, networkSummary, type NetworkMode } from '../lib/network'
 import { errMsg, initials } from '../lib/format'
 import { Avatar, Badge, Button, CodeBlock, Input, Textarea } from '../ui/ui'
 import { ModelField, NetworkFields } from './parts'
 import { buildCurl } from './curl'
 
-const DEFAULT_PROMPT =
-  'You are Restaurant Scout, a friendly research assistant. When the user asks about ' +
-  'restaurants, cafés, or places to go, look things up and recommend a few strong options, ' +
-  'each with a one-line reason. Keep answers concise, specific, and well organized.'
+const DEFAULT_PROMPT = 'You are an autonomous research and coding agent.'
 
 const STEP_LABELS = ['Create agent', 'Configure environment', 'Start session', 'First message']
 
 export function QuickStart({ onLaunch }: { onLaunch: (sessionId: string) => Promise<void> }) {
   const [step, setStep] = useState(1)
-  const [agentName, setAgentName] = useState('Restaurant Scout')
-  const [model, setModel] = useState(DEFAULT_MODEL_LABEL)
+  const [agentName, setAgentName] = useState('Funky Assistant')
+  const [model, setModel] = useState('Sonnet 5')
   const [systemPrompt, setSystemPrompt] = useState(DEFAULT_PROMPT)
   const [envName, setEnvName] = useState('basic')
   const [envDesc, setEnvDesc] = useState('default dev box')
   const [networkMode, setNetworkMode] = useState<NetworkMode>('unrestricted')
   const [allowedHosts, setAllowedHosts] = useState('')
-  const [message, setMessage] = useState('What are the best restaurants in San Francisco right now?')
+  const [message, setMessage] = useState('What is the top 3 trending project on Github?')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState('')
 


### PR DESCRIPTION
Aligns the two Quick Start examples so they showcase the same thing: the README shell/curl flow and the web console wizard (`QuickStart.tsx`) now both create a "Funky Assistant" agent on `claude-sonnet-5`, an environment with an explicit `unrestricted` network policy, and a "top 3 trending projects on GitHub" first message. The UI defaults (agent name, model, system prompt, first message) are updated to match, and the now-unused `DEFAULT_MODEL_LABEL` import is dropped. The README is also slimmed down: the Durability, default-sandbox, Local development, and Layout sections are removed, the real-model and E2B sections are condensed, and the Contributing note is simplified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)