### PR TITLE
Add "Why Funky?" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ docker compose down       # stop and remove the containers
 docker compose down -v    # ...and also delete the database volume
 ```
 
+## Why Funky?
+
+Most runtimes put the agent *inside* the sandbox: its reasoning loop, memory, and state all
+live in one box. When that box goes down, the agent and its in-flight work go with it. Funky
+decouples the agent from the box it runs in.
+
+Agents don't die when the server goes down. Funky records every session as an append-only
+event log, then safely resumes interrupted work when the runtime comes back online: a fresh,
+stateless worker replays the log and re-attaches to the still-running sandbox command, with
+nothing lost and nothing run twice. Run one agent or a multi-agent swarm on the same durable
+foundation.
+
 ## Contributing
 
 This is an early-stage project. The best contribution right now is feedback on the interfaces. Open an issue to discuss the protocol, a missing method, or a backend you'd want to plug in.


### PR DESCRIPTION
Adds a **Why Funky?** section to the README that frames Funky's core idea: it decouples the agent from the sandbox it runs in, rather than running the agent *inside* the box. It explains that both the durable event log and the session's sandbox container outlive any single worker, so agents survive a server going down and interrupted work resumes safely (a fresh worker replays the log and re-attaches to the still-running command). One agent or a multi-agent swarm run on the same durable foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)