### PR TITLE
Introduce 3P harness support, starting with Claude Code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,12 @@ DATABASE_URL=postgres://funky:funky@localhost:5432/funky
 # FUNKY_SANDBOX=e2b
 # E2B_API_KEY=e2b_...
 # FUNKY_E2B_SANDBOX_TIMEOUT_MS=1800000
+
+# --- harness (Claude Code sessions) ---
+# Agents created with runtime {"type":"claude-code"} run their turns inside the Claude
+# Code harness (Agent SDK) instead of Funky's native loop. Commands still execute in the
+# session's Funky sandbox; the conversation transcript is stored in Funky's Postgres
+# (harness_transcript_entries), so any worker can resume any session. Requires
+# ANTHROPIC_API_KEY (independent of FUNKY_LLM). See packages/ports/harness/DESIGN.md.
+# FUNKY_HARNESS_SCRATCH_ROOT=/dev/shm/funky-harness  # disposable per-attempt local copy; use RAM-backed storage
+# FUNKY_HARNESS_CWD_ROOT=/tmp/funky-harness-cwd      # MUST be identical across all workers

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ COPY apps/web/package.json apps/web/
 COPY packages/db/package.json packages/db/
 COPY packages/configs/package.json packages/configs/
 COPY packages/sessions/package.json packages/sessions/
+COPY packages/ports/harness/package.json packages/ports/harness/
 COPY packages/ports/llm/package.json packages/ports/llm/
 COPY packages/ports/sandbox/package.json packages/ports/sandbox/
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,65 @@ Now every session provisions an isolated [E2B](https://e2b.dev) sandbox, through
 [ComputeSDK](https://computesdk.com) so further providers can slot in behind the same
 driver.
 
+### Running an agent on the Claude Code harness
+
+Agents can run their turns inside [Claude Code](https://code.claude.com/docs/en/agent-sdk)
+(the Agent SDK) instead of Funky's native loop — same sessions, same sandboxes, same
+durable event log. This is a self-contained walkthrough; no need to run the Quickstart first.
+
+**1. Add your key to `.env`** (independent of `FUNKY_LLM`) and bring up the stack:
+
+```bash
+# .env
+FUNKY_AUTH_TOKEN=<any long random string>
+ANTHROPIC_API_KEY=sk-ant-...
+```
+```bash
+docker compose up --build -d
+# already running from the Quickstart? pick up the new key with: docker compose up -d --build worker
+```
+
+The stack is ready when the `worker` and `api` services report healthy (`docker compose ps`).
+
+**2. Create a harness agent, an environment, a session, and send it work.** The only
+difference from a native agent is the `"runtime"` field on the agent:
+
+```bash
+export TOKEN=<your FUNKY_AUTH_TOKEN>
+export H="Authorization: Bearer $TOKEN"
+export J="content-type: application/json"
+
+# an agent that runs its turns on the Claude Code harness (requires an anthropic model)
+AID=$(curl -s -X POST localhost:3000/v1/agents -H "$H" -H "$J" -d '{
+  "name": "Claude Code Agent",
+  "system_prompt": "You are an autonomous research and coding agent.",
+  "model":   { "provider": "anthropic", "model": "claude-sonnet-5" },
+  "runtime": { "type": "claude-code" }
+}' | jq -r .id)
+
+# an environment, then a session on it
+EID=$(curl -s -X POST localhost:3000/v1/environments -H "$H" -H "$J" \
+  -d '{"name":"basic","network":{"type":"unrestricted"}}' | jq -r .id)
+SID=$(curl -s -X POST localhost:3000/v1/sessions -H "$H" -H "$J" \
+  -d "{\"agent\":\"$AID\",\"environment_id\":\"$EID\"}" | jq -r .id)
+
+# watch it think (leave running), then give it work
+curl -N -H "$H" localhost:3000/v1/sessions/$SID/events/stream &
+curl -s -X POST localhost:3000/v1/sessions/$SID/messages -H "$H" -H "$J" \
+  -d '{"content":"create a file hello.txt containing hi, then read it back to me"}'
+```
+
+You'll see a `harness_attempt_started` event, then the agent run commands in its sandbox
+(`assistant_message` → `tool_result`) and answer — the same event stream as a native turn.
+
+> The **Console** at http://localhost:5173 can *view* a harness session, but can't yet
+> *create* one — use the `curl` above to create the agent with `runtime`.
+
+The harness's commands execute in the session's Funky sandbox (exactly-once, crash-safe),
+and the Claude Code transcript is stored in Funky's Postgres — so a session survives worker
+crashes and can be resumed by any worker, keeping turns fully stateless. Design and
+guarantees: [`packages/ports/harness/DESIGN.md`](packages/ports/harness/DESIGN.md).
+
 ### Tear down
 
 ```bash

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -28,7 +28,13 @@ const modelSchema = z
   })
   .strict();
 
-const createSchema = z
+// How turns execute: omitted/null = the native loop; claude-code = the harness
+// (requires an anthropic model — enforced below, not at turn time).
+const runtimeSchema = z
+  .object({ type: z.enum(["native", "claude-code"]) })
+  .strict();
+
+const createFields = z
   .object({
     id: z.uuid().optional(),
     name: z.string().min(1).max(256),
@@ -37,14 +43,30 @@ const createSchema = z
     system_prompt: z.string().min(1).max(100_000),
     model: modelSchema,
     tool_policy: z.record(z.string(), z.unknown()).optional(),
+    runtime: runtimeSchema.nullish(),
   })
   .strict();
 
-const updateSchema = createSchema
+const createSchema = createFields.refine(
+  (o) => o.runtime?.type !== "claude-code" || o.model.provider === "anthropic",
+  "runtime claude-code requires an anthropic model",
+);
+
+// The runtime↔model cross-check only fires when BOTH travel in the patch; a patch
+// touching one alone is resolved against the current version by the service (and a
+// mismatch surfaces as a terminal HARNESS turn failure, never silent misbehavior).
+const updateSchema = createFields
   .omit({ id: true })
   .partial()
   .strict()
-  .refine((o) => Object.keys(o).length > 0, "at least one field is required");
+  .refine((o) => Object.keys(o).length > 0, "at least one field is required")
+  .refine(
+    (o) =>
+      o.runtime?.type !== "claude-code" ||
+      o.model === undefined ||
+      o.model.provider === "anthropic",
+    "runtime claude-code requires an anthropic model",
+  );
 
 const versionsQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(20),

--- a/apps/api/test/agents.test.ts
+++ b/apps/api/test/agents.test.ts
@@ -27,6 +27,19 @@ describe("POST /v1/agents (create)", () => {
     expect(fake.create).toHaveBeenCalledWith(CTX, createBody());
   });
 
+  it("accepts runtime claude-code with an anthropic model and passes it through", async () => {
+    const agent = agentFixture();
+    const { app, fake } = makeApp({
+      agents: { create: vi.fn().mockResolvedValue({ agent, created: true }) },
+    });
+
+    const body = createBody({ runtime: { type: "claude-code" } });
+    const res = await post(app, "/v1/agents", body);
+
+    expect(res.status).toBe(201);
+    expect(fake.create).toHaveBeenCalledWith(CTX, body);
+  });
+
   it("returns 200 for an idempotent (already-exists) create", async () => {
     const agent = agentFixture();
     const { app } = makeApp({
@@ -50,6 +63,8 @@ describe("POST /v1/agents (create)", () => {
     ["unknown top-level field (strict)", createBody({ nope: true })],
     ["non-uuid id", createBody({ id: "not-a-uuid" })],
     ["too many metadata pairs", createBody({ metadata: Object.fromEntries(Array.from({ length: 17 }, (_, i) => [`k${i}`, "v"])) })],
+    ["unknown runtime type", createBody({ runtime: { type: "langchain" } })],
+    ["runtime claude-code with a non-anthropic model", createBody({ runtime: { type: "claude-code" }, model: { provider: "openai", model: "gpt-x" } })],
   ])("rejects %s with 400 and does not call the service", async (_label, body) => {
     const { app, fake } = makeApp();
 

--- a/apps/web/src/console/Agents.tsx
+++ b/apps/web/src/console/Agents.tsx
@@ -5,7 +5,7 @@ import type { Agent } from '../lib/types'
 import { DEFAULT_MODEL_LABEL, modelConfigFor, modelLabel } from '../lib/models'
 import { errMsg, initials } from '../lib/format'
 import { Avatar, Badge, Button, Checkbox, Modal, Textarea, Input } from '../ui/ui'
-import { ArchiveItem, EmptyState, Kebab, ModelField, PageHeader, SelectionBar } from './parts'
+import { ArchiveItem, EmptyState, Kebab, ModelField, PageHeader, RuntimeField, SelectionBar } from './parts'
 import { useSelection } from './data'
 
 export function Agents({
@@ -21,6 +21,7 @@ export function Agents({
   const [open, setOpen] = useState(false)
   const [name, setName] = useState('')
   const [model, setModel] = useState(DEFAULT_MODEL_LABEL)
+  const [runtime, setRuntime] = useState<'native' | 'claude-code'>('native')
   const [prompt, setPrompt] = useState('')
   const [saving, setSaving] = useState(false)
 
@@ -35,11 +36,13 @@ export function Agents({
         name: name.trim(),
         system_prompt: prompt.trim(),
         model: modelConfigFor(model),
+        runtime: { type: runtime },
       })
       setOpen(false)
       setName('')
       setPrompt('')
       setModel(DEFAULT_MODEL_LABEL)
+      setRuntime('native')
       await reload()
     } catch (e) {
       notify(errMsg(e))
@@ -88,6 +91,7 @@ export function Agents({
                   <div className="row__sub">{modelLabel(a.model)}</div>
                 </div>
                 <div className="row__excerpt">{a.system_prompt}</div>
+                {a.runtime?.type === 'claude-code' ? <Badge tone="neutral">Claude Code</Badge> : null}
                 <Badge tone="green" dot>
                   Ready
                 </Badge>
@@ -116,6 +120,7 @@ export function Agents({
         <div className="modal__form">
           <Input label="Agent name" placeholder="Name your agent" value={name} onChange={setName} />
           <ModelField value={model} onChange={setModel} />
+          <RuntimeField value={runtime} onChange={setRuntime} />
           <Textarea
             label="System prompt"
             rows={4}

--- a/apps/web/src/console/QuickStart.tsx
+++ b/apps/web/src/console/QuickStart.tsx
@@ -5,7 +5,7 @@ import { modelConfigFor } from '../lib/models'
 import { networkPolicy, networkSummary, type NetworkMode } from '../lib/network'
 import { errMsg, initials } from '../lib/format'
 import { Avatar, Badge, Button, CodeBlock, Input, Textarea } from '../ui/ui'
-import { ModelField, NetworkFields } from './parts'
+import { ModelField, NetworkFields, RuntimeField } from './parts'
 import { buildCurl } from './curl'
 
 const DEFAULT_PROMPT = 'You are an autonomous research and coding agent.'
@@ -16,6 +16,7 @@ export function QuickStart({ onLaunch }: { onLaunch: (sessionId: string) => Prom
   const [step, setStep] = useState(1)
   const [agentName, setAgentName] = useState('Funky Assistant')
   const [model, setModel] = useState('Sonnet 5')
+  const [runtime, setRuntime] = useState<'native' | 'claude-code'>('native')
   const [systemPrompt, setSystemPrompt] = useState(DEFAULT_PROMPT)
   const [envName, setEnvName] = useState('basic')
   const [envDesc, setEnvDesc] = useState('default dev box')
@@ -60,6 +61,7 @@ export function QuickStart({ onLaunch }: { onLaunch: (sessionId: string) => Prom
         name: agentName.trim(),
         system_prompt: systemPrompt.trim(),
         model: modelConfigFor(model),
+        runtime: { type: runtime },
       })
       const env = await envsApi.create({
         name: envName.trim(),
@@ -79,7 +81,7 @@ export function QuickStart({ onLaunch }: { onLaunch: (sessionId: string) => Prom
   }
 
   const network = networkPolicy(networkMode, allowedHosts)
-  const curl = buildCurl({ step, agentName, model, systemPrompt, envName, envDesc, network, message })
+  const curl = buildCurl({ step, agentName, model, runtime, systemPrompt, envName, envDesc, network, message })
 
   return (
     <div className="content">
@@ -100,6 +102,7 @@ export function QuickStart({ onLaunch }: { onLaunch: (sessionId: string) => Prom
               </div>
               <Input label="Agent name" placeholder="Name your agent" value={agentName} onChange={setAgentName} />
               <ModelField value={model} onChange={setModel} />
+              <RuntimeField value={runtime} onChange={setRuntime} />
               <Textarea label="System prompt" rows={5} value={systemPrompt} onChange={setSystemPrompt} />
               <div className="qs-foot qs-foot--end">
                 <Button variant="accent" size="lg" onClick={guardStep1}>
@@ -143,6 +146,7 @@ export function QuickStart({ onLaunch }: { onLaunch: (sessionId: string) => Prom
               <div className="review">
                 <ReviewRow label="Agent" value={agentName} strong />
                 <ReviewRow label="Model" value={model} mono />
+                <ReviewRow label="Runtime" value={runtime === 'claude-code' ? 'Claude Code' : 'Native'} />
                 <ReviewRow label="Environment" value={envName} mono />
                 <ReviewRow label="Network" value={networkSummary(network)} />
                 <ReviewRow label="System prompt" value={systemPrompt} />

--- a/apps/web/src/console/Sessions.tsx
+++ b/apps/web/src/console/Sessions.tsx
@@ -193,7 +193,10 @@ function CreateSessionModal({
         <Select
           label="Agent"
           value={agentId}
-          options={agents.map((a) => ({ value: a.id, label: a.name }))}
+          options={agents.map((a) => ({
+            value: a.id,
+            label: a.runtime?.type === 'claude-code' ? `${a.name} · Claude Code` : a.name,
+          }))}
           onChange={setAgentId}
         />
         <Select

--- a/apps/web/src/console/curl.ts
+++ b/apps/web/src/console/curl.ts
@@ -8,6 +8,7 @@ export type CurlState = {
   step: number
   agentName: string
   model: string
+  runtime: 'native' | 'claude-code'
   systemPrompt: string
   envName: string
   envDesc: string
@@ -26,11 +27,14 @@ export function buildCurl(st: CurlState): string {
   ].join('\n')
 
   if (st.step >= 1) {
+    // claude-code runs turns inside the Claude Agent SDK (the harness); native omits the field.
+    const runtimeLine =
+      st.runtime === 'claude-code' ? `,\n  "runtime": { "type": "claude-code" }` : ''
     code += `\n\n# 1. an agent: who it is and what model it uses
 AID=$(curl -s -X POST localhost:3000/v1/agents -H "$H" -H "$J" -d '{
   "name": ${j(st.agentName || 'my agent')},
   "system_prompt": ${j(st.systemPrompt || 'You are a helpful engineer.')},
-  "model": { "provider": ${j(provider)}, "model": ${j(model)} }
+  "model": { "provider": ${j(provider)}, "model": ${j(model)} }${runtimeLine}
 }' | jq -r .id)`
   }
 

--- a/apps/web/src/console/parts.tsx
+++ b/apps/web/src/console/parts.tsx
@@ -101,6 +101,35 @@ export function ModelField({ value, onChange }: { value: string; onChange: (v: s
   )
 }
 
+// How the agent runs its turns. claude-code (the harness) requires an anthropic model,
+// which the UI's model picker always is — so the choice is always valid here.
+export function RuntimeField({
+  value,
+  onChange,
+}: {
+  value: 'native' | 'claude-code'
+  onChange: (v: 'native' | 'claude-code') => void
+}) {
+  return (
+    <div className="field">
+      <Select
+        label="Runtime"
+        value={value}
+        options={[
+          { value: 'native', label: 'Native — Funky’s built-in agent loop' },
+          { value: 'claude-code', label: 'Claude Code — run turns inside the Claude Agent SDK' },
+        ]}
+        onChange={(v) => onChange(v as 'native' | 'claude-code')}
+      />
+      {value === 'claude-code' ? (
+        <p className="model-hint">
+          Runs each turn inside Claude Code; needs <code>ANTHROPIC_API_KEY</code> on the worker.
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
 export function NetworkFields({
   mode,
   allowedHosts,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -7,6 +7,7 @@ import type {
   ModelConfig,
   Page,
   NetworkPolicy,
+  RuntimeConfig,
   SendMessageResult,
   Session,
   SessionEvent,
@@ -63,6 +64,7 @@ export type CreateAgentInput = {
   name: string
   system_prompt: string
   model: ModelConfig
+  runtime?: RuntimeConfig | null
   description?: string | null
 }
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -18,6 +18,10 @@ export type ModelConfig = {
   temperature?: number
 }
 
+// How an agent runs its turns: 'native' = Funky's built-in loop; 'claude-code' = inside
+// the Claude Agent SDK (the harness). claude-code requires an anthropic model.
+export type RuntimeConfig = { type: 'native' } | { type: 'claude-code' }
+
 export type Agent = {
   type: 'agent'
   id: string
@@ -28,6 +32,7 @@ export type Agent = {
   system_prompt: string
   model: ModelConfig
   tool_policy: Record<string, unknown>
+  runtime: RuntimeConfig | null
   created_at: string
   updated_at: string
   archived_at: string | null
@@ -75,6 +80,7 @@ export type SessionEventType =
   | 'tool_result'
   | 'turn_completed'
   | 'turn_failed'
+  | 'harness_attempt_started' // bookkeeping (claude-code sessions); not rendered
 
 export type SessionEvent = {
   type: SessionEventType

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@funky/db": "workspace:*",
+    "@funky/harness": "workspace:*",
     "@funky/llm": "workspace:*",
     "@funky/sandbox": "workspace:*",
     "@funky/sessions": "workspace:*",

--- a/apps/worker/src/config.ts
+++ b/apps/worker/src/config.ts
@@ -20,8 +20,15 @@ const EnvSchema = z
     // e2b: an isolated remote sandbox per session. (The in-process subprocess driver still
     // exists for the offline test suites, but is not a production sandbox option.)
     FUNKY_SANDBOX: z.enum(["docker", "e2b"]).default("docker"),
-    // Required ONLY when FUNKY_LLM=ai-sdk (the fake driver makes no network calls).
+    // Required when FUNKY_LLM=ai-sdk, and for agents with runtime=claude-code (the
+    // harness driver is only constructed when this key is present).
     ANTHROPIC_API_KEY: optionalSecret,
+    // Harness (claude-code) knobs. CWD_ROOT must be identical across the worker
+    // fleet — the harness derives the transcript store's projectKey from it.
+    // SCRATCH_ROOT holds the disposable per-attempt local session copy; point it at
+    // RAM-backed storage (tmpfs) in production.
+    FUNKY_HARNESS_CWD_ROOT: z.string().min(1).default("/tmp/funky-harness-cwd"),
+    FUNKY_HARNESS_SCRATCH_ROOT: z.string().min(1).default("/tmp/funky-harness-scratch"),
     // Required ONLY when FUNKY_SANDBOX=e2b (docker needs no account).
     E2B_API_KEY: optionalSecret,
     // Base image for the docker driver (built from docker/sandbox.Dockerfile).
@@ -55,6 +62,8 @@ export type Config = {
   sandbox: "docker" | "e2b";
   /** null = fake driver; no key needed. */
   anthropicApiKey: string | null;
+  harnessCwdRoot: string;
+  harnessScratchRoot: string;
   /** null = docker driver; no key needed. */
   e2bApiKey: string | null;
   e2bSandboxTimeoutMs: number;
@@ -81,6 +90,8 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     llm: e.FUNKY_LLM,
     sandbox: e.FUNKY_SANDBOX,
     anthropicApiKey: e.ANTHROPIC_API_KEY ?? null,
+    harnessCwdRoot: e.FUNKY_HARNESS_CWD_ROOT,
+    harnessScratchRoot: e.FUNKY_HARNESS_SCRATCH_ROOT,
     e2bApiKey: e.E2B_API_KEY ?? null,
     e2bSandboxTimeoutMs: e.FUNKY_E2B_SANDBOX_TIMEOUT_MS,
     dockerImage: e.FUNKY_DOCKER_IMAGE,

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -5,6 +5,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Client, Pool } from "pg";
 import { createDb } from "@funky/db";
+import { type HarnessPort, makeHarness } from "@funky/harness";
 import { FakeLlm, type LlmConfig, makeLlm } from "@funky/llm";
 import { makeSandbox, type SandboxConfig } from "@funky/sandbox";
 import { EventStore, JobQueue } from "@funky/sessions";
@@ -28,11 +29,24 @@ const metrics = createMetrics();
 const listenClient = new Client({ connectionString: cfg.databaseUrl });
 await listenClient.connect();
 
+// The claude-code harness needs an Anthropic key regardless of FUNKY_LLM; without
+// one, harness sessions fail their turns with a terminal HARNESS error instead.
+const harness: HarnessPort | undefined = cfg.anthropicApiKey
+  ? makeHarness({
+      driver: "claude-code",
+      db,
+      apiKey: cfg.anthropicApiKey,
+      cwdRoot: cfg.harnessCwdRoot,
+      scratchRoot: cfg.harnessScratchRoot,
+    })
+  : undefined;
+
 const worker = startWorker({
   queue,
   store,
   llm: makeLlm(llmConfig(cfg)), // fake by default — no API key needed
   sandbox: makeSandbox(sandboxConfig(cfg)), // docker by default — isolated, no account needed
+  ...(harness ? { harness } : {}),
   db,
   listenClient,
   concurrency: cfg.concurrency,

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -12,6 +12,7 @@
 
 import type { Client } from "pg";
 import type { Db } from "@funky/db";
+import type { HarnessPort } from "@funky/harness/port";
 import type { LlmPort } from "@funky/llm";
 import type { SandboxDriver } from "@funky/sandbox";
 import {
@@ -31,6 +32,8 @@ export type WorkerDeps = {
   store: EventStore;
   llm: LlmPort;
   sandbox: SandboxDriver;
+  /** Optional — required only for agents whose runtime is a vendor harness. */
+  harness?: HarnessPort;
   db: Db;
   listenClient: Client; // DEDICATED client for LISTEN (never from the pool)
   concurrency: number; // FUNKY_WORKER_CONCURRENCY
@@ -75,7 +78,13 @@ export function startWorker(deps: WorkerDeps): WorkerHandle {
   const heartbeatMs = deps.heartbeatMs ?? HEARTBEAT_MS;
   // The subset the domain loop needs. runTurn/runProvision must not touch the queue or the
   // listen client — those are lifecycle concerns owned here.
-  const turnDeps = { store: deps.store, llm: deps.llm, sandbox: deps.sandbox, db: deps.db };
+  const turnDeps = {
+    store: deps.store,
+    llm: deps.llm,
+    sandbox: deps.sandbox,
+    db: deps.db,
+    ...(deps.harness ? { harness: deps.harness } : {}),
+  };
 
   let inFlight = 0;
   let draining = false;

--- a/apps/worker/test/config.test.ts
+++ b/apps/worker/test/config.test.ts
@@ -32,6 +32,8 @@ describe("loadConfig — valid input", () => {
       e2bSandboxTimeoutMs: 30 * 60_000,
       dockerImage: "funky-sandbox:trixie",
       dbPoolMax: 10,
+      harnessCwdRoot: "/tmp/funky-harness-cwd",
+      harnessScratchRoot: "/tmp/funky-harness-scratch",
     });
     expect(exitSpy).not.toHaveBeenCalled();
   });
@@ -63,6 +65,8 @@ describe("loadConfig — valid input", () => {
       FUNKY_SANDBOX: "e2b",
       E2B_API_KEY: "e2b_secret",
       FUNKY_E2B_SANDBOX_TIMEOUT_MS: "600000",
+      FUNKY_HARNESS_CWD_ROOT: "/var/funky/cwd",
+      FUNKY_HARNESS_SCRATCH_ROOT: "/dev/shm/funky",
     });
     expect(cfg).toEqual({
       databaseUrl: BASE.DATABASE_URL,
@@ -75,6 +79,8 @@ describe("loadConfig — valid input", () => {
       e2bSandboxTimeoutMs: 600_000,
       dockerImage: "funky-sandbox:trixie",
       dbPoolMax: 25,
+      harnessCwdRoot: "/var/funky/cwd",
+      harnessScratchRoot: "/dev/shm/funky",
     });
   });
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,11 @@ services:
     # workloads prefer FUNKY_SANDBOX=e2b (remote) or run the containers under gVisor/Kata.
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    # RAM-backed scratch for the claude-code harness: each in-flight harness turn keeps
+    # its DISPOSABLE local session copy here (the durable transcript is in Postgres).
+    # tmpfs means a dead worker leaves nothing behind — statelessness by construction.
+    tmpfs:
+      - /dev/shm/funky-harness
     environment:
       DATABASE_URL: postgres://funky:funky@postgres:5432/funky # ← service name, not localhost
       FUNKY_LLM: ${FUNKY_LLM:-fake}
@@ -92,6 +97,10 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-} # empty unless the user sets it
       E2B_API_KEY: ${E2B_API_KEY:-} # empty unless the user sets it
       FUNKY_E2B_SANDBOX_TIMEOUT_MS: ${FUNKY_E2B_SANDBOX_TIMEOUT_MS:-1800000}
+      # Harness (agents with runtime=claude-code). CWD_ROOT must be identical across
+      # every worker replica — the transcript store's key derives from it.
+      FUNKY_HARNESS_SCRATCH_ROOT: /dev/shm/funky-harness
+      FUNKY_HARNESS_CWD_ROOT: /tmp/funky-harness-cwd
     depends_on:
       migrate:
         condition: service_completed_successfully

--- a/packages/configs/src/service.ts
+++ b/packages/configs/src/service.ts
@@ -18,7 +18,7 @@ import type {
 } from "./types";
 
 const LABEL_FIELDS = ["name", "description", "metadata"] as const;
-const BEHAVIOR_FIELDS = ["system_prompt", "model", "tool_policy"] as const;
+const BEHAVIOR_FIELDS = ["system_prompt", "model", "tool_policy", "runtime"] as const;
 
 type IdentityRow = typeof agentConfigs.$inferSelect;
 type VersionRow = typeof agentConfigVersions.$inferSelect;
@@ -53,6 +53,7 @@ export class AgentsService {
           systemPrompt: input.system_prompt,
           model: input.model,
           toolPolicy: input.tool_policy ?? {},
+          runtime: input.runtime ?? null,
           createdBy: ctx.principal,
         });
         const created = await this.findRaw(tx, ctx, id);
@@ -78,7 +79,8 @@ export class AgentsService {
       jsonEq(existing.a.metadata, input.metadata ?? {}) &&
       existing.v.systemPrompt === input.system_prompt &&
       jsonEq(existing.v.model, input.model) &&
-      jsonEq(existing.v.toolPolicy, input.tool_policy ?? {});
+      jsonEq(existing.v.toolPolicy, input.tool_policy ?? {}) &&
+      jsonEq(existing.v.runtime ?? null, input.runtime ?? null);
     if (!same) {
       throw new ConflictError("an agent with this id exists with a different configuration");
     }
@@ -152,6 +154,8 @@ export class AgentsService {
           systemPrompt: patch.system_prompt ?? cur!.systemPrompt,
           model: patch.model ?? cur!.model,
           toolPolicy: patch.tool_policy ?? cur!.toolPolicy,
+          // `?? ` would swallow an explicit null (= reset to native); check presence.
+          runtime: patch.runtime !== undefined ? patch.runtime : (cur!.runtime ?? null),
           createdBy: ctx.principal,
         });
       }
@@ -273,6 +277,7 @@ function toAgent(row: { a: IdentityRow; v: VersionRow }): Agent {
     system_prompt: row.v.systemPrompt,
     model: row.v.model,
     tool_policy: row.v.toolPolicy,
+    runtime: row.v.runtime ?? null,
     created_at: row.a.createdAt.toISOString(),
     updated_at: row.a.updatedAt.toISOString(),
     archived_at: row.a.archivedAt?.toISOString() ?? null,
@@ -287,6 +292,7 @@ function toAgentVersion(v: VersionRow): AgentVersion {
     system_prompt: v.systemPrompt,
     model: v.model,
     tool_policy: v.toolPolicy,
+    runtime: v.runtime ?? null,
     created_at: v.createdAt.toISOString(),
     created_by: v.createdBy,
   };

--- a/packages/configs/src/types.ts
+++ b/packages/configs/src/types.ts
@@ -1,5 +1,5 @@
 // packages/configs/src/types.ts
-import type { ModelConfig } from "@funky/db/schema";
+import type { ModelConfig, RuntimeConfig } from "@funky/db/schema";
 
 /** Set by the auth middleware; consumed by every service method. */
 export type AuthContext = {
@@ -17,6 +17,8 @@ export type Agent = {
   system_prompt: string;
   model: ModelConfig;
   tool_policy: Record<string, unknown>;
+  /** null = the native loop; {"type":"claude-code"} = the Claude Code harness. */
+  runtime: RuntimeConfig | null;
   created_at: string;
   updated_at: string;
   archived_at: string | null;
@@ -29,6 +31,7 @@ export type AgentVersion = {
   system_prompt: string;
   model: ModelConfig;
   tool_policy: Record<string, unknown>;
+  runtime: RuntimeConfig | null;
   created_at: string;
   created_by: string | null;
 };
@@ -41,6 +44,7 @@ export type CreateAgentInput = {
   system_prompt: string;
   model: ModelConfig;
   tool_policy?: Record<string, unknown>;
+  runtime?: RuntimeConfig | null;
 };
 
 export type UpdateAgentInput = Partial<Omit<CreateAgentInput, "id">>;

--- a/packages/db/migrations/20260718201401_harness_port/migration.sql
+++ b/packages/db/migrations/20260718201401_harness_port/migration.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "harness_transcript_entries" (
+	"project_key" text NOT NULL,
+	"sdk_session_id" text NOT NULL,
+	"subpath" text DEFAULT '' NOT NULL,
+	"ord" bigserial PRIMARY KEY,
+	"entry_uuid" text,
+	"entry" jsonb NOT NULL,
+	"namespace" text NOT NULL,
+	"funky_session_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "agent_config_versions" ADD COLUMN "runtime" jsonb;--> statement-breakpoint
+ALTER TABLE "sessions" ADD COLUMN "harness_attempt" text;--> statement-breakpoint
+ALTER TABLE "sessions" ADD COLUMN "harness_state" jsonb;--> statement-breakpoint
+CREATE INDEX "harness_entries_key" ON "harness_transcript_entries" ("project_key","sdk_session_id","subpath","ord");--> statement-breakpoint
+CREATE UNIQUE INDEX "harness_entries_dedupe" ON "harness_transcript_entries" ("sdk_session_id","subpath","entry_uuid") WHERE "entry_uuid" is not null;--> statement-breakpoint
+CREATE INDEX "harness_entries_session" ON "harness_transcript_entries" ("funky_session_id","ord");--> statement-breakpoint
+ALTER TABLE "harness_transcript_entries" ADD CONSTRAINT "harness_transcript_entries_funky_session_id_sessions_id_fkey" FOREIGN KEY ("funky_session_id") REFERENCES "sessions"("id");

--- a/packages/db/migrations/20260718201401_harness_port/snapshot.json
+++ b/packages/db/migrations/20260718201401_harness_port/snapshot.json
@@ -1,0 +1,1364 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "6efd241b-9f65-4bca-93ef-84f5f9d2af0f",
+  "prevIds": [
+    "2a69d621-88c2-4e0c-86a2-490861716e20"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "agent_config_versions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "agent_configs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "env_configs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "harness_transcript_entries",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "session_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "sessions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "turn_jobs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "agent_config_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "system_prompt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "model",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "tool_policy",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "runtime",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "1",
+      "generated": null,
+      "identity": null,
+      "name": "latest_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{\"type\":\"unrestricted\"}'",
+      "generated": null,
+      "identity": null,
+      "name": "network",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "harness_transcript_entries"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "sdk_session_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "harness_transcript_entries"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "subpath",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "harness_transcript_entries"
+    },
+    {
+      "type": "bigserial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ord",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "harness_transcript_entries"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "entry_uuid",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "harness_transcript_entries"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "entry",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "harness_transcript_entries"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "harness_transcript_entries"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "funky_session_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "harness_transcript_entries"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "harness_transcript_entries"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seq",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "agent_config_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "agent_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "env_config_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resolved_env",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "sandbox_handle",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "harness_attempt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "harness_state",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'provisioning'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "namespace",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'turn'",
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'queued'",
+      "generated": null,
+      "identity": null,
+      "name": "state",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "run_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "attempts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "5",
+      "generated": null,
+      "identity": null,
+      "name": "max_attempts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "lease_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_configs_ns_name",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_configs_ns",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "agent_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "env_configs_ns_name",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "env_configs_ns",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "env_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "sdk_session_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "subpath",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "ord",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "harness_entries_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "harness_transcript_entries"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "sdk_session_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "subpath",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "entry_uuid",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"entry_uuid\" is not null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "harness_entries_dedupe",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "harness_transcript_entries"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "funky_session_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "ord",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "harness_entries_session",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "harness_transcript_entries"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "namespace",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_ns",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "run_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"state\" = 'queued'",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "turn_jobs_queued",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"state\" IN ('queued', 'running')",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "turn_jobs_active_session",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "agent_config_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "agent_configs",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "agent_config_versions_agent_config_id_agent_configs_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "funky_session_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "sessions",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "harness_transcript_entries_funky_session_id_sessions_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "harness_transcript_entries"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "session_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "sessions",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "session_events_session_id_sessions_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "agent_config_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "agent_configs",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "sessions_agent_config_id_agent_configs_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "env_config_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "env_configs",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "sessions_env_config_id_env_configs_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "session_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "sessions",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "turn_jobs_session_id_sessions_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "turn_jobs"
+    },
+    {
+      "columns": [
+        "agent_config_id",
+        "version"
+      ],
+      "nameExplicit": false,
+      "name": "agent_config_versions_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "agent_config_versions"
+    },
+    {
+      "columns": [
+        "session_id",
+        "seq"
+      ],
+      "nameExplicit": false,
+      "name": "session_events_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "session_events"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "agent_configs_pkey",
+      "schema": "public",
+      "table": "agent_configs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "env_configs_pkey",
+      "schema": "public",
+      "table": "env_configs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "ord"
+      ],
+      "nameExplicit": false,
+      "name": "harness_transcript_entries_pkey",
+      "schema": "public",
+      "table": "harness_transcript_entries",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pkey",
+      "schema": "public",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "turn_jobs_pkey",
+      "schema": "public",
+      "table": "turn_jobs",
+      "entityType": "pks"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db/schema/configs.ts
+++ b/packages/db/schema/configs.ts
@@ -25,6 +25,12 @@ import {
 } from "drizzle-orm/pg-core";
 
 /** Mirrors what the AI SDK needs to construct a model. Validated with zod at the API edge. */
+/** How the agent's turns execute. null/omitted = "native": Funky's own loop
+ *  (reducer + LLM port). "claude-code" = the Claude Code harness drives the turn
+ *  (packages/ports/harness). Behavior, so it lives on VERSIONS and is pinned per
+ *  session — a session's runtime never changes mid-life. */
+export type RuntimeConfig = { type: "native" } | { type: "claude-code" };
+
 export type ModelConfig = {
   provider:
     | "anthropic"
@@ -90,6 +96,8 @@ export const agentConfigVersions = pgTable(
       .$type<Record<string, unknown>>()
       .notNull()
       .default({}), // allowed tools, max turns/iterations, budgets
+    // null = native loop (backwards compatible). Validated with zod at the API edge.
+    runtime: jsonb("runtime").$type<RuntimeConfig>(),
 
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     createdBy: text("created_by"), // opaque principal: "user:123" | "key:fk_live_a1b2"

--- a/packages/db/schema/harness-transcript.ts
+++ b/packages/db/schema/harness-transcript.ts
@@ -1,0 +1,53 @@
+// packages/db/schema/harness-transcript.ts — the harness transcript store.
+//
+// One row per agent-SDK transcript entry (JSONL line), persisted VERBATIM as an
+// opaque blob — see packages/ports/harness/DESIGN.md §8. This table is the backing
+// store an agent SDK's SessionStore adapter mirrors into (Claude Code is the first
+// driver); it is NOT the event log. The event log (session_events) remains the API/SSE
+// source of truth; this table is what lets a stateless worker rehydrate the closed
+// harness binary's own session format on resume. Column names are SDK-neutral so a
+// second driver can reuse the table unchanged.
+//
+// Writes are FENCED: the adapter inserts with a guard against sessions.harness_attempt
+// (see DrizzleSessionStore), so a zombie worker's batches are rejected instead of
+// interleaving with the current attempt's. Because fenced writes never land, the
+// max-ord main-transcript row IS the resume tip for a session.
+
+import { sql } from "drizzle-orm";
+import { bigserial, index, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { sessions } from "./sessions";
+
+export const harnessTranscriptEntries = pgTable(
+  "harness_transcript_entries",
+  {
+    /** SDK SessionKey.projectKey — sanitized cwd; deterministic per Funky session. */
+    projectKey: text("project_key").notNull(),
+    /** SDK SessionKey.sessionId — the agent SDK's own session id, e.g. Claude Code's
+     *  session UUID (NOT the Funky session id). */
+    sdkSessionId: text("sdk_session_id").notNull(),
+    /** '' = main transcript; e.g. 'subagents/agent-<id>' for subagent transcripts. */
+    subpath: text("subpath").notNull().default(""),
+    /** Append order within a key; load() replays ORDER BY ord. */
+    ord: bigserial("ord", { mode: "number" }).primaryKey(),
+    /** Dedupe key — mirror retries may re-deliver a batch. Null for uuid-less entries. */
+    entryUuid: text("entry_uuid"),
+    /** The SessionStoreEntry, verbatim. Opaque: never interpreted, only round-tripped. */
+    entry: jsonb("entry").$type<Record<string, unknown>>().notNull(),
+
+    namespace: text("namespace").notNull(),
+    funkySessionId: uuid("funky_session_id")
+      .notNull()
+      .references(() => sessions.id),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    // load() path: one key's entries in append order.
+    index("harness_entries_key").on(t.projectKey, t.sdkSessionId, t.subpath, t.ord),
+    // Idempotent append: a re-delivered entry hits this and is skipped, never duplicated.
+    uniqueIndex("harness_entries_dedupe")
+      .on(t.sdkSessionId, t.subpath, t.entryUuid)
+      .where(sql`${t.entryUuid} is not null`),
+    // Lineage tip + GC by Funky session.
+    index("harness_entries_session").on(t.funkySessionId, t.ord),
+  ],
+);

--- a/packages/db/schema/sessions.ts
+++ b/packages/db/schema/sessions.ts
@@ -28,6 +28,12 @@ export type ResolvedEnv = {
 
 export type SessionStatus = "provisioning" | "ready" | "failed" | "archived";
 
+/** Committed harness state — opaque outside its own driver, like SandboxHandle.
+ *  For claude-code: { driver: "claude-code", sdk_session_id, project_key }.
+ *  A cache/audit field: the authoritative resume tip is derived from
+ *  harness_transcript_entries (see packages/ports/harness/DESIGN.md §5.2). */
+export type HarnessState = { driver: string } & Record<string, unknown>;
+
 export const sessions = pgTable(
   "sessions",
   {
@@ -44,6 +50,13 @@ export const sessions = pgTable(
       .references(() => envConfigs.id),
     resolvedEnv: jsonb("resolved_env").$type<ResolvedEnv>(),
     sandboxHandle: jsonb("sandbox_handle").$type<Record<string, unknown>>(),
+
+    // Harness sessions only (agent version runtime = claude-code). harness_attempt is
+    // the WRITE FENCE: the current attempt's token; the transcript store's guarded
+    // INSERT checks it, so a zombie worker's mirror batches bounce instead of
+    // interleaving. Set transactionally with the harness_attempt_started event.
+    harnessAttempt: text("harness_attempt"),
+    harnessState: jsonb("harness_state").$type<HarnessState>(),
 
     status: text("status").$type<SessionStatus>().notNull().default("provisioning"),
     title: text("title"),

--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -9,6 +9,7 @@ import {
   agentConfigs,
   agentConfigVersions,
   envConfigs,
+  harnessTranscriptEntries,
   sessionEvents,
   sessions,
   turnJobs,
@@ -62,6 +63,7 @@ describe("tables", () => {
     expect(tables.agentConfigs).toBe(agentConfigs);
     expect(tables.agentConfigVersions).toBe(agentConfigVersions);
     expect(tables.envConfigs).toBe(envConfigs);
+    expect(tables.harnessTranscriptEntries).toBe(harnessTranscriptEntries);
     expect(tables.sessions).toBe(sessions);
     expect(tables.sessionEvents).toBe(sessionEvents);
     expect(tables.turnJobs).toBe(turnJobs);
@@ -70,6 +72,7 @@ describe("tables", () => {
         "agentConfigVersions",
         "agentConfigs",
         "envConfigs",
+        "harnessTranscriptEntries",
         "sessions",
         "sessionEvents",
         "turnJobs",

--- a/packages/db/src/schema.test.ts
+++ b/packages/db/src/schema.test.ts
@@ -123,6 +123,8 @@ describe("agent_config_versions", () => {
       system_prompt: { type: "text", notNull: true },
       model: { type: "jsonb", notNull: true },
       tool_policy: { type: "jsonb", notNull: true, hasDefault: true, default: {} },
+      // null = native loop; {"type":"claude-code"} dispatches to the harness port.
+      runtime: { type: "jsonb", notNull: false },
       created_at: { type: "timestamp with time zone", notNull: true, hasDefault: true },
       created_by: { type: "text", notNull: false },
     });
@@ -203,6 +205,9 @@ describe("sessions", () => {
       // resolved_env / sandbox_handle are nullable: filled at provision time.
       resolved_env: { type: "jsonb", notNull: false },
       sandbox_handle: { type: "jsonb", notNull: false },
+      // Harness sessions only: the write-fence token + committed vendor session state.
+      harness_attempt: { type: "text", notNull: false },
+      harness_state: { type: "jsonb", notNull: false },
       status: { type: "text", notNull: true, hasDefault: true, default: "provisioning" },
       title: { type: "text", notNull: false },
       metadata: { type: "jsonb", notNull: true, hasDefault: true, default: {} },

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,3 +1,4 @@
 export * from "../schema/configs";
 export * from "../schema/envs";
+export * from "../schema/harness-transcript";
 export * from "../schema/sessions";

--- a/packages/ports/harness/DESIGN.md
+++ b/packages/ports/harness/DESIGN.md
@@ -1,0 +1,386 @@
+# The Harness Port — running managed agent SDKs on Funky's stateless runtime
+
+Status: **implemented** (v1). First driver: **Claude Code**
+(`@anthropic-ai/claude-agent-sdk`). See §11 for the map from this document to the code
+and the tests that pin each guarantee.
+
+This document explains what the harness port is, how the Claude Code driver keeps
+Funky's core promise — **stateless, crash-resumable turn execution with exactly-once
+command execution** — while the agentic loop runs inside a closed binary, and which
+alternatives were considered and rejected.
+
+---
+
+## 1. What problem this solves
+
+Funky's native loop (`packages/sessions/src/native-strategy.ts`) owns every step of a turn: it
+calls the LLM port for one completion, records the tool call in the event log, runs it
+in the sandbox, appends the result, repeats. The **log is the state**; any worker can
+replay it and compute the next action (`reducer.ts`).
+
+Agent SDKs like Claude Code invert this: the loop (context management, tool planning,
+compaction, subagents) lives inside a vendor harness — for Claude Code, a
+non-open-source CLI binary that the SDK spawns as a subprocess. We want Funky sessions
+to be able to *be* a Claude Code conversation, without giving up:
+
+1. **Stateless workers** — any worker can pick up any turn; nothing meaningful lives
+   only in worker memory or on a worker's disk.
+2. **Crash-resume as the normal code path** — a killed worker mid-turn loses nothing.
+3. **Exactly-once command execution** — a command with side effects never runs twice
+   because of a retry.
+4. **The Funky sandbox** — commands execute in the session's provisioned sandbox
+   (docker/e2b), never on the worker host.
+5. **One durable record** — the Postgres event log stays the API/SSE source of truth.
+
+## 2. The two SDK features that make this possible
+
+Both are documented SDK behavior (code.claude.com/docs/en/agent-sdk/session-storage):
+
+- **`SessionStore` adapter** (`options.sessionStore`): the SDK mirrors every transcript
+  entry (JSONL line) to a caller-provided store. `append(key, entries)` is called in
+  batches **continuously during the turn** (~100ms cadence while active); `load(key)`
+  is called before subprocess spawn when `resume` is set. Funky provides a Postgres
+  adapter, so **the Funky DB is the session storage** for Claude Code.
+
+- **Ephemeral local disk**: the binary always writes its JSONL locally first; the store
+  is a mirror. Pointing `CLAUDE_CONFIG_DIR` at a RAM-backed scratch directory (created
+  per attempt, deleted after) makes the local copy disposable. The docs endorse exactly
+  this ("set CLAUDE_CONFIG_DIR=/tmp for ephemeral local copy").
+
+So the durable trajectory lives in Postgres; the local filesystem is a per-attempt
+cache. Any worker can run the next turn: `load()` rehydrates the transcript from the
+DB, the subprocess resumes it.
+
+Two documented caveats we design around:
+
+- `sessionStore` cannot be combined with `persistSession: false` or file checkpointing.
+- **Mirror writes are best-effort**: after 3 failed attempts a batch is *dropped* and a
+  `{type:"system", subtype:"mirror_error"}` message is emitted. Because our local copy
+  is ephemeral, a dropped batch would be silent context loss — so the driver treats
+  `mirror_error` as a turn-aborting transient failure (§6). A committed turn is
+  therefore always backed by a gap-free mirrored transcript.
+
+## 3. Architecture
+
+```
+                       ┌────────────────────────────────────────────────┐
+                       │ worker (apps/worker)                           │
+                       │                                                │
+ turn job ──────────▶  │  runTurn ──┬─ nativeStrategy                   │
+                       │  (shell)   └─ harnessStrategy                  │
+                       │                   │        ▲ projected events  │
+                       │                   ▼        │ (conditional      │
+                       │            HarnessPort     │  appends)         │
+                       │                   │        │                   │
+                       │      ┌────────────┴─────────────┐              │
+                       │      │ ClaudeCodeHarness driver │              │
+                       │      │  query() → CC subprocess │              │
+                       │      │  CLAUDE_CONFIG_DIR=tmpfs │              │
+                       │      └───┬───────────┬──────────┘              │
+                       └──────────┼───────────┼─────────────────────────┘
+                                  │           │
+                    MCP exec bridge       SessionStore (fenced)
+                                  │           │
+                                  ▼           ▼
+                        Funky sandbox     Postgres
+                        (idemKey exec)    ├ session_events        (the log — truth)
+                                          └ harness_transcript_entries (CC transcript)
+```
+
+Division of labor (mirrors the llm/sandbox ports):
+
+- **`@funky/harness` — the port** (`src/port.ts`). Plain TypeScript interface. Knows
+  nothing about the event log, the queue, or Postgres row shapes. Drivers are selected
+  by config at the entrypoint; the worker never imports a driver.
+- **`ClaudeCodeHarness` — the driver** (`src/drivers/claude-code.ts`). Owns the SDK
+  invocation, the MCP exec bridge, the ephemeral config dir, and mirror-error watching.
+  It reports events through a caller-provided appender and never touches the log
+  directly.
+- **`harnessStrategy` — the caller** (`packages/sessions/src/harness-strategy.ts`). Owns
+  the harness-specific stateful work: fence acquisition, crash recovery, the commit
+  transaction, and the harness error classes. This is one `TurnStrategy`
+  (`packages/sessions/src/strategy.ts`); the native loop is another (`nativeStrategy`).
+- **`runTurn` — the shell** (`packages/sessions/src/turn.ts`). Owns everything the two
+  strategies share: the session gate, the pinned-version load, the single log read, the
+  conditional-append helper (and therefore conflict semantics), `terminalFail`,
+  exec-with-reboot, and the outcome/error mapping. It selects the strategy by the pinned
+  `runtime` and dispatches. The native loop is the degenerate strategy — its context is
+  a pure function of the log, so it needs no attempt-token fence, no recovery pre-pass,
+  and no continuation prompt; those exist *only* to reconcile a harness's external
+  transcript with the log.
+
+### Selection
+
+Agent behavior is versioned, so the switch lives on `agent_config_versions.runtime`
+(jsonb): `null` / `{"type":"native"}` → the existing loop; `{"type":"claude-code"}` →
+the harness. Sessions pin the agent version, so a session's runtime never changes
+mid-life.
+
+## 4. Exactly-once command execution
+
+### 4.1 How the native loop does it (recap)
+
+- The idemKey is **derived from log position** (`idemKeyFor(sessionId, seq, 0)`), and
+  the assistant's tool call is appended to the log **before** execution.
+- `Executor.exec(cmd, idemKey)` performs an atomic `mkdir .funky/<idemKey>` inside the
+  sandbox. The winner spawns the command detached; it writes `out` and stamps `exit`
+  from inside the sandbox. Any later call with the same key loses the `mkdir` and
+  simply tails the same files. Exec-with-known-key *is* attach.
+- The sandbox outlives workers. Recovery is **forward-only re-attach**, never rollback.
+
+### 4.2 The harness transplant
+
+The model's loop is closed, but every command still funnels through code we own: the
+built-in execution tools (Bash/Read/Edit/…) are disabled, and the only execution
+surface is an in-process **MCP tool `exec`** (`createSdkMcpServer`) whose handler:
+
+1. **Appends first.** The tool call is projected as an `assistant_message` event via a
+   conditional append; the seq it lands at yields the idemKey — the log is the
+   write-ahead journal, exactly as in the native loop.
+2. **Then executes** through the session's `Executor` (same port, same `mkdir` lock,
+   same reboot-once policy).
+3. **Then appends the `tool_result`** and returns the output to the model.
+
+An `ErrConflict` on any append means another worker owns the turn: the driver aborts
+the subprocess and stands down.
+
+### 4.3 Crash recovery protocol
+
+On (re)delivery of a harness turn, `harnessStrategy` (run by the `runTurn` shell):
+
+1. Reads the log. Terminal tail → stale redelivery → ack (`noop`).
+2. **Acquires the fence** (§5): appends `harness_attempt_started {attempt}` at
+   `lastSeq+1` and sets `sessions.harness_attempt = attempt` in one transaction.
+   Losing the seq race = another worker owns the turn.
+3. **Resolves unanswered exec calls** from this turn (reducer step 4, harness
+   flavor): for each projected `assistant_message` tool call without a matching
+   `tool_result`, re-run `exec` with the *same* idemKey. If the crashed attempt
+   started it, this attaches; if the crash landed between append and spawn, this
+   starts it — the logged decision is replayed, and the `mkdir` lock makes the race
+   against a zombie harmless. Append each `tool_result`.
+4. Builds the prompt: a fresh turn sends the user's message; a resumed turn sends a
+   continuation prompt carrying the recovered results ("the run was interrupted; the
+   command you started completed with exit N and output …; continue").
+5. Runs the driver with `resume: <transcript tip>` (§5.2).
+6. **Commits**: `turn_completed` + committed harness state on the session row, one
+   transaction.
+
+Case analysis for a command with side effects:
+
+| Crash point | What happens on retry |
+|---|---|
+| before the `assistant_message` append | nothing was decided durably and nothing ran; the model re-decides on continuation — zero executions so far |
+| after append, before exec spawn | recovery replays the logged decision — runs once |
+| after exec spawn, before `tool_result` | command kept running in the sandbox; recovery **attaches** — runs once |
+| after `tool_result`, before commit | recovery sees it answered; continuation prompt reports it — runs once |
+
+No path executes a command twice. A model that *chooses* to re-run something after
+reading the recovery note is issuing a new command — the same as a user asking twice.
+
+## 5. Write fencing (the zombie-worker problem)
+
+### 5.1 The problem and the native precedent
+
+A worker whose lease expired may still be alive (GC pause, partition) with a live
+Claude subprocess still mirroring entries. The native loop solves the analogous
+problem with the conditional append: `(session_id, seq)` is the PK, the loser's insert
+violates it, `ErrConflict`, stand down. One linear history; the DB is the fence.
+
+The `SessionStore` contract has no caller-computed seq — batches are opaque and
+unconditional — so we fence in the adapter, which we own:
+
+- Acquiring a turn attempt sets `sessions.harness_attempt = <token>` (transactionally
+  with the `harness_attempt_started` event — winning the seq race *is* acquiring the
+  fence).
+- The adapter's `append` is a **single guarded INSERT**:
+  `INSERT … WHERE (SELECT harness_attempt FROM sessions …) = $token` — the check is
+  fused into the write (no separate read, no TOCTOU). Zero rows inserted → the adapter
+  throws → the SDK surfaces `mirror_error` → the zombie driver aborts.
+
+A zombie is therefore killed by whichever write it attempts first — a transcript batch
+(fence) or a tool call (log conflict) — and until it dies, every one of its writes
+bounces. Worker B flips the fence *before* `load()`, so B reads exactly A's accepted
+prefix; nothing can interleave after the flip.
+
+Severity asymmetry the driver must preserve: for a **fenced** writer, rejection means
+"stand down" (ack as conflict); for the **current** attempt, a mirror failure that is
+*not* a fence rejection (DB blip, retries exhausted) means "the transcript would have
+a hole" → abort and retry later. The adapter throws distinguishable errors.
+
+### 5.2 The transcript lineage
+
+Because fenced writes never land, every row in `harness_transcript_entries` belongs to
+a legitimate attempt — so **the table itself records the lineage**. The resume point is
+simply the `sdk_session_id` of the max-`ord` main-transcript row for the Funky
+session; the committed pointer on the session row is a cache/audit field, not the
+authority. This is robust to either SDK behavior on resume (same session id, or a
+newly minted one): whatever id the entries land under is the tip.
+
+## 6. Failure taxonomy
+
+Mapped onto the existing worker outcomes — no queue or worker changes:
+
+| Condition | Class | Outcome |
+|---|---|---|
+| fence lost / seq conflict | conflict | ack silently (another worker owns it) |
+| `mirror_error` on current attempt | `HarnessTransientError` | nack → `retry_later`; terminal `INTERNAL` on last attempt |
+| SDK/process transient failure, `error_during_execution` result | `HarnessTransientError` | same |
+| non-anthropic model, auth failure | `HarnessPermanentError` | `turn_failed(HARNESS)` |
+| harness session on a worker with no driver (no `ANTHROPIC_API_KEY`) | — | terminal `turn_failed(HARNESS)` |
+| `error_max_turns` / `error_max_budget_usd` result | budget stop (returned, not thrown) | `turn_failed(BUDGET)` — the transcript tip is still committed, so the session continues cleanly on the next turn |
+| sandbox unobservable, reboot fails | `SandboxUnavailableError` | `retry_later` → `SANDBOX_FATAL` on last attempt (identical to native; a fatally dead sandbox fails the session honestly — see §7 "snapshots") |
+
+## 7. Alternatives considered (and why not)
+
+**Fork-per-turn / fork-per-attempt transcripts.** Earlier design: every attempt
+`forkSession`s from the last committed Claude session id; commit advances the pointer;
+crashed attempts leave orphaned branches. Correct, and attractive because retries
+replay from a clean snapshot — but (a) retry-by-fork lets the model *re-decide* the
+turn, degrading tool execution to at-least-once unless paired with the §4.3 recovery
+anyway, and (b) fork copies the entire history per turn (O(n²) storage). Once write
+fencing gives the same writer-isolation guarantee the fork was providing, the fork
+buys nothing: dropped in favor of one linear transcript per session — structurally
+identical to the native event log.
+
+**Docker/CRIU snapshot-and-restore for failed steps.** Snapshot the sandbox (FS +
+memory) after every step; on failure restore the last snapshot and re-run. Rejected
+for two reasons. Practically: `docker checkpoint` (CRIU) is experimental and fragile,
+and E2B exposes pause/resume, not point-in-time restore. Fundamentally: restore
+*worsens* side-effect semantics — a command that fired an external effect (HTTP POST,
+`git push`, email) before the crash would be re-run against a rolled-back sandbox that
+no longer remembers it ran, duplicating the effect. Snapshots can roll back the
+sandbox but not the world. Funky's model — the one execution survives (detached, in a
+sandbox that outlives workers) and retries **attach** to it — is the only way to
+exactly-once for side-effecting commands. Consequence kept from the native design: a
+*fatally* destroyed sandbox is an honest `SANDBOX_FATAL` failure, never a silent
+re-provision (a fresh sandbox would make the log lie about accumulated state).
+
+**Adapter-level fencing vs. fork (the tie-breaker).** Fencing needs the attempt token
+plumbed into the adapter and a guarded insert; fork needs neither but costs O(n²)
+storage and leaves branch bookkeeping. With the guard fused into the INSERT (one
+statement, no extra round trip, no TOCTOU) fencing is as simple and strictly closer to
+the native design (single linear history, losers' writes physically rejected). Chosen.
+
+**Sandbox-hosted harness (run the SDK inside the sandbox).** Would give Claude Code
+its full native tool surface (Read/Edit/Grep operate on the sandbox FS directly).
+Rejected for v1: the `ANTHROPIC_API_KEY` would live inside the sandbox — readable by
+any code the agent writes — and the worker would have to manage a harness process
+lifecycle through the sandbox boundary. The MCP exec bridge keeps the key on the
+worker and reuses the TCK-verified exec protocol. The port shape does not preclude a
+sandbox-hosted driver later.
+
+**Reusing `session_events` as the SessionStore.** The transcript entry format is
+CLI-internal, opaque, and much richer than our event schema (thinking blocks,
+compaction state, summaries, tags). Storing entries as our typed events would couple
+us to an undocumented format; projecting *both* directions invites divergence. Instead
+entries are stored verbatim in their own table (pass-through blobs, per the SDK
+contract) and the log receives a **projection** (assistant text, exec calls, results)
+that the existing API/SSE/UI consume unchanged.
+
+**Trusting the SDK transcript for exec idempotency (tool_use ids as idemKeys without
+the log).** Mirror writes are best-effort and batched; a tool call can execute before
+its transcript entry is durably mirrored. The Funky log append is synchronous and
+conditional — that's what a write-ahead journal needs — so the log stays the journal
+and the transcript stays a mirror.
+
+## 8. Schema
+
+```
+harness_transcript_entries
+  project_key        text      — SessionKey.projectKey (sanitized cwd; deterministic per session)
+  sdk_session_id     text      — SessionKey.sessionId (the agent SDK's own session id; SDK-neutral)
+  subpath            text ''   — '' = main transcript; 'subagents/agent-<id>' otherwise
+  ord                bigserial — append order within a key (load ORDER BY)
+  entry_uuid         text?     — dedupe key; retried batches may re-deliver entries
+  entry              jsonb     — opaque SessionStoreEntry, persisted verbatim
+  namespace          text      — tenancy scoping
+  funky_session_id   uuid      — lineage-tip query + GC + the fence join
+  created_at         timestamptz
+
+  unique (sdk_session_id, subpath, entry_uuid) where entry_uuid is not null
+  index  (project_key, sdk_session_id, subpath, ord)
+  index  (funky_session_id)
+
+sessions               + harness_attempt text?   — current fence token
+                       + harness_state   jsonb?  — committed { driver, sdk_session_id } (cache/audit; tip query is authoritative)
+
+agent_config_versions  + runtime jsonb?          — null/native | {"type":"claude-code"}
+```
+
+Event model additions (`packages/sessions/src/events.ts`):
+
+- `harness_attempt_started { attempt, resumed_from }` — bookkeeping; skipped by
+  `buildContext`. `attempt` is the fence token; `resumed_from` records the transcript
+  tip this attempt resumed from (audit).
+- `turn_failed.error_class` gains `"HARNESS"`.
+
+Everything else projects onto existing event types (`assistant_message`,
+`tool_result`, `turn_completed`, `turn_failed`); the SSE/API surface is unchanged. An
+SDK assistant message with parallel exec calls is projected as one `assistant_message`
+event per call, respecting the v1 `tool_calls.max(1)` runtime cap. Thinking blocks are
+not projected in v1 (additive `ContentBlock` kind later).
+
+## 9. Driver specifics (Claude Code)
+
+- `query()` options: `resume` (transcript tip or fresh), `systemPrompt` and `model`
+  from the pinned agent version, `maxTurns` from `tool_policy.max_iterations`,
+  `mcpServers: { funky: <exec bridge> }`, built-in tools disabled (`tools: []`),
+  `allowedTools: ["mcp__funky__exec"]`, `permissionMode: "dontAsk"`,
+  `settingSources: []` (full isolation from host settings/CLAUDE.md),
+  `env: { CLAUDE_CONFIG_DIR: <per-attempt scratch dir> }`, `abortController`
+  (aborted on conflict/fence loss), `sessionStore` (the fenced adapter bound to this
+  attempt's token) with `sessionStoreFlush: "eager"` (a crash loses at most the
+  in-flight frame).
+- `cwd` must be **deterministic per session** (default `<cwdRoot>/<funky-session-id>`)
+  because the SDK derives `projectKey` from the sanitized cwd and `load()` looks up by
+  it. `cwdRoot` must be identical across the worker fleet — it is worker config
+  (`FUNKY_HARNESS_CWD_ROOT`), and changing it orphans in-flight transcripts
+  (documented operational constraint).
+- The scratch dir (`FUNKY_HARNESS_SCRATCH_ROOT`) should live on RAM-backed storage —
+  docker-compose mounts a tmpfs at `/dev/shm/funky-harness` for it. It holds only the
+  disposable per-attempt local JSONL copy.
+- Selection is data, not config: the worker constructs the driver whenever
+  `ANTHROPIC_API_KEY` is set (independent of `FUNKY_LLM`); the pinned agent version's
+  `runtime` decides per session. The API enforces `runtime: {"type":"claude-code"}` ⇒
+  anthropic model at the edge (`apps/api/src/routes/agents.ts`).
+- Provider must be `anthropic`; anything else is a `HarnessPermanentError`.
+- Concurrency note: each in-flight harness turn is a spawned Node subprocess. The
+  default `FUNKY_WORKER_CONCURRENCY=50` is sized for the native loop; deployments
+  running mostly harness sessions should size it down.
+
+## 10. Invariants (the contract, in one place)
+
+1. Every exec decision is in the log **before** the sandbox sees it; its idemKey is
+   its log position.
+2. A command executes at most once per idemKey, no matter how many workers retry
+   (sandbox `mkdir` lock + detached runner + in-sandbox exit stamping).
+3. At most one attempt per Funky session can write transcript entries (fence), and at
+   most one worker can append events at a given seq (PK). Losers stand down.
+4. A committed turn implies a gap-free transcript in Postgres (mirror errors abort).
+5. Recovery is forward-only: attach/replay from durable records; never roll back,
+   never silently re-provision.
+
+## 11. Implementation map
+
+Where each piece of this document lives, and the test that pins it:
+
+| Piece (§) | Code | Pinned by |
+|---|---|---|
+| The port + error taxonomy (§3, §6) | `src/port.ts` | type-level; policy tested via harness-turn tests |
+| Exec bridge: journal → idemKey → exec → record (§4.2) | `makeExecToolHandler` in `src/drivers/claude-code.ts` | `src/claude-code.test.ts` ("journals BEFORE executing…") |
+| Driver: confinement, projection, mirror_error, result mapping (§6, §9) | `ClaudeCodeHarness` in `src/drivers/claude-code.ts` | `src/claude-code.test.ts` (fake `queryFn` seam) |
+| Fenced transcript store (§5.1) | `src/drivers/claude-code-store.ts` | `src/claude-code-store.test.ts` ("★ the write fence") |
+| Transcript lineage / resume tip (§5.2) | `latestTranscriptTip` in `packages/sessions/src/harness-strategy.ts` (and `latestClaudeSessionId` in the store module) | store test "latestClaudeSessionId"; harness-turn test "resumes from the transcript tip" |
+| Fence acquisition + recovery + commit (§4.3, §5) | `harnessStrategy` in `packages/sessions/src/harness-strategy.ts` | `packages/sessions/src/harness-turn.test.ts` — the two ★ crash-resume tests are the exactly-once proof |
+| Shared turn shell + strategy seam (§3) | `runTurn` / `selectStrategy` in `packages/sessions/src/turn.ts`; `TurnShell` / `TurnStrategy` in `packages/sessions/src/strategy.ts`; `nativeStrategy` in `native-strategy.ts` | driven through `runTurn` by `turn.test.ts` + `harness-turn.test.ts` |
+| Shared exec/reboot policy (§4.1) | `packages/sessions/src/exec.ts` (extracted from `turn.ts`, used by both strategies) | native `turn.test.ts` + chaos suite (unchanged) |
+| Schema (§8) | `packages/db/schema/harness.ts`, `sessions.ts`, `configs.ts`; migration `20260718201401_harness_port` | `packages/db/src/schema.test.ts` |
+| Event model additions (§8) | `harness_attempt_started` + `HARNESS` error class in `packages/sessions/src/events.ts` | `events.test.ts` round-trip |
+| API edge (`runtime` on agents) (§3, §9) | `apps/api/src/routes/agents.ts`, `packages/configs/{types,service}.ts` | `apps/api/test/agents.test.ts` |
+| Worker wiring + env knobs (§9) | `apps/worker/src/{index,config,worker}.ts`; compose tmpfs in `docker-compose.yml` | `apps/worker/test/config.test.ts` |
+
+Not covered offline: a live end-to-end run against the real Claude Code subprocess
+(needs `ANTHROPIC_API_KEY`). The driver's SDK-facing behavior is exercised through the
+`queryFn` test seam; the real subprocess's message cadence and resume-id behavior
+should be smoke-tested once per SDK upgrade (`resume` id changes are tolerated by
+design — the tip query accepts whatever id entries land under).

--- a/packages/ports/harness/package.json
+++ b/packages/ports/harness/package.json
@@ -1,29 +1,27 @@
 {
-  "name": "@funky/sessions",
+  "name": "@funky/harness",
   "private": true,
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./events": "./src/events.ts"
+    "./port": "./src/port.ts"
   },
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@funky/configs": "workspace:*",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.214",
     "@funky/db": "workspace:*",
-    "@funky/harness": "workspace:*",
-    "@funky/llm": "workspace:*",
     "@funky/sandbox": "workspace:*",
+    "@funky/sessions": "workspace:*",
     "drizzle-orm": "^1.0.0-beta.2",
-    "pg": "^8.22.0",
-    "uuid": "^13.0.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {
     "@testcontainers/postgresql": "^12.0.4",
     "@types/pg": "^8.20.0",
+    "pg": "^8.22.0",
     "vitest": "^4.1.10"
   }
 }

--- a/packages/ports/harness/src/claude-code-store.test.ts
+++ b/packages/ports/harness/src/claude-code-store.test.ts
@@ -1,0 +1,195 @@
+// packages/ports/harness/src/claude-code-store.test.ts — the fenced SessionStore
+// against a real Postgres. The contract under test is DESIGN.md §5: entries round-trip
+// verbatim and in order; re-delivered batches dedupe by uuid; and a writer whose
+// attempt token no longer matches sessions.harness_attempt is REJECTED (fenced), not
+// interleaved.
+
+import { randomUUID } from "node:crypto";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { SessionStoreEntry } from "@anthropic-ai/claude-agent-sdk";
+import {
+  PostgreSqlContainer,
+  type StartedPostgreSqlContainer,
+} from "@testcontainers/postgresql";
+import { Pool } from "pg";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createDb, type Db } from "@funky/db";
+import { DrizzleSessionStore, latestSdkSessionId } from "./drivers/claude-code-store";
+import { HarnessFencedError } from "./port";
+
+process.env.TESTCONTAINERS_RYUK_DISABLED ??= "true";
+
+const migrationsDir = fileURLToPath(new URL("../../../db/migrations", import.meta.url));
+
+let container: StartedPostgreSqlContainer;
+let pool: Pool;
+let db: Db;
+
+const NS = "test-ns";
+const agentConfigId = randomUUID();
+const envConfigId = randomUUID();
+let sessionId: string;
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer("postgres:16").start();
+  pool = new Pool({ connectionString: container.getConnectionUri() });
+  for (const dir of readdirSync(migrationsDir).sort()) {
+    await pool.query(readFileSync(join(migrationsDir, dir, "migration.sql"), "utf8"));
+  }
+  db = createDb(pool);
+  await pool.query(
+    "insert into agent_configs (id, namespace, name, latest_version) values ($1,$2,$3,1)",
+    [agentConfigId, NS, "test-agent"],
+  );
+  await pool.query("insert into env_configs (id, namespace, name) values ($1,$2,$3)", [
+    envConfigId,
+    NS,
+    "test-env",
+  ]);
+}, 120_000);
+
+afterAll(async () => {
+  await pool?.end();
+  await container?.stop();
+});
+
+beforeEach(async () => {
+  await pool.query("truncate table harness_transcript_entries");
+  sessionId = randomUUID();
+  await pool.query(
+    `insert into sessions (id, namespace, agent_config_id, agent_version, env_config_id, status)
+     values ($1,$2,$3,1,$4,'ready')`,
+    [sessionId, NS, agentConfigId, envConfigId],
+  );
+});
+
+async function setFence(attempt: string | null) {
+  await pool.query("update sessions set harness_attempt=$1 where id=$2", [attempt, sessionId]);
+}
+
+function makeStore(attempt: string) {
+  return new DrizzleSessionStore({ db, namespace: NS, funkySessionId: sessionId, attempt });
+}
+
+const key = (sdkSessionId: string, subpath?: string) => ({
+  projectKey: "pk-test",
+  sessionId: sdkSessionId,
+  ...(subpath !== undefined ? { subpath } : {}),
+});
+
+const entry = (i: number, extra: Record<string, unknown> = {}): SessionStoreEntry => ({
+  type: "user",
+  uuid: `00000000-0000-0000-0000-${String(i).padStart(12, "0")}`,
+  message: { i, nested: { deep: true } },
+  ...extra,
+});
+
+describe("append/load round-trip", () => {
+  it("returns entries deep-equal to what was appended, in append order", async () => {
+    await setFence("a1");
+    const store = makeStore("a1");
+    const batch1 = [entry(1), entry(2)];
+    const batch2 = [entry(3)];
+    await store.append(key("cc-1"), batch1);
+    await store.append(key("cc-1"), batch2);
+
+    const loaded = await store.load(key("cc-1"));
+    expect(loaded).toEqual([...batch1, ...batch2]);
+  });
+
+  it("load returns null for a key never written", async () => {
+    await setFence("a1");
+    expect(await makeStore("a1").load(key("cc-unknown"))).toBeNull();
+  });
+
+  it("uuid-less entries append without dedup", async () => {
+    await setFence("a1");
+    const store = makeStore("a1");
+    const noUuid: SessionStoreEntry = { type: "custom-title", title: "t" };
+    await store.append(key("cc-1"), [noUuid]);
+    await store.append(key("cc-1"), [noUuid]); // no uuid → both land
+    expect(await store.load(key("cc-1"))).toHaveLength(2);
+  });
+
+  it("a re-delivered batch dedupes by uuid instead of duplicating rows", async () => {
+    await setFence("a1");
+    const store = makeStore("a1");
+    const batch = [entry(1), entry(2)];
+    await store.append(key("cc-1"), batch);
+    await store.append(key("cc-1"), batch); // mirror retry re-delivers
+    expect(await store.load(key("cc-1"))).toEqual(batch);
+  });
+
+  it("main and subagent transcripts are separate keys; listSubkeys finds subagents", async () => {
+    await setFence("a1");
+    const store = makeStore("a1");
+    await store.append(key("cc-1"), [entry(1)]);
+    await store.append(key("cc-1", "subagents/agent-7"), [entry(2)]);
+
+    expect(await store.load(key("cc-1"))).toEqual([entry(1)]);
+    expect(await store.load(key("cc-1", "subagents/agent-7"))).toEqual([entry(2)]);
+    expect(await store.listSubkeys({ projectKey: "pk-test", sessionId: "cc-1" })).toEqual([
+      "subagents/agent-7",
+    ]);
+  });
+
+  it("deleting the main key cascades to subkeys", async () => {
+    await setFence("a1");
+    const store = makeStore("a1");
+    await store.append(key("cc-1"), [entry(1)]);
+    await store.append(key("cc-1", "subagents/agent-7"), [entry(2)]);
+
+    await store.delete(key("cc-1")); // no subpath → cascade
+    expect(await store.load(key("cc-1"))).toBeNull();
+    expect(await store.load(key("cc-1", "subagents/agent-7"))).toBeNull();
+  });
+});
+
+describe("★ the write fence", () => {
+  it("a writer whose token no longer matches is rejected and inserts NOTHING", async () => {
+    await setFence("a1");
+    const zombie = makeStore("a1");
+    await zombie.append(key("cc-1"), [entry(1)]); // accepted while current
+
+    await setFence("a2"); // a new attempt took the turn
+    await expect(zombie.append(key("cc-1"), [entry(2)])).rejects.toBeInstanceOf(
+      HarnessFencedError,
+    );
+    expect(zombie.fenced).toBe(true); // the driver reads this to classify mirror_error
+
+    // The zombie's post-fence batch never landed — no interleaving, ever.
+    expect(await makeStore("a2").load(key("cc-1"))).toEqual([entry(1)]);
+  });
+
+  it("a fence of null (no active attempt) rejects writers too", async () => {
+    await setFence(null);
+    await expect(makeStore("a1").append(key("cc-1"), [entry(1)])).rejects.toBeInstanceOf(
+      HarnessFencedError,
+    );
+  });
+
+  it("duplicates under the CURRENT fence are benign, not a fence rejection", async () => {
+    await setFence("a1");
+    const store = makeStore("a1");
+    await store.append(key("cc-1"), [entry(1)]);
+    await expect(store.append(key("cc-1"), [entry(1)])).resolves.toBeUndefined();
+    expect(store.fenced).toBe(false);
+  });
+});
+
+describe("latestSdkSessionId (the resume tip)", () => {
+  it("null with no transcript; then the newest main-transcript session id", async () => {
+    expect(await latestSdkSessionId(db, NS, sessionId)).toBeNull();
+
+    await setFence("a1");
+    const store = makeStore("a1");
+    await store.append(key("cc-old"), [entry(1)]);
+    await store.append(key("cc-new"), [entry(2)]);
+    // Subagent rows must not win the tip.
+    await store.append(key("cc-old", "subagents/agent-1"), [entry(3)]);
+
+    expect(await latestSdkSessionId(db, NS, sessionId)).toBe("cc-new");
+  });
+});

--- a/packages/ports/harness/src/claude-code.test.ts
+++ b/packages/ports/harness/src/claude-code.test.ts
@@ -1,0 +1,241 @@
+// packages/ports/harness/src/claude-code.test.ts — the driver against a FAKE SDK.
+//
+// Everything here is offline: `queryFn` is the test seam standing where the Agent
+// SDK's query() would spawn the Claude Code subprocess. Two surfaces are under test:
+//   1. makeExecToolHandler — the exec bridge's write-ahead discipline (journal →
+//      idemKey from the landed seq → exec → record) and its failure propagation.
+//   2. ClaudeCodeHarness.runTurn — message projection, mirror_error policy, result
+//      mapping, and option plumbing (resume, model, confinement).
+// The real-SDK path is exercised end-to-end only with an API key (not in this suite).
+
+import { describe, expect, it } from "vitest";
+import type { Db } from "@funky/db";
+import {
+  ClaudeCodeHarness,
+  makeExecToolHandler,
+} from "./drivers/claude-code";
+import {
+  HarnessPermanentError,
+  HarnessTransientError,
+  type HarnessProjectedEvent,
+  type HarnessTurnRequest,
+} from "./port";
+
+// ------------------------------------------------------------------ exec bridge
+
+function bridgeCtx() {
+  const calls: string[] = [];
+  const appended: HarnessProjectedEvent[] = [];
+  const failures: unknown[] = [];
+  let seq = 10;
+  const ctx = {
+    sessionId: "11111111-1111-1111-1111-111111111111",
+    append: async (e: HarnessProjectedEvent) => {
+      calls.push(`append:${e.kind}`);
+      appended.push(e);
+      return { seq: ++seq };
+    },
+    exec: async (_call: unknown, idemKey: string) => {
+      calls.push(`exec:${idemKey}`);
+      return { output: "hi\n", exitCode: 0, truncated: false };
+    },
+    fail: (err: unknown) => failures.push(err),
+  };
+  return { ctx, calls, appended, failures };
+}
+
+describe("makeExecToolHandler — the exec bridge", () => {
+  it("journals BEFORE executing, derives the idemKey from the landed seq, records the result", async () => {
+    const { ctx, calls, appended } = bridgeCtx();
+    const handler = makeExecToolHandler(ctx);
+
+    const result = await handler({ cmd: "echo hi" });
+    // Write-ahead order: the log sees the decision before the sandbox does.
+    expect(calls).toEqual([
+      "append:assistant_message",
+      `exec:${ctx.sessionId}:11:0`, // idemKey = the seq the journal landed at
+      "append:tool_result",
+    ]);
+    const journal = appended[0] as Extract<HarnessProjectedEvent, { kind: "assistant_message" }>;
+    expect(journal.toolCalls).toEqual([{ kind: "exec", cmd: "echo hi" }]);
+    const recorded = appended[1] as Extract<HarnessProjectedEvent, { kind: "tool_result" }>;
+    expect(recorded.idemKey).toBe(`${ctx.sessionId}:11:0`);
+    expect(result.content[0]).toEqual({ type: "text", text: "hi\n" });
+  });
+
+  it("a non-zero exit is a RESULT the model sees, flagged isError, never thrown", async () => {
+    const { ctx } = bridgeCtx();
+    ctx.exec = async () => ({ output: "boom\n", exitCode: 3, truncated: false });
+    const result = await makeExecToolHandler(ctx)({ cmd: "exit 3" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]).toEqual({ type: "text", text: "boom\n\n[exit code: 3]" });
+  });
+
+  it("an append rejection (conflict/fence) reaches fail() and rethrows — no exec happens", async () => {
+    const { ctx, calls, failures } = bridgeCtx();
+    const conflict = new Error("seq taken");
+    ctx.append = async () => {
+      calls.push("append:rejected");
+      throw conflict;
+    };
+    await expect(makeExecToolHandler(ctx)({ cmd: "echo hi" })).rejects.toThrow("seq taken");
+    expect(failures).toEqual([conflict]); // the driver aborts the subprocess on this
+    expect(calls).toEqual(["append:rejected"]); // the sandbox never saw the command
+  });
+
+  it("timeout_ms travels on the journaled call", async () => {
+    const { ctx, appended } = bridgeCtx();
+    await makeExecToolHandler(ctx)({ cmd: "sleep 1", timeout_ms: 5000 });
+    const journal = appended[0] as Extract<HarnessProjectedEvent, { kind: "assistant_message" }>;
+    expect(journal.toolCalls).toEqual([{ kind: "exec", cmd: "sleep 1", timeout_ms: 5000 }]);
+  });
+});
+
+// ------------------------------------------------------------------ runTurn vs fake SDK
+
+/** Minimal fake SDK message stream. The driver only reads type/subtype + a few fields. */
+function fakeQuery(messages: Array<Record<string, unknown>>) {
+  const seen: Array<{ prompt: unknown; options: Record<string, unknown> }> = [];
+  const queryFn = ((params: { prompt: unknown; options?: Record<string, unknown> }) => {
+    seen.push({ prompt: params.prompt, options: params.options ?? {} });
+    return (async function* () {
+      for (const m of messages) yield m;
+    })();
+  }) as never;
+  return { queryFn, seen };
+}
+
+const successResult = {
+  type: "result",
+  subtype: "success",
+  session_id: "cc-abc",
+  usage: { input_tokens: 7, output_tokens: 9 },
+};
+
+function makeRequest(overrides: Partial<HarnessTurnRequest> = {}): {
+  req: HarnessTurnRequest;
+  appended: HarnessProjectedEvent[];
+} {
+  const appended: HarnessProjectedEvent[] = [];
+  let seq = 1;
+  const req: HarnessTurnRequest = {
+    namespace: "test-ns",
+    sessionId: "22222222-2222-2222-2222-222222222222",
+    attempt: "attempt-1",
+    systemPrompt: "be helpful",
+    model: { provider: "anthropic", model: "claude-sonnet-5" },
+    prompt: "do the thing",
+    resume: null,
+    limits: { maxTurns: 20 },
+    exec: async () => ({ output: "", exitCode: 0, truncated: false }),
+    append: async (e) => {
+      appended.push(e);
+      return { seq: ++seq };
+    },
+    ...overrides,
+  };
+  return { req, appended };
+}
+
+function harness(queryFn: never) {
+  // The store is only constructed, never queried, when queryFn is fake — a dummy Db
+  // is safe here.
+  return new ClaudeCodeHarness({ db: {} as Db, apiKey: "sk-test", queryFn });
+}
+
+describe("ClaudeCodeHarness.runTurn — projection and result mapping", () => {
+  it("projects top-level assistant text, maps a success result, and plumbs the options", async () => {
+    const { queryFn, seen } = fakeQuery([
+      {
+        type: "assistant",
+        parent_tool_use_id: null,
+        message: { content: [{ type: "text", text: "working on it" }] },
+      },
+      {
+        // Subagent output must NOT be projected.
+        type: "assistant",
+        parent_tool_use_id: "toolu_123",
+        message: { content: [{ type: "text", text: "subagent noise" }] },
+      },
+      successResult,
+    ]);
+    const { req, appended } = makeRequest({ resume: "cc-prev" });
+
+    const result = await harness(queryFn).runTurn(req);
+    expect(result).toEqual({
+      sdkSessionId: "cc-abc",
+      usage: { inputTokens: 7, outputTokens: 9 },
+      stop: { type: "success" },
+    });
+
+    expect(appended).toEqual([
+      {
+        kind: "assistant_message",
+        content: [{ type: "text", text: "working on it" }],
+        toolCalls: [],
+      },
+    ]);
+
+    const { prompt, options } = seen[0]!;
+    expect(prompt).toBe("do the thing");
+    expect(options["resume"]).toBe("cc-prev");
+    expect(options["model"]).toBe("claude-sonnet-5");
+    expect(options["systemPrompt"]).toBe("be helpful");
+    expect(options["maxTurns"]).toBe(20);
+    // Confinement: no built-in tools, no host settings, only the exec bridge.
+    expect(options["tools"]).toEqual([]);
+    expect(options["allowedTools"]).toEqual(["mcp__funky__exec"]);
+    expect(options["settingSources"]).toEqual([]);
+    expect(options["permissionMode"]).toBe("dontAsk");
+    // Statelessness plumbing: fenced store + eager flush + scratch config dir.
+    expect(options["sessionStore"]).toBeDefined();
+    expect(options["sessionStoreFlush"]).toBe("eager");
+    const env = options["env"] as Record<string, string>;
+    expect(env["CLAUDE_CONFIG_DIR"]).toContain("attempt-");
+    expect(env["ANTHROPIC_API_KEY"]).toBe("sk-test");
+  });
+
+  it("maps error_max_turns to a budget stop (still carrying the transcript tip)", async () => {
+    const { queryFn } = fakeQuery([
+      { ...successResult, subtype: "error_max_turns" },
+    ]);
+    const { req } = makeRequest();
+    const result = await harness(queryFn).runTurn(req);
+    expect(result.stop).toEqual({ type: "budget", message: "harness max_turns exhausted" });
+    expect(result.sdkSessionId).toBe("cc-abc");
+  });
+
+  it("error_during_execution → HarnessTransientError (the queue's backoff owns the retry)", async () => {
+    const { queryFn } = fakeQuery([
+      { ...successResult, subtype: "error_during_execution", errors: ["api blew up"] },
+    ]);
+    const { req } = makeRequest();
+    await expect(harness(queryFn).runTurn(req)).rejects.toThrowError(HarnessTransientError);
+  });
+
+  it("a stream that ends without a result message is transient", async () => {
+    const { queryFn } = fakeQuery([]);
+    const { req } = makeRequest();
+    await expect(harness(queryFn).runTurn(req)).rejects.toThrowError(HarnessTransientError);
+  });
+
+  it("mirror_error without a fence loss aborts the turn as transient — a committed turn never sits on a holed transcript", async () => {
+    const { queryFn } = fakeQuery([
+      {
+        type: "system",
+        subtype: "mirror_error",
+        error: "db unreachable",
+        key: { projectKey: "pk", sessionId: "cc-abc" },
+      },
+      successResult, // even a later success must NOT win over the dropped batch
+    ]);
+    const { req } = makeRequest();
+    await expect(harness(queryFn).runTurn(req)).rejects.toThrowError(HarnessTransientError);
+  });
+
+  it("a non-anthropic model is a permanent config error", async () => {
+    const { queryFn } = fakeQuery([successResult]);
+    const { req } = makeRequest({ model: { provider: "openai", model: "gpt-x" } });
+    await expect(harness(queryFn).runTurn(req)).rejects.toThrowError(HarnessPermanentError);
+  });
+});

--- a/packages/ports/harness/src/claude-code.test.ts
+++ b/packages/ports/harness/src/claude-code.test.ts
@@ -195,6 +195,55 @@ describe("ClaudeCodeHarness.runTurn — projection and result mapping", () => {
     expect(env["ANTHROPIC_API_KEY"]).toBe("sk-test");
   });
 
+  it("drains in-flight projected appends before returning — a slow appender never loses the final message", async () => {
+    const { queryFn } = fakeQuery([
+      {
+        type: "assistant",
+        parent_tool_use_id: null,
+        message: { content: [{ type: "text", text: "final answer" }] },
+      },
+      successResult, // arrives immediately after the text — the race window
+    ]);
+    // A DB-realistic appender: resolves on a macrotask, so it is still in flight
+    // when the result message is processed. Without the drain, runTurn resolves
+    // before the append lands and the caller's commit races it for the next seq.
+    const appended: HarnessProjectedEvent[] = [];
+    const { req } = makeRequest({
+      append: async (e) => {
+        await new Promise((r) => setTimeout(r, 10));
+        appended.push(e);
+        return { seq: appended.length };
+      },
+    });
+
+    await harness(queryFn).runTurn(req);
+    expect(appended).toEqual([
+      {
+        kind: "assistant_message",
+        content: [{ type: "text", text: "final answer" }],
+        toolCalls: [],
+      },
+    ]);
+  });
+
+  it("a slow append that REJECTS still fails the turn — the error is not lost after return", async () => {
+    const { queryFn } = fakeQuery([
+      {
+        type: "assistant",
+        parent_tool_use_id: null,
+        message: { content: [{ type: "text", text: "final answer" }] },
+      },
+      successResult,
+    ]);
+    const { req } = makeRequest({
+      append: async () => {
+        await new Promise((r) => setTimeout(r, 10));
+        throw new Error("seq taken");
+      },
+    });
+    await expect(harness(queryFn).runTurn(req)).rejects.toThrow("seq taken");
+  });
+
   it("maps error_max_turns to a budget stop (still carrying the transcript tip)", async () => {
     const { queryFn } = fakeQuery([
       { ...successResult, subtype: "error_max_turns" },

--- a/packages/ports/harness/src/claude-code.test.ts
+++ b/packages/ports/harness/src/claude-code.test.ts
@@ -149,7 +149,10 @@ describe("ClaudeCodeHarness.runTurn — projection and result mapping", () => {
       {
         type: "assistant",
         parent_tool_use_id: null,
-        message: { content: [{ type: "text", text: "working on it" }] },
+        message: {
+          content: [{ type: "text", text: "working on it" }],
+          usage: { input_tokens: 12, output_tokens: 34 },
+        },
       },
       {
         // Subagent output must NOT be projected.
@@ -173,6 +176,8 @@ describe("ClaudeCodeHarness.runTurn — projection and result mapping", () => {
         kind: "assistant_message",
         content: [{ type: "text", text: "working on it" }],
         toolCalls: [],
+        // Per-inference usage rides the projection — the log records it like native.
+        usage: { inputTokens: 12, outputTokens: 34 },
       },
     ]);
 

--- a/packages/ports/harness/src/drivers/claude-code-store.ts
+++ b/packages/ports/harness/src/drivers/claude-code-store.ts
@@ -1,0 +1,152 @@
+// packages/ports/harness/src/drivers/claude-code-store.ts — the fenced SessionStore.
+//
+// The Agent SDK mirrors every transcript entry (JSONL line) to this adapter; entries
+// are persisted VERBATIM in harness_transcript_entries and replayed by load() on
+// resume. This is what makes the worker stateless: the binary's local JSONL lives on
+// a per-attempt RAM disk and dies with the attempt; Postgres holds the trajectory.
+//
+// The append is WRITE-FENCED — the harness twin of the event log's conditional
+// append. The check is fused into the INSERT (single statement, no TOCTOU): rows land
+// only while sessions.harness_attempt still equals this attempt's token. A zombie
+// worker's batches affect zero rows; the adapter then re-reads the fence to
+// distinguish "I was fenced out" (HarnessFencedError → stand down) from "every entry
+// was a duplicate" (fine — mirror retries re-deliver batches; the partial unique
+// index on entry_uuid makes re-delivery a no-op).
+
+import type { SessionKey, SessionStore, SessionStoreEntry } from "@anthropic-ai/claude-agent-sdk";
+import { and, eq, sql } from "drizzle-orm";
+import type { Db } from "@funky/db";
+import { harnessTranscriptEntries, sessions } from "@funky/db/schema";
+import { HarnessFencedError } from "../port";
+
+export type DrizzleSessionStoreOptions = {
+  db: Db;
+  namespace: string;
+  /** The Funky session id — scopes every row; NOT the vendor session id. */
+  funkySessionId: string;
+  /** This attempt's fence token (sessions.harness_attempt). */
+  attempt: string;
+};
+
+export class DrizzleSessionStore implements SessionStore {
+  private readonly db: Db;
+  private readonly ns: string;
+  private readonly sid: string;
+  private readonly attempt: string;
+  /** Set once this adapter observes it has been fenced out; the driver reads it to
+   *  classify the SDK's mirror_error message. */
+  fenced = false;
+
+  constructor(opts: DrizzleSessionStoreOptions) {
+    this.db = opts.db;
+    this.ns = opts.namespace;
+    this.sid = opts.funkySessionId;
+    this.attempt = opts.attempt;
+  }
+
+  async append(key: SessionKey, entries: SessionStoreEntry[]): Promise<void> {
+    if (entries.length === 0) return;
+    // One guarded statement: the fence subquery gates every row; WITH ORDINALITY keeps
+    // the batch's order for the bigserial; ON CONFLICT eats re-delivered entries.
+    const result = await this.db.execute(sql`
+      insert into ${harnessTranscriptEntries}
+        (project_key, sdk_session_id, subpath, entry_uuid, entry, namespace, funky_session_id)
+      select ${key.projectKey}, ${key.sessionId}, ${key.subpath ?? ""},
+             t.e->>'uuid', t.e, ${this.ns}, ${this.sid}
+      from jsonb_array_elements(${JSON.stringify(entries)}::jsonb) with ordinality as t(e, i)
+      where (select harness_attempt from ${sessions}
+             where ${sessions.id} = ${this.sid} and ${sessions.namespace} = ${this.ns}) = ${this.attempt}
+      order by t.i
+      on conflict (sdk_session_id, subpath, entry_uuid) where entry_uuid is not null
+      do nothing
+    `);
+    const inserted = result.rowCount ?? 0;
+    if (inserted === entries.length) return;
+    // Fewer rows than entries: either duplicates (benign) or the fence flipped. Only
+    // now pay a read to find out — and if the fence flips between the insert and this
+    // check, "fenced" is the correct answer anyway.
+    const [row] = await this.db
+      .select({ attempt: sessions.harnessAttempt })
+      .from(sessions)
+      .where(and(eq(sessions.id, this.sid), eq(sessions.namespace, this.ns)))
+      .limit(1);
+    if (row?.attempt !== this.attempt) {
+      this.fenced = true;
+      throw new HarnessFencedError(
+        `attempt ${this.attempt} lost the write fence (current: ${row?.attempt ?? "none"})`,
+      );
+    }
+    // Same fence, short row count → duplicates from a retried batch (only rows WITH a
+    // uuid can hit the partial unique index; uuid-less rows always insert). Benign.
+  }
+
+  async load(key: SessionKey): Promise<SessionStoreEntry[] | null> {
+    const rows = await this.db
+      .select({ entry: harnessTranscriptEntries.entry })
+      .from(harnessTranscriptEntries)
+      .where(keyWhere(key))
+      .orderBy(harnessTranscriptEntries.ord);
+    if (rows.length === 0) return null;
+    return rows.map((r) => r.entry as SessionStoreEntry);
+  }
+
+  /** Subagent transcript discovery on resume. */
+  async listSubkeys(key: { projectKey: string; sessionId: string }): Promise<string[]> {
+    const rows = await this.db
+      .selectDistinct({ subpath: harnessTranscriptEntries.subpath })
+      .from(harnessTranscriptEntries)
+      .where(
+        and(
+          eq(harnessTranscriptEntries.projectKey, key.projectKey),
+          eq(harnessTranscriptEntries.sdkSessionId, key.sessionId),
+        ),
+      );
+    return rows.map((r) => r.subpath).filter((s) => s !== "");
+  }
+
+  /** Main key (no subpath) cascades to all subkeys, per the SessionStore contract. */
+  async delete(key: SessionKey): Promise<void> {
+    await this.db
+      .delete(harnessTranscriptEntries)
+      .where(
+        key.subpath === undefined
+          ? and(
+              eq(harnessTranscriptEntries.projectKey, key.projectKey),
+              eq(harnessTranscriptEntries.sdkSessionId, key.sessionId),
+            )
+          : keyWhere(key),
+      );
+  }
+}
+
+function keyWhere(key: SessionKey) {
+  return and(
+    eq(harnessTranscriptEntries.projectKey, key.projectKey),
+    eq(harnessTranscriptEntries.sdkSessionId, key.sessionId),
+    eq(harnessTranscriptEntries.subpath, key.subpath ?? ""),
+  );
+}
+
+/** The resume tip: the vendor session id of the newest main-transcript row for a
+ *  Funky session. Authoritative because fenced writes never land — every row belongs
+ *  to a legitimate attempt (DESIGN.md §5.2). Null = the session has no transcript
+ *  yet (first turn). */
+export async function latestSdkSessionId(
+  db: Db,
+  namespace: string,
+  funkySessionId: string,
+): Promise<string | null> {
+  const [row] = await db
+    .select({ sdkSessionId: harnessTranscriptEntries.sdkSessionId })
+    .from(harnessTranscriptEntries)
+    .where(
+      and(
+        eq(harnessTranscriptEntries.namespace, namespace),
+        eq(harnessTranscriptEntries.funkySessionId, funkySessionId),
+        eq(harnessTranscriptEntries.subpath, ""),
+      ),
+    )
+    .orderBy(sql`${harnessTranscriptEntries.ord} desc`)
+    .limit(1);
+  return row?.sdkSessionId ?? null;
+}

--- a/packages/ports/harness/src/drivers/claude-code.ts
+++ b/packages/ports/harness/src/drivers/claude-code.ts
@@ -1,0 +1,298 @@
+// packages/ports/harness/src/drivers/claude-code.ts — the Claude Code harness driver.
+//
+// One runTurn = one `query()` = one Claude Code subprocess driving the agentic loop.
+// The driver's job is confinement: the ONLY execution surface the model gets is the
+// in-process MCP `exec` tool, which journals to the Funky log (via the caller's
+// appender — the append yields the seq, the seq yields the idemKey) and then runs the
+// command through the caller's exec function (the sandbox port's exactly-once
+// protocol). Built-in tools are disabled; the subprocess's local session files live
+// on a per-attempt scratch dir (point it at RAM-backed storage) and are deleted after
+// the turn; the durable transcript is the fenced Postgres mirror.
+//
+// Failure discipline (DESIGN.md §6): an appender rejection or a fence loss aborts the
+// subprocess and stands down; a dropped mirror batch (mirror_error) aborts the turn
+// so a committed turn never sits on a holed transcript; SDK/API failures map onto the
+// transient/permanent taxonomy.
+
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createSdkMcpServer,
+  query as sdkQuery,
+  tool,
+} from "@anthropic-ai/claude-agent-sdk";
+import type { Options, SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import type { Db } from "@funky/db";
+import { idemKeyFor, textContent, type ToolCall } from "@funky/sessions/events";
+import {
+  HarnessFencedError,
+  HarnessPermanentError,
+  HarnessTransientError,
+  type HarnessPort,
+  type HarnessTurnRequest,
+  type HarnessTurnResult,
+} from "../port";
+import { DrizzleSessionStore } from "./claude-code-store";
+
+export const EXEC_TOOL = "exec";
+/** Fully-qualified name the SDK gives an MCP tool: mcp__<server>__<tool>. */
+const MCP_SERVER = "funky";
+const EXEC_TOOL_FQN = `mcp__${MCP_SERVER}__${EXEC_TOOL}`;
+
+export type ClaudeCodeHarnessOptions = {
+  db: Db;
+  apiKey: string;
+  /** Parent dir for per-attempt CLAUDE_CONFIG_DIR scratch dirs. Point at RAM-backed
+   *  storage (tmpfs) in production; the contents are disposable by design. */
+  scratchRoot?: string;
+  /** Parent dir for per-session cwd dirs. The SDK derives the transcript store's
+   *  projectKey from the sanitized cwd, so this MUST be identical across the worker
+   *  fleet — changing it orphans in-flight session transcripts. */
+  cwdRoot?: string;
+  /** Test seam: replaces the SDK's query(). */
+  queryFn?: typeof sdkQuery;
+};
+
+export class ClaudeCodeHarness implements HarnessPort {
+  private readonly db: Db;
+  private readonly apiKey: string;
+  private readonly scratchRoot: string;
+  private readonly cwdRoot: string;
+  private readonly queryFn: typeof sdkQuery;
+
+  constructor(opts: ClaudeCodeHarnessOptions) {
+    this.db = opts.db;
+    this.apiKey = opts.apiKey;
+    this.scratchRoot = opts.scratchRoot ?? join(tmpdir(), "funky-harness");
+    this.cwdRoot = opts.cwdRoot ?? "/tmp/funky-harness-cwd";
+    this.queryFn = opts.queryFn ?? sdkQuery;
+  }
+
+  async runTurn(req: HarnessTurnRequest): Promise<HarnessTurnResult> {
+    if (req.model.provider !== "anthropic") {
+      throw new HarnessPermanentError(
+        `claude-code harness requires an anthropic model (got ${req.model.provider})`,
+      );
+    }
+
+    // Deterministic per session → stable projectKey for the transcript store.
+    const cwd = join(this.cwdRoot, req.sessionId);
+    await mkdir(cwd, { recursive: true });
+    // Per-attempt, disposable. The subprocess's local JSONL lives (and dies) here.
+    await mkdir(this.scratchRoot, { recursive: true });
+    const configDir = await mkdtemp(join(this.scratchRoot, "attempt-"));
+
+    const store = new DrizzleSessionStore({
+      db: this.db,
+      namespace: req.namespace,
+      funkySessionId: req.sessionId,
+      attempt: req.attempt,
+    });
+
+    // First fatal error wins; everything after is the abort unwinding.
+    const abort = new AbortController();
+    let fatal: unknown;
+    const fail = (err: unknown): void => {
+      fatal ??= err;
+      abort.abort();
+    };
+
+    // The appender may be called from the tool handler and the message loop
+    // concurrently; the port contract says the CALLER serializes, but a driver-side
+    // chain costs nothing and makes the driver correct against a non-conforming
+    // caller too.
+    let appendChain: Promise<unknown> = Promise.resolve();
+    const append = (e: Parameters<HarnessTurnRequest["append"]>[0]) => {
+      const next = appendChain.then(() => req.append(e));
+      appendChain = next.catch(() => {});
+      return next;
+    };
+
+    const execTool = tool(
+      EXEC_TOOL,
+      "Run a shell command in this session's sandbox and return its combined " +
+        "stdout/stderr and exit code. This is the only way to execute commands, " +
+        "read or write files, or access the network — the sandbox filesystem " +
+        "persists across commands and turns.",
+      {
+        cmd: z.string().min(1).describe("The shell command to run."),
+        timeout_ms: z
+          .number()
+          .int()
+          .min(1)
+          .max(600_000)
+          .optional()
+          .describe("Optional wall-clock timeout in milliseconds."),
+      },
+      makeExecToolHandler({ sessionId: req.sessionId, exec: req.exec, append, fail }),
+    );
+
+    const options: Options = {
+      cwd,
+      abortController: abort,
+      resume: req.resume ?? undefined,
+      systemPrompt: req.systemPrompt,
+      model: req.model.model,
+      maxTurns: req.limits.maxTurns,
+      // Confinement: no built-in tools, no host settings/CLAUDE.md, no prompts.
+      tools: [],
+      allowedTools: [EXEC_TOOL_FQN],
+      permissionMode: "dontAsk",
+      settingSources: [],
+      mcpServers: {
+        [MCP_SERVER]: createSdkMcpServer({ name: MCP_SERVER, tools: [execTool] }),
+      },
+      // Statelessness: durable transcript in Postgres (fenced, eager flush so a crash
+      // loses at most the in-flight frame), disposable local copy on scratch.
+      sessionStore: store,
+      sessionStoreFlush: "eager",
+      env: {
+        ...process.env,
+        CLAUDE_CONFIG_DIR: configDir,
+        ANTHROPIC_API_KEY: this.apiKey,
+      },
+    };
+
+    let result:
+      | { subtype: string; session_id: string; usage: { input_tokens: number; output_tokens: number }; errors?: string[] }
+      | undefined;
+
+    try {
+      for await (const msg of this.queryFn({ prompt: req.prompt, options })) {
+        this.observe(msg as SDKMessage, { store, append, fail });
+        if (msg.type === "result") {
+          result = msg as typeof result & { type: "result" };
+        }
+      }
+    } catch (err) {
+      // An abort we triggered unwinds as an error here; the stored cause is the
+      // truth. An SDK error without a stored cause is a transient turn failure —
+      // the log + recovery make a retry safe.
+      if (fatal === undefined) fatal = classify(err);
+    } finally {
+      await rm(configDir, { recursive: true, force: true }).catch(() => {});
+    }
+
+    if (fatal !== undefined) throw fatal;
+    if (!result) {
+      throw new HarnessTransientError("claude-code subprocess ended without a result message");
+    }
+
+    const usage = {
+      inputTokens: result.usage?.input_tokens ?? 0,
+      outputTokens: result.usage?.output_tokens ?? 0,
+    };
+    switch (result.subtype) {
+      case "success":
+        return { sdkSessionId: result.session_id, usage, stop: { type: "success" } };
+      case "error_max_turns":
+        return {
+          sdkSessionId: result.session_id,
+          usage,
+          stop: { type: "budget", message: "harness max_turns exhausted" },
+        };
+      case "error_max_budget_usd":
+        return {
+          sdkSessionId: result.session_id,
+          usage,
+          stop: { type: "budget", message: "harness max budget exhausted" },
+        };
+      default:
+        throw new HarnessTransientError(
+          `claude-code turn failed (${result.subtype}): ${(result.errors ?? []).join("; ")}`,
+        );
+    }
+  }
+
+  /** Side-channel observation of the message stream: project assistant text into the
+   *  log, and turn a dropped mirror batch into a turn-aborting failure. */
+  private observe(
+    msg: SDKMessage,
+    ctx: {
+      store: DrizzleSessionStore;
+      append: HarnessTurnRequest["append"];
+      fail: (err: unknown) => void;
+    },
+  ): void {
+    if (msg.type === "assistant" && msg.parent_tool_use_id === null) {
+      const text = (msg.message.content ?? [])
+        .filter((b) => b.type === "text")
+        .map((b) => (b as { text: string }).text)
+        .join("");
+      if (text.length > 0) {
+        void ctx
+          .append({ kind: "assistant_message", content: textContent(text), toolCalls: [] })
+          .catch(ctx.fail);
+      }
+      return;
+    }
+    if (msg.type === "system" && msg.subtype === "mirror_error") {
+      // The batch was DROPPED after retries. Ephemeral local copy ⇒ this would be
+      // silent context loss if the turn committed. Fence loss stands down; anything
+      // else retries the turn from the last good state.
+      ctx.fail(
+        ctx.store.fenced
+          ? new HarnessFencedError("transcript write fenced (mirror_error)")
+          : new HarnessTransientError(`transcript mirror batch dropped: ${msg.error}`),
+      );
+    }
+  }
+}
+
+/** The exec bridge — the ONLY execution surface the model gets, and the load-bearing
+ *  piece of the exactly-once story. Exported for direct unit testing. */
+export function makeExecToolHandler(ctx: {
+  sessionId: string;
+  exec: HarnessTurnRequest["exec"];
+  append: HarnessTurnRequest["append"];
+  fail: (err: unknown) => void;
+}) {
+  return async (args: { cmd: string; timeout_ms?: number }) => {
+    try {
+      const call: ToolCall =
+        args.timeout_ms !== undefined
+          ? { kind: "exec", cmd: args.cmd, timeout_ms: args.timeout_ms }
+          : { kind: "exec", cmd: args.cmd };
+      // Journal FIRST: the decision enters the log before the sandbox sees it, and
+      // the seq it lands at is the idemKey — the native loop's write-ahead
+      // discipline, verbatim.
+      const { seq } = await ctx.append({
+        kind: "assistant_message",
+        content: [],
+        toolCalls: [call],
+      });
+      const idemKey = idemKeyFor(ctx.sessionId, seq, 0);
+      const res = await ctx.exec(call, idemKey);
+      await ctx.append({ kind: "tool_result", idemKey, ...res });
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text:
+              res.exitCode === 0 ? res.output : `${res.output}\n[exit code: ${res.exitCode}]`,
+          },
+        ],
+        ...(res.exitCode !== 0 ? { isError: true } : {}),
+      };
+    } catch (err) {
+      // Conflict, fence loss, sandbox death — abort the subprocess; the caller's
+      // error policy takes it from here. Rethrow so the SDK stops waiting.
+      ctx.fail(err);
+      throw err instanceof Error ? err : new Error(String(err));
+    }
+  };
+}
+
+/** SDK/transport failures outside our own fail() path. AbortError without a recorded
+ *  cause means the SDK aborted internally — retryable. */
+function classify(err: unknown): unknown {
+  if (err instanceof HarnessTransientError || err instanceof HarnessPermanentError) return err;
+  if (err instanceof HarnessFencedError) return err;
+  const msg = err instanceof Error ? err.message : String(err);
+  if (/api key|authentication|401|403/i.test(msg)) {
+    return new HarnessPermanentError(`claude-code auth failure: ${msg}`);
+  }
+  return new HarnessTransientError(`claude-code failure: ${msg}`);
+}

--- a/packages/ports/harness/src/drivers/claude-code.ts
+++ b/packages/ports/harness/src/drivers/claude-code.ts
@@ -172,6 +172,13 @@ export class ClaudeCodeHarness implements HarnessPort {
       // the log + recovery make a retry safe.
       if (fatal === undefined) fatal = classify(err);
     } finally {
+      // Drain the projected appends before deciding the turn's fate: observe()'s
+      // assistant-text appends are fire-and-forget, and returning while one is still
+      // in flight would race the caller's commit for the next seq — losing that race
+      // silently drops the final message or fails a successful turn as a conflict.
+      // The chain never rejects; a failed append lands in `fatal` via fail() before
+      // this await resumes.
+      await appendChain;
       await rm(configDir, { recursive: true, force: true }).catch(() => {});
     }
 

--- a/packages/ports/harness/src/drivers/claude-code.ts
+++ b/packages/ports/harness/src/drivers/claude-code.ts
@@ -229,8 +229,25 @@ export class ClaudeCodeHarness implements HarnessPort {
         .map((b) => (b as { text: string }).text)
         .join("");
       if (text.length > 0) {
+        // Per-inference usage rides the projection so harness sessions record token
+        // usage in the log just like native ones. Tool-call decisions are journaled
+        // by the exec bridge (which never sees the vendor message), so their
+        // inferences' usage is not recorded in v1.
+        const u = msg.message.usage;
         void ctx
-          .append({ kind: "assistant_message", content: textContent(text), toolCalls: [] })
+          .append({
+            kind: "assistant_message",
+            content: textContent(text),
+            toolCalls: [],
+            ...(u
+              ? {
+                  usage: {
+                    inputTokens: u.input_tokens ?? 0,
+                    outputTokens: u.output_tokens ?? 0,
+                  },
+                }
+              : {}),
+          })
           .catch(ctx.fail);
       }
       return;

--- a/packages/ports/harness/src/index.ts
+++ b/packages/ports/harness/src/index.ts
@@ -1,0 +1,37 @@
+// packages/ports/harness — public surface.
+// The worker imports the port; the entrypoint selects a driver by config.
+
+export * from "./port";
+export {
+  ClaudeCodeHarness,
+  type ClaudeCodeHarnessOptions,
+} from "./drivers/claude-code";
+export {
+  DrizzleSessionStore,
+  latestSdkSessionId,
+  type DrizzleSessionStoreOptions,
+} from "./drivers/claude-code-store";
+
+import type { Db } from "@funky/db";
+import type { HarnessPort } from "./port";
+import { ClaudeCodeHarness } from "./drivers/claude-code";
+
+/** Driver selection at the entrypoint, mirroring makeLlm/makeSandbox. */
+export type HarnessConfig = {
+  driver: "claude-code";
+  db: Db;
+  apiKey: string;
+  scratchRoot?: string;
+  cwdRoot?: string;
+};
+
+export function makeHarness(cfg: HarnessConfig): HarnessPort {
+  switch (cfg.driver) {
+    case "claude-code":
+      return new ClaudeCodeHarness(cfg);
+    default: {
+      const never: never = cfg.driver;
+      throw new Error(`unknown harness driver: ${JSON.stringify(never)}`);
+    }
+  }
+}

--- a/packages/ports/harness/src/port.ts
+++ b/packages/ports/harness/src/port.ts
@@ -1,0 +1,107 @@
+// packages/ports/harness/src/port.ts — the harness port.
+//
+// A "harness" is a vendor agent SDK that owns the agentic loop (context management,
+// tool planning, compaction) — e.g. Claude Code. Plain TypeScript interface, NOT
+// proto/codegen: a same-process contract the worker imports directly. Drivers are
+// selected by config at the entrypoint; the worker never imports a driver.
+//
+// The port is deliberately LOG-BLIND: the driver reports projected events through a
+// caller-provided appender and executes commands through a caller-provided exec
+// function. The caller (@funky/sessions harnessStrategy) owns the event log, the
+// conditional-append conflict semantics, the write fence, and the commit — so the
+// crash-safety story lives in exactly one place. See DESIGN.md.
+
+import type { HarnessState, ModelConfig } from "@funky/db/schema";
+import type { ContentBlock, ToolCall } from "@funky/sessions/events";
+
+export type { HarnessState };
+
+/** What one exec produced. Non-zero exit / timeout(124) / OOM(137) are RESULTS, not
+ *  errors — same rule as the sandbox port. */
+export type ExecResult = { output: string; exitCode: number; truncated: boolean };
+
+/** Runs one tool call under an idemKey with the caller's full retry/reboot policy.
+ *  Calling with an idemKey that already ran MUST NOT run the command twice — the
+ *  caller wires this to the sandbox port's exec/attach protocol. */
+export type HarnessExecFn = (call: ToolCall, idemKey: string) => Promise<ExecResult>;
+
+/** Events the driver projects into the Funky log — the SUBSET of the harness's
+ *  activity that the API/SSE surface renders. The full vendor transcript is mirrored
+ *  separately (the driver's session store); the log stays the source of truth for
+ *  what EXECUTED. */
+export type HarnessProjectedEvent =
+  | {
+      kind: "assistant_message";
+      content: ContentBlock[];
+      /** v1 cap: 0 or 1 calls, matching the log's tool_calls.max(1). A vendor message
+       *  with parallel calls is projected as one event per call. */
+      toolCalls: ToolCall[];
+      usage?: { inputTokens: number; outputTokens: number };
+    }
+  | {
+      kind: "tool_result";
+      idemKey: string;
+      output: string;
+      exitCode: number;
+      truncated: boolean;
+    };
+
+/** Conditionally appends a projected event; resolves with the seq it landed at (the
+ *  driver derives exec idemKeys from it). MUST serialize internally — the driver may
+ *  call it from concurrent contexts (message stream + tool handler). A rejection is
+ *  the caller's conflict signal: the driver must abort the harness subprocess and
+ *  rethrow the rejection unchanged. */
+export type HarnessAppender = (e: HarnessProjectedEvent) => Promise<{ seq: number }>;
+
+export type HarnessTurnRequest = {
+  namespace: string;
+  /** The Funky session id (trace, cwd derivation, store scoping). */
+  sessionId: string;
+  /** The write-fence token for this attempt — already installed on the session row
+   *  by the caller. The driver binds its transcript store to it. */
+  attempt: string;
+  /** From the PINNED agent version. */
+  systemPrompt: string;
+  model: ModelConfig;
+  /** The prompt for this turn: the user's message, or the caller-built continuation
+   *  prompt when resuming a crashed attempt (recovery is the CALLER's job — by the
+   *  time the driver runs, every logged exec decision is already resolved). */
+  prompt: string;
+  /** Vendor session id to resume from (the transcript tip); null = first turn. */
+  resume: string | null;
+  limits: { maxTurns?: number };
+  exec: HarnessExecFn;
+  append: HarnessAppender;
+};
+
+export type HarnessTurnResult = {
+  /** The agent SDK's own session id this turn's transcript ended under — committed by
+   *  the caller transactionally with turn_completed. */
+  sdkSessionId: string;
+  usage: { inputTokens: number; outputTokens: number };
+  /** "success" → turn_completed; "budget" → turn_failed(BUDGET). Transient/permanent
+   *  failures are thrown, never returned. */
+  stop: { type: "success" } | { type: "budget"; message: string };
+};
+
+export interface HarnessPort {
+  runTurn(req: HarnessTurnRequest): Promise<HarnessTurnResult>;
+}
+
+/** Retryable: subprocess/API transient failure, or a dropped transcript-mirror batch
+ *  (a committed turn must never sit on a holed transcript — abort and retry). The
+ *  worker nacks; on the last attempt it becomes turn_failed(INTERNAL). */
+export class HarnessTransientError extends Error {
+  readonly kind = "harness_transient" as const;
+}
+
+/** Not retryable: unsupported config, auth failure. Becomes turn_failed(HARNESS). */
+export class HarnessPermanentError extends Error {
+  readonly kind = "harness_permanent" as const;
+}
+
+/** This attempt lost the write fence — another worker owns the turn. Stand down
+ *  silently (the caller maps it to the "conflict" outcome, like ErrConflict). */
+export class HarnessFencedError extends Error {
+  readonly kind = "harness_fenced" as const;
+}

--- a/packages/sessions/src/events.test.ts
+++ b/packages/sessions/src/events.test.ts
@@ -32,6 +32,10 @@ const samples: { [T in EventType]: EventPayload<T> } = {
   turn_completed: {},
   turn_failed: { error_class: "INTERNAL", message: "boom" },
   session_provisioned: {},
+  harness_attempt_started: {
+    attempt: "22222222-2222-2222-2222-222222222222",
+    resumed_from: null,
+  },
 };
 
 describe("event model coverage", () => {

--- a/packages/sessions/src/events.ts
+++ b/packages/sessions/src/events.ts
@@ -76,12 +76,23 @@ export const eventPayloadSchemas = {
       "LLM_PERMANENT",
       "SANDBOX_FATAL",
       "BUDGET",
+      "HARNESS", // permanent harness failure (bad config, auth) — harness sessions only
       "INTERNAL",
     ]), // transient classes never reach the log — they retry
     message: z.string(),
   }),
 
   session_provisioned: z.object({}),
+
+  // Harness sessions only (bookkeeping; skipped by buildContext). Appending this at
+  // lastSeq+1 IS acquiring the turn attempt: losing the seq race means another worker
+  // owns the turn. `attempt` is the write-fence token mirrored onto the session row
+  // (sessions.harness_attempt) in the same transaction. See ports/harness/DESIGN.md §5.
+  harness_attempt_started: z.object({
+    attempt: z.string().min(1),
+    /** The Claude session id this attempt resumes from; null on a session's first turn. */
+    resumed_from: z.string().nullable(),
+  }),
 } as const;
 
 export type EventType = keyof typeof eventPayloadSchemas;

--- a/packages/sessions/src/exec.ts
+++ b/packages/sessions/src/exec.ts
@@ -1,0 +1,84 @@
+// packages/sessions/src/exec.ts — exec collection + the single-reboot policy.
+//
+// Extracted from turn.ts so the native loop and the harness loop (harness-turn.ts)
+// share ONE implementation of "run a tool call in the sandbox": collect the stream,
+// treat a missing exit event as unobservable (never a zero exit), and on an
+// unobservable sandbox reboot ONCE and retry by the same idemKey — the idemKey
+// protocol re-attaches to a still-running command or re-runs it safely, so nothing
+// runs twice.
+
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@funky/db";
+import { sessions } from "@funky/db/schema";
+import type { Executor, SandboxDriver, SandboxHandle } from "@funky/sandbox";
+import { SandboxUnavailableError } from "@funky/sandbox";
+import type { ToolCall } from "./events";
+
+export type ExecResult = { output: string; exitCode: number; truncated: boolean };
+
+/** Run one exec. Non-zero exit / timeout(124) / OOM(137) are RESULTS (they carry an
+ *  exit code) and are returned, never thrown. Only an unobservable command throws. */
+export async function runExec(
+  executor: Executor,
+  call: ToolCall,
+  idemKey: string,
+): Promise<ExecResult> {
+  const req = {
+    cmd: call.cmd,
+    idemKey,
+    ...(call.timeout_ms !== undefined ? { timeoutMs: call.timeout_ms } : {}),
+  };
+  let output = "";
+  let exitCode = 0;
+  let truncated = false;
+  let sawExit = false;
+  for await (const ev of executor.exec(req)) {
+    if (ev.kind === "exit") {
+      exitCode = ev.code;
+      truncated = ev.truncated;
+      sawExit = true;
+    } else {
+      output += ev.data; // stdout / stderr both fold into combined output
+    }
+  }
+  // A stream that ends without an exit event is unobservable, not a zero exit.
+  if (!sawExit) throw new SandboxUnavailableError("exec stream ended without an exit event");
+  return { output, exitCode, truncated };
+}
+
+/** Exec with a single reboot on an unobservable sandbox. The same idemKey re-attaches
+ *  to a still-running command or re-runs it safely, so nothing runs twice. A second
+ *  failure propagates to the caller's error policy. The rebooted handle is persisted
+ *  so later workers reconnect to the same sandbox. */
+export function makeExecWithReboot(opts: {
+  db: Db;
+  sandbox: SandboxDriver;
+  ns: string;
+  sessionId: string;
+  handle: SandboxHandle | null;
+}): (call: ToolCall, idemKey: string) => Promise<ExecResult> {
+  let handle = opts.handle;
+  return async (call, idemKey) => {
+    if (!handle) throw new SandboxUnavailableError("session has no sandbox handle");
+    try {
+      return await runExec(opts.sandbox.connect(handle), call, idemKey);
+    } catch (err) {
+      if (!(err instanceof SandboxUnavailableError)) throw err;
+      handle = await opts.sandbox.reboot(handle); // persistent FS survives the reboot
+      await persistHandle(opts.db, opts.ns, opts.sessionId, handle);
+      return await runExec(opts.sandbox.connect(handle), call, idemKey);
+    }
+  };
+}
+
+export async function persistHandle(
+  db: Db,
+  ns: string,
+  sessionId: string,
+  handle: SandboxHandle,
+): Promise<void> {
+  await db
+    .update(sessions)
+    .set({ sandboxHandle: handle, updatedAt: new Date() })
+    .where(and(eq(sessions.namespace, ns), eq(sessions.id, sessionId)));
+}

--- a/packages/sessions/src/harness-strategy.ts
+++ b/packages/sessions/src/harness-strategy.ts
@@ -1,0 +1,283 @@
+// packages/sessions/src/harness-strategy.ts — the harness TurnStrategy.
+//
+// A harness session's agentic loop runs inside a vendor binary (ports/harness), so the
+// reducer cannot compute mid-turn actions — but every stateful decision still lives
+// HERE, against the same log the shell handed us, with the same conditional-append
+// semantics:
+//
+//   1. FENCE: appending harness_attempt_started at lastSeq+1 (+ mirroring the token
+//      onto sessions.harness_attempt, one tx) IS acquiring the turn. Losing the seq
+//      race = another worker owns it. The token fences the driver's transcript mirror
+//      (see ports/harness DESIGN.md §5).
+//   2. RECOVERY: before the model speaks, every logged-but-unanswered exec call is
+//      resolved by the SAME idemKey — attach to a surviving execution or replay the
+//      logged decision. Exactly-once is settled from durable records, never left to the
+//      (stochastic) model. The recovered results ride the continuation prompt.
+//   3. COMMIT: turn_completed (or turn_failed) + the vendor session id land in one
+//      transaction. A crash before commit leaves a resumable transcript tip.
+//
+// These three (fence / recovery pre-pass / continuation prompt) exist ONLY to reconcile
+// the opaque external transcript with the log; the native strategy needs none of them.
+// If you ever reach for `if (resuming) { ... }` around EXECUTION, you have misunderstood
+// the design — resumption only shapes the PROMPT.
+
+import { randomUUID } from "node:crypto";
+import { and, desc, eq } from "drizzle-orm";
+import { harnessTranscriptEntries, sessions } from "@funky/db/schema";
+import {
+  HarnessFencedError,
+  HarnessPermanentError,
+  type HarnessProjectedEvent,
+  type HarnessTurnResult,
+} from "@funky/harness/port";
+import {
+  type EventPayload,
+  type SessionEvent,
+  type ToolCall,
+  idemKeyFor,
+  makeEvent,
+  plainText,
+} from "./events";
+import type { ExecResult } from "./exec";
+import { ErrConflict } from "./store";
+import type { TurnShell, TurnStrategy } from "./strategy";
+import { type TurnDeps, readMaxIterations } from "./turn";
+
+export const harnessStrategy: TurnStrategy = {
+  async run(shell: TurnShell) {
+    const { ns, sessionId, session, version, events, append, terminalFail, exec, deps } = shell;
+
+    const last = events.at(-1);
+    if (!last || last.type === "turn_completed" || last.type === "turn_failed") {
+      return "completed"; // stale redelivery (or no work yet) — silent ack
+    }
+    const lastUser = findLastIndex(events, (e) => e.type === "user_message");
+    if (lastUser < 0) return "completed"; // nothing to answer
+
+    if (!deps.harness) {
+      return terminalFail(
+        "HARNESS",
+        "agent runtime is claude-code but this worker has no harness driver (is ANTHROPIC_API_KEY set?)",
+      );
+    }
+
+    // Was this turn already attempted? Decided BEFORE we append our own attempt event.
+    const priorAttempts = events
+      .slice(lastUser + 1)
+      .filter((e) => e.type === "harness_attempt_started").length;
+
+    // 1. Acquire the fence: attempt event + token on the session row, ONE transaction.
+    // Winning the (session_id, seq) race is winning the turn; the token makes the
+    // transcript store reject any still-running previous attempt's mirror batches. Any
+    // failure to acquire is a retry (never terminal): a conflict means another worker
+    // owns it, anything else is a blip we back off from.
+    const attempt = randomUUID();
+    const resumeTip = await latestTranscriptTip(deps, ns, sessionId);
+    try {
+      await deps.db.transaction(async (tx) => {
+        const seq = (events.at(-1)?.seq ?? 0) + 1;
+        const evt = makeEvent({ sessionId, namespace: ns, seq }, "harness_attempt_started", {
+          attempt,
+          resumed_from: resumeTip,
+        });
+        await deps.store.appendEvent(ns, sessionId, seq, evt, tx);
+        await tx
+          .update(sessions)
+          .set({ harnessAttempt: attempt, updatedAt: new Date() })
+          .where(and(eq(sessions.namespace, ns), eq(sessions.id, sessionId)));
+        events.push({ ...evt, createdAt: new Date() });
+      });
+    } catch (err) {
+      if (err instanceof ErrConflict) return "conflict";
+      return "retry_later";
+    }
+
+    // From here on, escaping errors flow to the shell's error map (harness classes via
+    // this strategy's mapError, shared classes as fallback) — no inner catch needed.
+
+    // 2. RECOVERY: resolve every logged exec decision that has no recorded result. The
+    // idemKey is the log position, so this attaches to a command the crashed attempt
+    // started (it kept running in the surviving sandbox) or replays one that was
+    // journaled but never spawned. Either way: executed exactly once.
+    const recovered: Array<{ call: ToolCall; result: ExecResult }> = [];
+    for (const { call, seq } of unansweredCalls(events, lastUser, sessionId)) {
+      const idemKey = idemKeyFor(sessionId, seq, 0);
+      const result = await exec(call, idemKey);
+      await append("tool_result", {
+        idem_key: idemKey,
+        output: result.output,
+        exit_code: result.exitCode,
+        truncated: result.truncated,
+      });
+      recovered.push({ call, result });
+    }
+
+    // 3. The prompt: the user's message, or a continuation carrying the recovery.
+    const userText = plainText((events[lastUser] as SessionEvent<"user_message">).payload.content);
+    const prompt = priorAttempts === 0 ? userText : continuationPrompt(userText, recovered);
+
+    // 4. The driver's appends ride the shell's conditional-append helper, serialized.
+    let chain: Promise<unknown> = Promise.resolve();
+    const appender = (e: HarnessProjectedEvent): Promise<{ seq: number }> => {
+      const next = chain.then(async () => {
+        if (e.kind === "assistant_message") {
+          const seq = await append("assistant_message", {
+            content: e.content,
+            tool_calls: e.toolCalls,
+            ...(e.usage
+              ? {
+                  usage: {
+                    input_tokens: e.usage.inputTokens,
+                    output_tokens: e.usage.outputTokens,
+                  },
+                }
+              : {}),
+          });
+          return { seq };
+        }
+        const seq = await append("tool_result", {
+          idem_key: e.idemKey,
+          output: e.output,
+          exit_code: e.exitCode,
+          truncated: e.truncated,
+        });
+        return { seq };
+      });
+      chain = next.catch(() => {});
+      return next;
+    };
+
+    const result: HarnessTurnResult = await deps.harness.runTurn({
+      namespace: ns,
+      sessionId,
+      attempt,
+      systemPrompt: version.systemPrompt,
+      model: version.model,
+      prompt,
+      resume: resumeTip,
+      limits: { maxTurns: readMaxIterations(version.toolPolicy) },
+      exec,
+      append: appender,
+    });
+
+    // 5. COMMIT: terminal event + the vendor session id, one transaction. Both stop
+    // types commit the transcript tip — a budget stop still advanced the transcript.
+    await deps.db.transaction(async (tx) => {
+      const seq = (events.at(-1)?.seq ?? 0) + 1;
+      const evt =
+        result.stop.type === "success"
+          ? makeEvent({ sessionId, namespace: ns, seq }, "turn_completed", {})
+          : makeEvent({ sessionId, namespace: ns, seq }, "turn_failed", {
+              error_class: "BUDGET",
+              message: result.stop.message,
+            });
+      await deps.store.appendEvent(ns, sessionId, seq, evt, tx);
+      await tx
+        .update(sessions)
+        .set({
+          harnessState: { driver: "claude-code", sdk_session_id: result.sdkSessionId },
+          updatedAt: new Date(),
+        })
+        .where(and(eq(sessions.namespace, ns), eq(sessions.id, sessionId)));
+      events.push({ ...evt, createdAt: new Date() });
+    });
+    return result.stop.type === "success" ? "completed" : "failed";
+  },
+
+  // Error policy — the harness-specific classes; everything else defers to the shell.
+  mapError(err, shell) {
+    if (err instanceof HarnessFencedError) return "conflict"; // fenced = another worker owns it
+    if (err instanceof HarnessPermanentError) return shell.terminalFail("HARNESS", err.message);
+    return null; // ErrConflict / SandboxUnavailable / generic → shell's shared mapping
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Log scans
+// ---------------------------------------------------------------------------
+
+/** Exec decisions journaled this turn with no recorded result — the harness flavor of
+ *  the reducer's "has that call been answered?" step. */
+function unansweredCalls(
+  events: SessionEvent[],
+  lastUser: number,
+  sessionId: string,
+): Array<{ call: ToolCall; seq: number }> {
+  const out: Array<{ call: ToolCall; seq: number }> = [];
+  const turn = events.slice(lastUser + 1);
+  for (const e of turn) {
+    if (e.type !== "assistant_message") continue;
+    const p = e.payload as EventPayload<"assistant_message">;
+    const call = p.tool_calls[0];
+    if (!call) continue;
+    const idemKey = idemKeyFor(sessionId, e.seq, 0);
+    const answered = turn.some(
+      (r) =>
+        r.type === "tool_result" &&
+        (r.payload as EventPayload<"tool_result">).idem_key === idemKey,
+    );
+    if (!answered) out.push({ call, seq: e.seq });
+  }
+  return out;
+}
+
+/** The vendor session id to resume from: the newest main-transcript row for this
+ *  session. Authoritative because fenced writes never land (every row belongs to a
+ *  legitimate attempt); the session row's harness_state is only a cache/audit field. */
+async function latestTranscriptTip(
+  deps: TurnDeps,
+  ns: string,
+  sessionId: string,
+): Promise<string | null> {
+  const [row] = await deps.db
+    .select({ sdkSessionId: harnessTranscriptEntries.sdkSessionId })
+    .from(harnessTranscriptEntries)
+    .where(
+      and(
+        eq(harnessTranscriptEntries.namespace, ns),
+        eq(harnessTranscriptEntries.funkySessionId, sessionId),
+        eq(harnessTranscriptEntries.subpath, ""),
+      ),
+    )
+    .orderBy(desc(harnessTranscriptEntries.ord))
+    .limit(1);
+  return row?.sdkSessionId ?? null;
+}
+
+/** The recovery preamble: what the interrupted attempt's commands actually did, so the
+ *  resumed model continues instead of re-running side effects it can't see. */
+function continuationPrompt(
+  userText: string,
+  recovered: Array<{ call: ToolCall; result: ExecResult }>,
+): string {
+  const lines = [
+    "<system-reminder>",
+    "This turn was interrupted by an infrastructure failure and is being resumed.",
+    "The user's request for this turn was:",
+    userText,
+    "",
+  ];
+  if (recovered.length > 0) {
+    lines.push(
+      "Commands you had already started completed with these results (do NOT re-run them):",
+    );
+    for (const { call, result } of recovered) {
+      lines.push(
+        `$ ${call.cmd}`,
+        `[exit code: ${result.exitCode}]`,
+        result.output.length > 4000 ? `${result.output.slice(0, 4000)}\n[truncated]` : result.output,
+        "",
+      );
+    }
+  }
+  lines.push(
+    "Continue the task from where it left off; only run new commands that are still needed.",
+    "</system-reminder>",
+  );
+  return lines.join("\n");
+}
+
+function findLastIndex<T>(xs: T[], p: (x: T) => boolean): number {
+  for (let i = xs.length - 1; i >= 0; i--) if (p(xs[i]!)) return i;
+  return -1;
+}

--- a/packages/sessions/src/harness-turn.test.ts
+++ b/packages/sessions/src/harness-turn.test.ts
@@ -1,0 +1,476 @@
+// packages/sessions/src/harness-turn.test.ts — the harness turn loop against a fake
+// HarnessPort + the subprocess sandbox + a testcontainers Postgres. Everything here
+// is offline: no Agent SDK subprocess, no API keys — the fake stands where the
+// Claude Code driver would, exercising the SAME appender/exec contract the driver
+// uses. The two ★ tests are the phase: fence + commit on the happy path, and
+// crash-resume with EXACTLY-ONCE exec recovery.
+
+import { randomUUID } from "node:crypto";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  PostgreSqlContainer,
+  type StartedPostgreSqlContainer,
+} from "@testcontainers/postgresql";
+import { Pool } from "pg";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createDb, type Db } from "@funky/db";
+import type {
+  HarnessPort,
+  HarnessTurnRequest,
+  HarnessTurnResult,
+} from "@funky/harness/port";
+import type { LlmPort } from "@funky/llm";
+import { type SandboxHandle, SubprocessDriver } from "@funky/sandbox";
+import {
+  type EventPayload,
+  type Job,
+  type SessionEvent,
+  EventStore,
+  makeEvent,
+  runTurn,
+  textContent,
+} from "./index";
+
+process.env.TESTCONTAINERS_RYUK_DISABLED ??= "true";
+
+const migrationsDir = fileURLToPath(new URL("../../db/migrations", import.meta.url));
+
+let container: StartedPostgreSqlContainer;
+let pool: Pool;
+let db: Db;
+let store: EventStore;
+let sandbox: SubprocessDriver;
+
+const NS = "test-ns";
+const agentConfigId = randomUUID();
+const envConfigId = randomUUID();
+
+let sessionId: string;
+const handles: SandboxHandle[] = [];
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer("postgres:16").start();
+  pool = new Pool({ connectionString: container.getConnectionUri() });
+  for (const dir of readdirSync(migrationsDir).sort()) {
+    await pool.query(readFileSync(join(migrationsDir, dir, "migration.sql"), "utf8"));
+  }
+  db = createDb(pool);
+  store = new EventStore(db);
+  sandbox = new SubprocessDriver();
+}, 120_000);
+
+afterAll(async () => {
+  await pool?.end();
+  await container?.stop();
+});
+
+beforeEach(async () => {
+  await pool.query(
+    "truncate table harness_transcript_entries, session_events, turn_jobs, sessions cascade",
+  );
+  await pool.query("delete from agent_config_versions");
+  await pool.query("delete from agent_configs");
+  await pool.query("delete from env_configs");
+  await pool.query(
+    "insert into agent_configs (id, namespace, name, latest_version) values ($1,$2,$3,1)",
+    [agentConfigId, NS, "test-agent"],
+  );
+  await pool.query("insert into env_configs (id, namespace, name) values ($1,$2,$3)", [
+    envConfigId,
+    NS,
+    "test-env",
+  ]);
+  sessionId = randomUUID();
+});
+
+afterEach(async () => {
+  while (handles.length) await sandbox.teardown(handles.pop()!);
+});
+
+// ------------------------------------------------------------------------- helpers
+
+async function seedAgentVersion(opts: { maxIterations?: number } = {}) {
+  const toolPolicy =
+    opts.maxIterations !== undefined ? { max_iterations: opts.maxIterations } : {};
+  await pool.query(
+    `insert into agent_config_versions (agent_config_id, version, namespace, system_prompt, model, tool_policy, runtime)
+     values ($1, 1, $2, $3, $4, $5, $6)`,
+    [
+      agentConfigId,
+      NS,
+      "you are a harness agent",
+      JSON.stringify({ provider: "anthropic", model: "claude-sonnet-5" }),
+      JSON.stringify(toolPolicy),
+      JSON.stringify({ type: "claude-code" }),
+    ],
+  );
+}
+
+async function seedSession() {
+  const handle = await sandbox.provision({ network: { type: "unrestricted" } }, sessionId);
+  handles.push(handle);
+  await pool.query(
+    `insert into sessions (id, namespace, agent_config_id, agent_version, env_config_id, status, sandbox_handle)
+     values ($1,$2,$3,1,$4,'ready',$5)`,
+    [sessionId, NS, agentConfigId, envConfigId, JSON.stringify(handle)],
+  );
+  return handle;
+}
+
+async function seedUserMessage(text = "do the thing") {
+  const evt = makeEvent({ sessionId, namespace: NS, seq: 1 }, "user_message", {
+    content: textContent(text),
+  });
+  await store.appendEvent(NS, sessionId, 1, evt);
+}
+
+function job(overrides: Partial<Job> = {}): Job {
+  return {
+    id: randomUUID(),
+    namespace: NS,
+    sessionId,
+    kind: "turn",
+    attempts: 1,
+    maxAttempts: 5,
+    ...overrides,
+  };
+}
+
+// runTurn dispatches to runHarnessTurn via the version's runtime; the llm port is
+// never called on the harness path — a throwing stub proves it.
+const untouchableLlm: LlmPort = {
+  complete: async () => {
+    throw new Error("llm port must not be called for harness sessions");
+  },
+};
+
+function deps(harness?: HarnessPort) {
+  return { store, llm: untouchableLlm, sandbox, db, ...(harness ? { harness } : {}) };
+}
+
+async function log() {
+  return store.readEvents(NS, sessionId);
+}
+
+async function sessionRow() {
+  const r = await pool.query("select harness_attempt, harness_state from sessions where id=$1", [
+    sessionId,
+  ]);
+  return r.rows[0] as { harness_attempt: string | null; harness_state: unknown };
+}
+
+/** A scripted harness: each runTurn call pops the next behavior. */
+function fakeHarness(
+  behaviors: Array<(req: HarnessTurnRequest) => Promise<HarnessTurnResult>>,
+): HarnessPort & { requests: HarnessTurnRequest[] } {
+  const requests: HarnessTurnRequest[] = [];
+  return {
+    requests,
+    async runTurn(req) {
+      requests.push(req);
+      const next = behaviors.shift();
+      if (!next) throw new Error("fake harness: no scripted behavior left");
+      return next(req);
+    },
+  };
+}
+
+/** What the real driver's exec bridge does: journal → exec by seq-derived idemKey →
+ *  record. Kept here so the fake exercises the exact contract. */
+async function bridgeExec(req: HarnessTurnRequest, cmd: string) {
+  const { seq } = await req.append({
+    kind: "assistant_message",
+    content: [],
+    toolCalls: [{ kind: "exec", cmd }],
+  });
+  const idemKey = `${req.sessionId}:${seq}:0`;
+  const res = await req.exec({ kind: "exec", cmd }, idemKey);
+  await req.append({ kind: "tool_result", idemKey, ...res });
+  return res;
+}
+
+const success = (sdkSessionId: string): HarnessTurnResult => ({
+  sdkSessionId,
+  usage: { inputTokens: 1, outputTokens: 1 },
+  stop: { type: "success" },
+});
+
+// ================================================================= ★ HAPPY PATH
+
+describe("runHarnessTurn — the happy path", () => {
+  it("★ fences the attempt, journals exec through the log, commits state", async () => {
+    await seedAgentVersion();
+    await seedSession();
+    await seedUserMessage();
+
+    const harness = fakeHarness([
+      async (req) => {
+        const res = await bridgeExec(req, "echo hi");
+        expect(res.exitCode).toBe(0);
+        expect(res.output).toContain("hi");
+        await req.append({
+          kind: "assistant_message",
+          content: textContent("done"),
+          toolCalls: [],
+        });
+        return success("cc-session-1");
+      },
+    ]);
+
+    const outcome = await runTurn(job(), deps(harness));
+    expect(outcome).toBe("completed");
+
+    const events = await log();
+    expect(events.map((e) => e.type)).toEqual([
+      "user_message",
+      "harness_attempt_started",
+      "assistant_message", // the journaled exec decision
+      "tool_result",
+      "assistant_message", // the text answer
+      "turn_completed",
+    ]);
+    // idemKey is the log position of the journaled decision.
+    const result = events[3] as SessionEvent<"tool_result">;
+    expect(result.payload.idem_key).toBe(`${sessionId}:3:0`);
+
+    // Fresh turn: the prompt is the user's message, no resume tip.
+    expect(harness.requests[0]!.prompt).toBe("do the thing");
+    expect(harness.requests[0]!.resume).toBeNull();
+    expect(harness.requests[0]!.systemPrompt).toBe("you are a harness agent");
+
+    // Committed: fence token installed, vendor session id recorded.
+    const row = await sessionRow();
+    expect(row.harness_attempt).toBe(
+      (events[1] as SessionEvent<"harness_attempt_started">).payload.attempt,
+    );
+    expect(row.harness_state).toEqual({
+      driver: "claude-code",
+      sdk_session_id: "cc-session-1",
+    });
+  });
+
+  it("a stale redelivery of a finished turn is a silent ack", async () => {
+    await seedAgentVersion();
+    await seedSession();
+    await seedUserMessage();
+    const harness = fakeHarness([async () => success("cc-1")]);
+    await runTurn(job(), deps(harness));
+
+    const before = (await log()).length;
+    const outcome = await runTurn(job(), deps(fakeHarness([])));
+    expect(outcome).toBe("completed");
+    expect((await log()).length).toBe(before); // nothing appended
+  });
+});
+
+// ================================================================= ★ CRASH-RESUME
+
+describe("runHarnessTurn — crash-resume, exactly-once", () => {
+  it("★ crash AFTER journaling but BEFORE exec: recovery replays the logged decision once", async () => {
+    await seedAgentVersion();
+    await seedSession();
+    await seedUserMessage("append a line");
+
+    // Attempt 1: journals the decision, then dies before the sandbox sees it.
+    const crashing = fakeHarness([
+      async (req) => {
+        await req.append({
+          kind: "assistant_message",
+          content: [],
+          toolCalls: [{ kind: "exec", cmd: "echo once >> marker.txt" }],
+        });
+        throw new Error("worker died");
+      },
+    ]);
+    expect(await runTurn(job(), deps(crashing))).toBe("retry_later");
+
+    // Attempt 2: recovery must execute the journaled command (exactly once) BEFORE
+    // the harness runs, and hand the result to the continuation prompt.
+    const resumed = fakeHarness([
+      async (req) => {
+        const check = await bridgeExec(req, "cat marker.txt | wc -l");
+        expect(check.output.trim()).toBe("1"); // ← ran exactly once
+        return success("cc-2");
+      },
+    ]);
+    expect(await runTurn(job({ attempts: 2 }), deps(resumed))).toBe("completed");
+
+    const req = resumed.requests[0]!;
+    expect(req.prompt).toContain("interrupted");
+    expect(req.prompt).toContain("append a line"); // original user request
+    expect(req.prompt).toContain("echo once >> marker.txt"); // recovered command
+    expect(req.prompt).toContain("do NOT re-run");
+
+    // The recovered result is in the log under the ORIGINAL decision's idemKey.
+    const events = await log();
+    const results = events.filter((e) => e.type === "tool_result");
+    const recovered = results[0] as SessionEvent<"tool_result">;
+    expect(recovered.payload.idem_key).toBe(`${sessionId}:3:0`);
+    expect(events.at(-1)!.type).toBe("turn_completed");
+  });
+
+  it("★ crash AFTER exec ran but BEFORE the result was recorded: recovery ATTACHES, never re-runs", async () => {
+    await seedAgentVersion();
+    await seedSession();
+    await seedUserMessage();
+
+    // Attempt 1: journals AND executes (the command's side effect lands), then dies
+    // before recording the result — the worst window for a side-effecting command.
+    const crashing = fakeHarness([
+      async (req) => {
+        const { seq } = await req.append({
+          kind: "assistant_message",
+          content: [],
+          toolCalls: [{ kind: "exec", cmd: "echo once >> marker.txt; cat marker.txt | wc -l" }],
+        });
+        await req.exec(
+          { kind: "exec", cmd: "echo once >> marker.txt; cat marker.txt | wc -l" },
+          `${req.sessionId}:${seq}:0`,
+        );
+        throw new Error("worker died before recording the result");
+      },
+    ]);
+    expect(await runTurn(job(), deps(crashing))).toBe("retry_later");
+
+    const resumed = fakeHarness([async () => success("cc-2")]);
+    expect(await runTurn(job({ attempts: 2 }), deps(resumed))).toBe("completed");
+
+    // The idemKey replay attached to the FIRST execution's recorded output: the
+    // marker was appended exactly once, and the recovered result proves it.
+    const results = (await log()).filter((e) => e.type === "tool_result");
+    expect(results).toHaveLength(1);
+    expect((results[0]!.payload as EventPayload<"tool_result">).output.trim()).toBe("1");
+    expect(resumed.requests[0]!.prompt).toContain("[exit code: 0]");
+  });
+
+  it("the retry resumes from the transcript tip left by the crashed attempt", async () => {
+    await seedAgentVersion();
+    await seedSession();
+    await seedUserMessage();
+
+    // Simulate the crashed attempt's mirrored transcript rows (what the fenced store
+    // would have written before the crash).
+    await pool.query(
+      `insert into harness_transcript_entries (project_key, sdk_session_id, subpath, entry_uuid, entry, namespace, funky_session_id)
+       values ('pk', 'cc-crashed-tip', '', $1, '{"type":"user"}', $2, $3)`,
+      [randomUUID(), NS, sessionId],
+    );
+
+    const resumed = fakeHarness([async () => success("cc-next")]);
+    expect(await runTurn(job({ attempts: 2 }), deps(resumed))).toBe("completed");
+    expect(resumed.requests[0]!.resume).toBe("cc-crashed-tip");
+
+    const attempt = (await log()).find(
+      (e) => e.type === "harness_attempt_started",
+    ) as SessionEvent<"harness_attempt_started">;
+    expect(attempt.payload.resumed_from).toBe("cc-crashed-tip");
+  });
+});
+
+// ================================================================= conflicts & fences
+
+describe("runHarnessTurn — conflicts", () => {
+  it("losing an append race mid-turn → conflict, no terminal event from the loser", async () => {
+    await seedAgentVersion();
+    await seedSession();
+    await seedUserMessage();
+
+    const harness = fakeHarness([
+      async (req) => {
+        // Another worker steals the next seq out from under this attempt.
+        const events = await store.readEvents(NS, sessionId);
+        const seq = (events.at(-1)?.seq ?? 0) + 1;
+        await store.appendEvent(
+          NS,
+          sessionId,
+          seq,
+          makeEvent({ sessionId, namespace: NS, seq }, "harness_attempt_started", {
+            attempt: randomUUID(),
+            resumed_from: null,
+          }),
+        );
+        // This attempt's next append must lose and the rejection must propagate.
+        await req.append({ kind: "assistant_message", content: textContent("x"), toolCalls: [] });
+        throw new Error("unreachable — append should have rejected");
+      },
+    ]);
+
+    expect(await runTurn(job(), deps(harness))).toBe("conflict");
+    const events = await log();
+    expect(events.at(-1)!.type).toBe("harness_attempt_started"); // no terminal junk
+  });
+
+  it("a second attempt flips the fence token on the session row", async () => {
+    await seedAgentVersion();
+    await seedSession();
+    await seedUserMessage();
+
+    expect(await runTurn(job(), deps(fakeHarness([async () => { throw new Error("die"); }])))).toBe(
+      "retry_later",
+    );
+    const first = (await sessionRow()).harness_attempt;
+    expect(first).toBeTruthy();
+
+    expect(await runTurn(job({ attempts: 2 }), deps(fakeHarness([async () => success("cc")])))).toBe(
+      "completed",
+    );
+    const second = (await sessionRow()).harness_attempt;
+    expect(second).toBeTruthy();
+    expect(second).not.toBe(first); // the zombie's token is dead — its store writes bounce
+  });
+});
+
+// ================================================================= error policy
+
+describe("runHarnessTurn — error policy", () => {
+  it("budget stop → turn_failed(BUDGET), transcript tip still committed", async () => {
+    await seedAgentVersion({ maxIterations: 3 });
+    await seedSession();
+    await seedUserMessage();
+
+    const harness = fakeHarness([
+      async (req) => {
+        expect(req.limits.maxTurns).toBe(3);
+        return {
+          sdkSessionId: "cc-budget",
+          usage: { inputTokens: 1, outputTokens: 1 },
+          stop: { type: "budget", message: "harness max_turns exhausted" },
+        };
+      },
+    ]);
+
+    expect(await runTurn(job(), deps(harness))).toBe("failed");
+    const lastEvent = (await log()).at(-1) as SessionEvent<"turn_failed">;
+    expect(lastEvent.type).toBe("turn_failed");
+    expect(lastEvent.payload.error_class).toBe("BUDGET");
+    expect((await sessionRow()).harness_state).toEqual({
+      driver: "claude-code",
+      sdk_session_id: "cc-budget",
+    });
+  });
+
+  it("no harness driver on this worker → terminal turn_failed(HARNESS)", async () => {
+    await seedAgentVersion();
+    await seedSession();
+    await seedUserMessage();
+
+    expect(await runTurn(job(), deps(/* no harness */))).toBe("failed");
+    const lastEvent = (await log()).at(-1) as SessionEvent<"turn_failed">;
+    expect(lastEvent.payload.error_class).toBe("HARNESS");
+  });
+
+  it("a transient harness failure retries, then terminates as INTERNAL on the last attempt", async () => {
+    await seedAgentVersion();
+    await seedSession();
+    await seedUserMessage();
+
+    const die = () => fakeHarness([async () => { throw new Error("subprocess lost"); }]);
+    expect(await runTurn(job({ attempts: 1 }), deps(die()))).toBe("retry_later");
+    expect(await runTurn(job({ attempts: 5 }), deps(die()))).toBe("failed");
+    const lastEvent = (await log()).at(-1) as SessionEvent<"turn_failed">;
+    expect(lastEvent.payload.error_class).toBe("INTERNAL");
+    expect(lastEvent.payload.message).toContain("subprocess lost");
+  });
+});

--- a/packages/sessions/src/harness-turn.test.ts
+++ b/packages/sessions/src/harness-turn.test.ts
@@ -214,6 +214,7 @@ describe("runHarnessTurn — the happy path", () => {
           kind: "assistant_message",
           content: textContent("done"),
           toolCalls: [],
+          usage: { inputTokens: 5, outputTokens: 7 },
         });
         return success("cc-session-1");
       },
@@ -234,6 +235,10 @@ describe("runHarnessTurn — the happy path", () => {
     // idemKey is the log position of the journaled decision.
     const result = events[3] as SessionEvent<"tool_result">;
     expect(result.payload.idem_key).toBe(`${sessionId}:3:0`);
+
+    // The projection's usage lands on the logged event — parity with the native loop.
+    const answer = events[4] as SessionEvent<"assistant_message">;
+    expect(answer.payload.usage).toEqual({ input_tokens: 5, output_tokens: 7 });
 
     // Fresh turn: the prompt is the user's message, no resume tip.
     expect(harness.requests[0]!.prompt).toBe("do the thing");

--- a/packages/sessions/src/native-strategy.ts
+++ b/packages/sessions/src/native-strategy.ts
@@ -1,0 +1,134 @@
+// packages/sessions/src/native-strategy.ts — Funky's native turn loop.
+//
+// The simplest TurnStrategy: Funky owns every step. The reducer computes the single
+// next Action from the log, the strategy performs it, appends the result, and repeats
+// — reading the log ONCE (via the shell) and keeping it current in memory. buildContext
+// is the ONLY source of provider messages: it rebuilds the conversation from our log
+// every inference, so "every assistant tool_use is answered by a matching tool_result"
+// holds across crashes and the v1 one-call cap. Raw provider responses are never cached.
+//
+// Because the model's context is a pure function of the log, crash-resume is FREE here:
+// the reducer replays the log prefix and recomputes the same next action. There is no
+// fence beyond the (session_id, seq) PK, no recovery pre-pass, and no continuation
+// prompt — the harness strategy needs all three only to reconcile an external vendor
+// transcript with the log; the native loop has no external state to reconcile.
+
+import type { ChatMessage } from "@funky/llm";
+import { LlmPermanentError, LlmTransientError } from "@funky/llm";
+import {
+  type EventPayload,
+  type SessionEvent,
+  plainText,
+  textContent,
+} from "./events";
+import { nextAction } from "./reducer";
+import type { TurnOutcome } from "./turn";
+import { readMaxIterations } from "./turn";
+import type { TurnShell, TurnStrategy } from "./strategy";
+
+// ---------------------------------------------------------------------------
+// buildContext — log → provider messages
+// ---------------------------------------------------------------------------
+/** Rebuild the provider message list from the log. The system prompt comes from the
+ *  PINNED agent version on the session row, never the agent's current latest. Bookkeeping
+ *  events (turn_completed / turn_failed / session_provisioned / harness_attempt_started)
+ *  are skipped — they are not conversation. This is the sole producer of ChatMessage[];
+ *  never replay a raw response. */
+export function buildContext(events: SessionEvent[], systemPrompt: string): ChatMessage[] {
+  const messages: ChatMessage[] = [{ role: "system", content: systemPrompt }];
+  for (const e of events) {
+    switch (e.type) {
+      case "user_message": {
+        const p = e.payload as EventPayload<"user_message">;
+        messages.push({ role: "user", content: plainText(p.content) });
+        break;
+      }
+      case "assistant_message": {
+        const p = e.payload as EventPayload<"assistant_message">;
+        messages.push({
+          role: "assistant",
+          content: plainText(p.content),
+          // v1 cap: at most one call; buildContext mirrors what the log recorded.
+          ...(p.tool_calls[0] ? { toolCall: p.tool_calls[0] } : {}),
+        });
+        break;
+      }
+      case "tool_result": {
+        const p = e.payload as EventPayload<"tool_result">;
+        messages.push({ role: "tool", idemKey: p.idem_key, output: p.output, exitCode: p.exit_code });
+        break;
+      }
+      // turn_completed / turn_failed / session_provisioned / harness_attempt_started
+      // → skipped (bookkeeping).
+    }
+  }
+  return messages;
+}
+
+// ---------------------------------------------------------------------------
+// nativeStrategy — perform the reducer's action, append, repeat
+// ---------------------------------------------------------------------------
+export const nativeStrategy: TurnStrategy = {
+  async run(shell: TurnShell): Promise<TurnOutcome> {
+    const { events, append, exec, version } = shell;
+    const systemPrompt = version.systemPrompt;
+    const model = version.model;
+    const maxIterations = readMaxIterations(version.toolPolicy);
+
+    for (;;) {
+      const action = nextAction(events, maxIterations);
+      switch (action.kind) {
+        case "noop":
+          return "completed"; // redelivery of finished work — silent ack
+        case "finish":
+          await append("turn_completed", {});
+          return "completed";
+        case "fail":
+          await append("turn_failed", {
+            error_class: "BUDGET",
+            message: `iteration budget exhausted (max_iterations=${maxIterations})`,
+          });
+          return "failed";
+        case "infer": {
+          const result = await shell.deps.llm.complete({
+            model,
+            messages: buildContext(events, systemPrompt),
+            trace: { sessionId: shell.sessionId },
+          });
+          await append("assistant_message", {
+            content: textContent(result.content),
+            tool_calls: result.toolCall ? [result.toolCall] : [],
+            usage: {
+              input_tokens: result.usage.inputTokens,
+              output_tokens: result.usage.outputTokens,
+            },
+          });
+          break;
+        }
+        case "exec_tool": {
+          const res = await exec(action.call, action.idemKey);
+          await append("tool_result", {
+            idem_key: action.idemKey,
+            output: res.output,
+            exit_code: res.exitCode, // a non-zero exit is a result the model reacts to
+            truncated: res.truncated,
+          });
+          break;
+        }
+      }
+    }
+  },
+
+  // Error policy — the LLM-specific classes; everything else defers to the shell.
+  // A command that ran and failed never reaches here — that's a result, not a throw.
+  mapError(err, shell) {
+    if (err instanceof LlmPermanentError) return shell.terminalFail("LLM_PERMANENT", err.message);
+    if (err instanceof LlmTransientError) {
+      // Escaped the driver's retries. Append nothing; the queue's backoff replays the log.
+      return shell.lastAttempt
+        ? shell.terminalFail("INTERNAL", `llm transient: ${err.message}`)
+        : "retry_later";
+    }
+    return null; // ErrConflict / SandboxUnavailable / generic → shell's shared mapping
+  },
+};

--- a/packages/sessions/src/strategy.ts
+++ b/packages/sessions/src/strategy.ts
@@ -1,0 +1,59 @@
+// packages/sessions/src/strategy.ts — the shared turn seam.
+//
+// runTurn (turn.ts) is a SHELL: it gates on session status, loads the pinned agent
+// version, reads the log once, builds the shared plumbing (append / terminalFail /
+// exec), and then hands a TurnShell to a TurnStrategy selected by the pinned runtime.
+//
+// A strategy owns the turn's INNER loop and everything that genuinely differs between
+// runtimes — the native loop's reducer-driven steps, or the harness loop's fence +
+// crash-recovery + vendor delegation + commit. The shell owns everything they share.
+// See ports/harness/DESIGN.md and turn.ts.
+
+import type { EventPayload, EventType, SessionEvent, ToolCall } from "./events";
+import type { ExecResult } from "./exec";
+import type { Job } from "./queue";
+import type { SessionRow, TurnDeps, TurnOutcome, VersionRow } from "./turn";
+
+/** The classes turn_failed records (events.ts). Transient classes never reach the log
+ *  — they retry — so they are not part of this union. */
+export type ErrorClass = "LLM_PERMANENT" | "SANDBOX_FATAL" | "BUDGET" | "HARNESS" | "INTERNAL";
+
+/** Everything a strategy needs from the shell. Built once per turn, after the session
+ *  gate and the single log read. */
+export type TurnShell = {
+  job: Job;
+  ns: string;
+  sessionId: string;
+  /** The queue already incremented attempts on claim; true on the final delivery. A
+   *  would-be retry_later on the last attempt must instead record a terminal failure. */
+  lastAttempt: boolean;
+  session: SessionRow;
+  /** The PINNED agent version — system prompt, model, tool policy. Never the latest. */
+  version: VersionRow;
+  deps: TurnDeps;
+  /** The log, read ONCE. `append` keeps it current in memory; a strategy that does its
+   *  own transactional appends (the harness fence/commit) MUST push to this array too,
+   *  so later reads reflect reality without another round-trip — exactly as today. */
+  events: SessionEvent[];
+  /** Conditional append at lastSeq+1; mirrors the row into `events`; resolves with the
+   *  seq it landed at (the harness derives exec idemKeys from it; native ignores it).
+   *  Throws ErrConflict on a lost (session_id, seq) race — another worker owns the turn. */
+  append: <T extends EventType>(type: T, payload: EventPayload<T>) => Promise<number>;
+  /** Record a terminal turn_failed. Returns "conflict" if even that append loses the
+   *  race (another worker owns the turn); "retry_later" if it could not be recorded. */
+  terminalFail: (errorClass: ErrorClass, message: string) => Promise<TurnOutcome>;
+  /** Run one tool call under an idemKey with the single-reboot policy (exec.ts), bound
+   *  to this session's sandbox handle. The same idemKey re-attaches, never re-runs. */
+  exec: (call: ToolCall, idemKey: string) => Promise<ExecResult>;
+};
+
+export interface TurnStrategy {
+  /** Run the turn's inner loop. Return a TurnOutcome, or throw for mapError / the
+   *  shell's shared error map. */
+  run(shell: TurnShell): Promise<TurnOutcome>;
+  /** Classify a strategy-specific error into an outcome. Return null to DEFER to the
+   *  shell's shared mapping (ErrConflict → conflict, SandboxUnavailable → SANDBOX_FATAL
+   *  / retry, else INTERNAL / retry). Runs inside the shell's catch, so terminalFail
+   *  and lastAttempt are reached through `shell`. */
+  mapError?(err: unknown, shell: TurnShell): TurnOutcome | Promise<TurnOutcome> | null;
+}

--- a/packages/sessions/src/turn.ts
+++ b/packages/sessions/src/turn.ts
@@ -1,77 +1,51 @@
-// packages/sessions/src/turn.ts — Phase D: the turn loop.
+// packages/sessions/src/turn.ts — the turn SHELL.
 //
-// runTurn performs the single next Action the reducer computes, appends its result to the
-// log, and repeats — reading the log ONCE and keeping it current in memory thereafter.
-// buildContext is the ONLY source of provider messages: it rebuilds the conversation from
-// our log every inference, so the invariant "every assistant tool_use is answered by a
-// matching tool_result" holds even across crashes and the driver's v1 one-call cap. Raw
-// provider response objects are never cached or replayed.
+// runTurn is deliberately thin: it gates on session status, loads the PINNED agent
+// version, reads the log ONCE, builds the plumbing every runtime shares (the
+// conditional-append helper, terminalFail, exec-with-reboot), and hands a TurnShell to
+// the TurnStrategy selected by the pinned runtime. The strategies own everything that
+// genuinely differs:
+//
+//   - nativeStrategy (native-strategy.ts): Funky's own infer/exec loop. The model's
+//     context is a pure function of the log, so crash-resume is free (reducer replay).
+//   - harnessStrategy (harness-strategy.ts): a vendor agent SDK (e.g. Claude Code) owns
+//     the loop; the strategy adds a write fence, a crash-recovery pre-pass, and a commit
+//     to reconcile the opaque external transcript with the log.
+//
+// The pinned runtime never changes mid-session, so a session's strategy is stable for
+// its whole life. See ports/harness/DESIGN.md.
 
 import { and, eq } from "drizzle-orm";
 import type { Db } from "@funky/db";
-import { agentConfigVersions, sessions } from "@funky/db/schema";
-import type { ChatMessage, LlmPort } from "@funky/llm";
-import { LlmPermanentError, LlmTransientError } from "@funky/llm";
-import type { Executor, SandboxDriver, SandboxHandle } from "@funky/sandbox";
+import { type RuntimeConfig, agentConfigVersions, sessions } from "@funky/db/schema";
+import type { HarnessPort } from "@funky/harness/port";
+import type { LlmPort } from "@funky/llm";
+import type { SandboxDriver, SandboxHandle } from "@funky/sandbox";
 import { SandboxUnavailableError } from "@funky/sandbox";
-import {
-  type EventPayload,
-  type EventType,
-  type SessionEvent,
-  type ToolCall,
-  makeEvent,
-  plainText,
-  textContent,
-} from "./events";
+import { type EventPayload, type EventType, makeEvent } from "./events";
+import { makeExecWithReboot } from "./exec";
+import { harnessStrategy } from "./harness-strategy";
+import { nativeStrategy } from "./native-strategy";
 import type { Job } from "./queue";
-import { nextAction } from "./reducer";
 import { ErrConflict, EventStore } from "./store";
+import type { ErrorClass, TurnShell, TurnStrategy } from "./strategy";
+
+// buildContext is native's context builder; re-exported here so `./turn`'s public
+// surface (and its importers/tests) stay stable after the strategy split.
+export { buildContext } from "./native-strategy";
 
 // ---------------------------------------------------------------------------
-// buildContext — log → provider messages
-// ---------------------------------------------------------------------------
-/** Rebuild the provider message list from the log. The system prompt comes from the
- *  PINNED agent version on the session row, never the agent's current latest. Bookkeeping
- *  events (turn_completed / turn_failed / session_provisioned) are skipped — they are not
- *  conversation. This is the sole producer of ChatMessage[]; never replay a raw response. */
-export function buildContext(events: SessionEvent[], systemPrompt: string): ChatMessage[] {
-  const messages: ChatMessage[] = [{ role: "system", content: systemPrompt }];
-  for (const e of events) {
-    switch (e.type) {
-      case "user_message": {
-        const p = e.payload as EventPayload<"user_message">;
-        messages.push({ role: "user", content: plainText(p.content) });
-        break;
-      }
-      case "assistant_message": {
-        const p = e.payload as EventPayload<"assistant_message">;
-        messages.push({
-          role: "assistant",
-          content: plainText(p.content),
-          // v1 cap: at most one call; buildContext mirrors what the log recorded.
-          ...(p.tool_calls[0] ? { toolCall: p.tool_calls[0] } : {}),
-        });
-        break;
-      }
-      case "tool_result": {
-        const p = e.payload as EventPayload<"tool_result">;
-        messages.push({ role: "tool", idemKey: p.idem_key, output: p.output, exitCode: p.exit_code });
-        break;
-      }
-      // turn_completed / turn_failed / session_provisioned → skipped (bookkeeping).
-    }
-  }
-  return messages;
-}
-
-// ---------------------------------------------------------------------------
-// runTurn — perform the action, append, repeat
+// runTurn — gate, load, build the shell, dispatch to the strategy
 // ---------------------------------------------------------------------------
 export type TurnDeps = {
   store: EventStore;
   llm: LlmPort;
   sandbox: SandboxDriver;
   db: Db; // for reading session + agent version rows
+  /** Optional: agent versions with runtime {type:"claude-code"} dispatch to this
+   *  port (harness-strategy.ts). A harness session on a worker without a driver fails
+   *  the turn with a terminal HARNESS error. */
+  harness?: HarnessPort;
 };
 
 export type TurnOutcome =
@@ -96,32 +70,26 @@ export async function runTurn(job: Job, deps: TurnDeps): Promise<TurnOutcome> {
   if (session.status === "provisioning") return "retry_later"; // backoff waits; do NOT block
   if (session.status === "failed" || session.status === "archived") return "abandoned";
 
-  // 2. The PINNED agent version → system prompt, model, iteration budget.
+  // 2. The PINNED agent version → system prompt, model, iteration budget, runtime.
   const version = await loadAgentVersion(deps.db, session.agentConfigId, session.agentVersion);
   if (!version) return "abandoned"; // pinned version vanished — nothing coherent to run
-  const systemPrompt = version.systemPrompt;
-  const model = version.model;
-  const maxIterations = readMaxIterations(version.toolPolicy);
 
-  // 3. The log IS the state. Read once; keep it current in memory (never re-read per loop).
+  // 3. The log IS the state. Read once; the shell's append keeps it current in memory.
   const events = await deps.store.readEvents(ns, sessionId);
-  let handle = (session.sandboxHandle ?? null) as SandboxHandle | null;
 
-  // Append at lastSeq+1 and mirror the row into `events` so the loop reflects reality
-  // without another DB round-trip. A lost (session_id, seq) race surfaces as ErrConflict.
-  const append = async <T extends EventType>(type: T, payload: EventPayload<T>): Promise<void> => {
+  // 4. Shared plumbing: conditional append, terminal-failure recorder, exec+reboot.
+  const append = async <T extends EventType>(
+    type: T,
+    payload: EventPayload<T>,
+  ): Promise<number> => {
     const seq = (events.at(-1)?.seq ?? 0) + 1;
     const evt = makeEvent({ sessionId, namespace: ns, seq }, type, payload);
     await deps.store.appendEvent(ns, sessionId, seq, evt);
     events.push({ ...evt, createdAt: new Date() });
+    return seq;
   };
 
-  // Record a terminal failure. If even this append loses the seq race, another worker
-  // owns the turn → conflict; a non-conflict failure means we could not record it → retry.
-  const terminalFail = async (
-    errorClass: "LLM_PERMANENT" | "SANDBOX_FATAL" | "INTERNAL",
-    message: string,
-  ): Promise<TurnOutcome> => {
+  const terminalFail = async (errorClass: ErrorClass, message: string): Promise<TurnOutcome> => {
     try {
       await append("turn_failed", { error_class: errorClass, message });
     } catch (e) {
@@ -131,111 +99,72 @@ export async function runTurn(job: Job, deps: TurnDeps): Promise<TurnOutcome> {
     return "failed";
   };
 
-  // Run one exec. Non-zero exit / timeout(124) / OOM(137) are RESULTS (they carry an exit
-  // code) and are returned, never thrown. Only an unobservable command throws.
-  const runExec = async (executor: Executor, call: ToolCall, idemKey: string) => {
-    const req = {
-      cmd: call.cmd,
-      idemKey,
-      ...(call.timeout_ms !== undefined ? { timeoutMs: call.timeout_ms } : {}),
-    };
-    let output = "";
-    let exitCode = 0;
-    let truncated = false;
-    let sawExit = false;
-    for await (const ev of executor.exec(req)) {
-      if (ev.kind === "exit") {
-        exitCode = ev.code;
-        truncated = ev.truncated;
-        sawExit = true;
-      } else {
-        output += ev.data; // stdout / stderr both fold into combined output
-      }
-    }
-    // A stream that ends without an exit event is unobservable, not a zero exit.
-    if (!sawExit) throw new SandboxUnavailableError("exec stream ended without an exit event");
-    return { output, exitCode, truncated };
+  const exec = makeExecWithReboot({
+    db: deps.db,
+    sandbox: deps.sandbox,
+    ns,
+    sessionId,
+    handle: (session.sandboxHandle ?? null) as SandboxHandle | null,
+  });
+
+  const shell: TurnShell = {
+    job,
+    ns,
+    sessionId,
+    lastAttempt,
+    session,
+    version,
+    deps,
+    events,
+    append,
+    terminalFail,
+    exec,
   };
 
-  // Exec with a single reboot on an unobservable sandbox. The same idemKey re-attaches to
-  // a still-running command or re-runs it safely, so nothing runs twice. A second failure
-  // propagates to the error policy below.
-  const execWithReboot = async (call: ToolCall, idemKey: string) => {
-    if (!handle) throw new SandboxUnavailableError("session has no sandbox handle");
-    try {
-      return await runExec(deps.sandbox.connect(handle), call, idemKey);
-    } catch (err) {
-      if (!(err instanceof SandboxUnavailableError)) throw err;
-      handle = await deps.sandbox.reboot(handle); // persistent FS survives the reboot
-      await persistHandle(deps.db, ns, sessionId, handle);
-      return await runExec(deps.sandbox.connect(handle), call, idemKey);
-    }
-  };
-
+  // 5. Select the strategy by pinned runtime, run it, and map any escaping error onto
+  //    a TurnOutcome (strategy-specific classes first, shared classes as fallback).
+  const strategy = selectStrategy(version.runtime);
   try {
-    for (;;) {
-      const action = nextAction(events, maxIterations);
-      switch (action.kind) {
-        case "noop":
-          return "completed"; // redelivery of finished work — silent ack
-        case "finish":
-          await append("turn_completed", {});
-          return "completed";
-        case "fail":
-          await append("turn_failed", {
-            error_class: "BUDGET",
-            message: `iteration budget exhausted (max_iterations=${maxIterations})`,
-          });
-          return "failed";
-        case "infer": {
-          const result = await deps.llm.complete({
-            model,
-            messages: buildContext(events, systemPrompt),
-            trace: { sessionId },
-          });
-          await append("assistant_message", {
-            content: textContent(result.content),
-            tool_calls: result.toolCall ? [result.toolCall] : [],
-            usage: {
-              input_tokens: result.usage.inputTokens,
-              output_tokens: result.usage.outputTokens,
-            },
-          });
-          break;
-        }
-        case "exec_tool": {
-          const res = await execWithReboot(action.call, action.idemKey);
-          await append("tool_result", {
-            idem_key: action.idemKey,
-            output: res.output,
-            exit_code: res.exitCode, // a non-zero exit is a result the model reacts to
-            truncated: res.truncated,
-          });
-          break;
-        }
-      }
-    }
+    return await strategy.run(shell);
   } catch (err) {
-    // Error policy. A command that ran and failed never reaches here — that's a result.
-    if (err instanceof ErrConflict) return "conflict"; // someone else owns this turn
-    if (err instanceof LlmPermanentError) return terminalFail("LLM_PERMANENT", err.message);
-    if (err instanceof LlmTransientError) {
-      // Escaped the driver's retries. Append nothing; the queue's backoff replays the log.
-      return lastAttempt ? terminalFail("INTERNAL", `llm transient: ${err.message}`) : "retry_later";
-    }
-    if (err instanceof SandboxUnavailableError) {
-      return lastAttempt ? terminalFail("SANDBOX_FATAL", err.message) : "retry_later";
-    }
-    const message = err instanceof Error ? err.message : String(err);
-    return lastAttempt ? terminalFail("INTERNAL", message) : "retry_later";
+    const mapped = await strategy.mapError?.(err, shell);
+    return mapped ?? (await mapError(err, shell));
   }
+}
+
+/** Pinned runtime → strategy. null / {type:"native"} → the native loop; {type:"claude-code"}
+ *  → the harness loop. Replaces the former inline dispatch branch. */
+function selectStrategy(runtime: RuntimeConfig | null): TurnStrategy {
+  switch (runtime?.type) {
+    case "claude-code":
+      return harnessStrategy;
+    case "native":
+    case undefined: // null runtime column → native (the historical default)
+      return nativeStrategy;
+    default: {
+      const never: never = runtime;
+      throw new Error(`unknown runtime: ${JSON.stringify(never)}`);
+    }
+  }
+}
+
+/** The shared error map: the classes every strategy resolves the same way. Strategy-
+ *  specific classes (Llm*, Harness*) are handled by the strategy's own mapError first;
+ *  anything it defers on lands here. */
+function mapError(err: unknown, shell: TurnShell): TurnOutcome | Promise<TurnOutcome> {
+  if (err instanceof ErrConflict) return "conflict"; // someone else owns this turn
+  if (err instanceof SandboxUnavailableError) {
+    return shell.lastAttempt ? shell.terminalFail("SANDBOX_FATAL", err.message) : "retry_later";
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return shell.lastAttempt ? shell.terminalFail("INTERNAL", message) : "retry_later";
 }
 
 // ---------------------------------------------------------------------------
 // Row access — every query scoped by namespace.
 // ---------------------------------------------------------------------------
-type SessionRow = typeof sessions.$inferSelect;
-type VersionRow = typeof agentConfigVersions.$inferSelect;
+export type SessionRow = typeof sessions.$inferSelect;
+export type VersionRow = typeof agentConfigVersions.$inferSelect;
 
 async function loadSession(db: Db, ns: string, sessionId: string): Promise<SessionRow | undefined> {
   const [row] = await db
@@ -264,21 +193,10 @@ async function loadAgentVersion(
   return row;
 }
 
-async function persistHandle(
-  db: Db,
-  ns: string,
-  sessionId: string,
-  handle: SandboxHandle,
-): Promise<void> {
-  await db
-    .update(sessions)
-    .set({ sandboxHandle: handle, updatedAt: new Date() })
-    .where(and(eq(sessions.namespace, ns), eq(sessions.id, sessionId)));
-}
-
 /** The spigot that stops a buggy agent looping forever against a paid LLM API.
- *  `tool_policy.max_iterations`, default 20. */
-function readMaxIterations(toolPolicy: Record<string, unknown>): number {
+ *  `tool_policy.max_iterations`, default 20. (Harness sessions map it onto the
+ *  vendor loop's maxTurns.) */
+export function readMaxIterations(toolPolicy: Record<string, unknown>): number {
   const v = toolPolicy["max_iterations"];
   return typeof v === "number" && Number.isInteger(v) && v > 0 ? v : 20;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       '@funky/db':
         specifier: workspace:*
         version: link:../../packages/db
+      '@funky/harness':
+        specifier: workspace:*
+        version: link:../../packages/ports/harness
       '@funky/llm':
         specifier: workspace:*
         version: link:../../packages/ports/llm
@@ -191,6 +194,40 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
+  packages/ports/harness:
+    dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.3.214
+        version: 0.3.214(@anthropic-ai/sdk@0.112.3(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+      '@funky/db':
+        specifier: workspace:*
+        version: link:../../db
+      '@funky/sandbox':
+        specifier: workspace:*
+        version: link:../sandbox
+      '@funky/sessions':
+        specifier: workspace:*
+        version: link:../../sessions
+      drizzle-orm:
+        specifier: ^1.0.0-beta.2
+        version: 1.0.0-rc.4-5d5b77c(@electric-sql/pglite@0.5.4)(@types/pg@8.20.0)(pg@8.22.0)(zod@4.4.3)
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
+    devDependencies:
+      '@testcontainers/postgresql':
+        specifier: ^12.0.4
+        version: 12.0.4
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
+      pg:
+        specifier: ^8.22.0
+        version: 8.22.0
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+
   packages/ports/llm:
     dependencies:
       '@ai-sdk/anthropic':
@@ -243,6 +280,9 @@ importers:
       '@funky/db':
         specifier: workspace:*
         version: link:../db
+      '@funky/harness':
+        specifier: workspace:*
+        version: link:../ports/harness
       '@funky/llm':
         specifier: workspace:*
         version: link:../ports/llm
@@ -338,6 +378,67 @@ packages:
   '@ai-sdk/provider@4.0.3':
     resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
     engines: {node: '>=22'}
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.214':
+    resolution: {integrity: sha512-vAAOeVtlXs3p7MpFVfvfu9ja32eaKtB+MDZnPxCbdzxJk5nofCHlNsHa1UJwXHOsP9lOnFYNIccYztsZ4DNaJA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.214':
+    resolution: {integrity: sha512-NTbV8U2yucxCWqEiDC7L0MUehNmd8x3Op8OGzLZRhMF3xmQBy2DxpXiNZgSwwKWNDC3HdgKmJM5ZBbT7XrF/0g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.214':
+    resolution: {integrity: sha512-i06wQRsmevE7spY1ryYfs+NP+xdZ1FwAyTjDaF0k/xG+cgtzZYghTFUemdYF3GVwgWgpcava9GiCFDT3DoHI6w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.214':
+    resolution: {integrity: sha512-KBCf+BlusG0ZcgvpjjHwv1kh+6WiR8vJbPjpR2udwkrtcQgKLN+24l+FeaQEzO2TL+ExCmM1KC4tNPvnPpy+tw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.214':
+    resolution: {integrity: sha512-948RstHDhs0E69h+2dKYWIAL1kcwEme4zvtgNUwP8XpKXzWOhrTKmd6MAokHn25zwfuSx5d+HE0XHfFH6R4hLg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.214':
+    resolution: {integrity: sha512-vqadSceJkBKHaTUszxI35uTuECGWtsHWK/mOwIJ4b9DUtYYySz6EJEk4gHg4ccutisJ/oRVCpFXHIKFb+osrKw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.214':
+    resolution: {integrity: sha512-CEKlPFCPv+ee79utQMEDSsgeo2f27ulhNHpjrKIt1jXz5G04J7lAWN/QwvPDv9XaLBkWpyfqZWiPXlRcwuaO/w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.214':
+    resolution: {integrity: sha512-cJMJfFoR9IWBZWnTtt9PnEm89hGOsZjoDNjOCEOF3+x+g/ANIXAjMJTcaQYv2HKh6MylWZ0AkxBASI+twkukaQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.3.214':
+    resolution: {integrity: sha512-wt5ImwhU+p259Zt4K/Q9v5xVi6ruxYO5+KFICyJxnjs/QFEClAeSRqhcXx1J8jgGfatPW1faw09hkm66680UjA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
+      zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.112.3':
+    resolution: {integrity: sha512-wjcozJlitVIuBEw9cj/xBuRznwkhcLmXmNzlFoeHbh4AvrDG3HGZrdvEOTTmobcbhjGkfOpKbmDTCQ4s9LQvCg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@balena/dockerignore@1.0.2':
     resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
@@ -706,6 +807,12 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@hono/node-server@2.0.8':
     resolution: {integrity: sha512-GuCWzLxwg218fy1JaHculFsdcuY12hxit83V+algozTPnwhNjLrRL/Alg9OYjLZLoUZ1rw/S4CdTMsnkSKCmFA==}
     engines: {node: '>=20'}
@@ -742,6 +849,16 @@ packages:
 
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -989,6 +1106,9 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1095,11 +1215,26 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   ai@7.0.22:
     resolution: {integrity: sha512-iAXYwQtR18qN7GXwNmGVAQM4uSJOh2+nZ5RP9NtDXfH5d4tlYyYzAM133O3U+eVcyWrvNRzecN9yW58xpCdfMg==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1199,6 +1334,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
@@ -1223,6 +1362,18 @@ packages:
   byline@5.0.0:
     resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
     engines: {node: '>=0.10.0'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1260,11 +1411,35 @@ packages:
   computesdk@4.1.3:
     resolution: {integrity: sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cpu-features@0.0.10:
     resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
@@ -1299,6 +1474,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1443,6 +1622,10 @@ packages:
       zod:
         optional: true
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   e2b@2.33.0:
     resolution: {integrity: sha512-n6W0nsJMetz8m30sLPMYfliPTW0VpuaDTUOjB0ZdYZ87li4zyX0UQqeQ5S/YPvq8EX9zEYcy3SijBxn1FGFlkQ==}
     engines: {node: '>=20.18.1 <21 || >=22'}
@@ -1450,17 +1633,36 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.3.0:
     resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -1476,8 +1678,15 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
 
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -1494,12 +1703,35 @@ packages:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
+  express-rate-limit@8.6.0:
+    resolution: {integrity: sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1510,9 +1742,21 @@ packages:
       picomatch:
         optional: true
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -1522,13 +1766,24 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-port@5.1.1:
     resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
     engines: {node: '>=8'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
@@ -1544,12 +1799,32 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
 
   hono@4.12.29:
     resolution: {integrity: sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw==}
     engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1557,9 +1832,20 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -1582,8 +1868,21 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   jsbi@4.3.2:
     resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -1686,6 +1985,26 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -1725,13 +2044,29 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1758,6 +2093,10 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -1769,6 +2108,9 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1814,6 +2156,10 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
@@ -1855,8 +2201,24 @@ packages:
     resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
@@ -1885,6 +2247,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -1896,6 +2262,10 @@ packages:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
 
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -1909,6 +2279,17 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1916,6 +2297,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1947,6 +2344,13 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
@@ -2021,6 +2425,13 @@ packages:
     resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -2031,6 +2442,10 @@ packages:
 
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -2059,12 +2474,20 @@ packages:
     resolution: {integrity: sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==}
     engines: {node: '>=22.19.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   uuid@13.0.2:
     resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@8.1.4:
     resolution: {integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==}
@@ -2206,6 +2629,11 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -2241,6 +2669,54 @@ snapshots:
   '@ai-sdk/provider@4.0.3':
     dependencies:
       json-schema: 0.4.0
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.214':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.214':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.214':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.214':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.214':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.214':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.214':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.214':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.3.214(@anthropic-ai/sdk@0.112.3(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.112.3(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.214
+
+  '@anthropic-ai/sdk@0.112.3(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.4.3
+
+  '@babel/runtime@7.29.7': {}
 
   '@balena/dockerignore@1.0.2': {}
 
@@ -2464,6 +2940,10 @@ snapshots:
       protobufjs: 7.6.5
       yargs: 17.7.3
 
+  '@hono/node-server@1.19.14(hono@4.12.29)':
+    dependencies:
+      hono: 4.12.29
+
   '@hono/node-server@2.0.8(hono@4.12.29)':
     dependencies:
       hono: 4.12.29
@@ -2499,6 +2979,28 @@ snapshots:
   '@kwsites/file-exists@1.1.1':
     dependencies:
       debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.29)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.6.0(express@5.2.1)
+      hono: 4.12.29
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -2642,6 +3144,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@testcontainers/postgresql@12.0.4':
@@ -2667,13 +3171,13 @@ snapshots:
 
   '@types/docker-modem@3.0.6':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
       '@types/ssh2': 1.15.5
 
   '@types/dockerode@4.0.1':
     dependencies:
       '@types/docker-modem': 3.0.6
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
       '@types/ssh2': 1.15.5
 
   '@types/estree@1.0.9': {}
@@ -2692,7 +3196,7 @@ snapshots:
 
   '@types/pg@8.20.0':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
@@ -2706,11 +3210,11 @@ snapshots:
 
   '@types/ssh2-streams@0.1.13':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
 
   '@types/ssh2@0.5.52':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
       '@types/ssh2-streams': 0.1.13
 
   '@types/ssh2@1.15.5':
@@ -2779,12 +3283,28 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   ai@7.0.22(zod@4.4.3):
     dependencies:
       '@ai-sdk/gateway': 4.0.16(zod@4.4.3)
       '@ai-sdk/provider': 4.0.3
       '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
       zod: 4.4.3
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -2877,6 +3397,20 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
@@ -2901,6 +3435,18 @@ snapshots:
     optional: true
 
   byline@5.0.0: {}
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   chai@6.2.2: {}
 
@@ -2937,9 +3483,24 @@ snapshots:
       '@computesdk/cmd': 0.4.1
       daemond: 0.1.4
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cpu-features@0.0.10:
     dependencies:
@@ -2967,6 +3528,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  depd@2.0.0: {}
 
   detect-libc@2.1.2: {}
 
@@ -3016,6 +3579,12 @@ snapshots:
       pg: 8.22.0
       zod: 4.4.3
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   e2b@2.33.0:
     dependencies:
       '@bufbuild/protobuf': 2.12.1
@@ -3032,15 +3601,27 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  ee-first@1.1.1: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.3.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -3102,9 +3683,13 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
+
+  etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
 
@@ -3118,27 +3703,113 @@ snapshots:
 
   eventsource-parser@3.1.0: {}
 
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   expect-type@1.4.0: {}
 
+  express-rate-limit@8.6.0(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
   fast-fifo@1.3.2: {}
+
+  fast-sha256@1.3.0: {}
+
+  fast-uri@3.1.3: {}
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   get-caller-file@2.0.5: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
   get-port@5.1.1: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-tsconfig@4.14.0:
     dependencies:
@@ -3162,15 +3833,41 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   hono@4.12.29: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
   inherits@2.0.4: {}
 
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
+
+  is-promise@4.0.0: {}
 
   is-stream@2.0.1: {}
 
@@ -3190,7 +3887,18 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jose@6.2.3: {}
+
   jsbi@4.3.2: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -3265,6 +3973,18 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.7
@@ -3294,9 +4014,19 @@ snapshots:
 
   nanoid@3.3.15: {}
 
+  negotiator@1.0.0: {}
+
   normalize-path@3.0.0: {}
 
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   obug@2.1.3: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -3332,6 +4062,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  parseurl@1.3.3: {}
+
   path-key@3.1.1: {}
 
   path-scurry@1.11.1:
@@ -3343,6 +4075,8 @@ snapshots:
     dependencies:
       lru-cache: 11.5.2
       minipass: 7.1.3
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -3384,6 +4118,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
+
+  pkce-challenge@5.0.1: {}
 
   platform@1.3.6: {}
 
@@ -3431,13 +4167,32 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.2
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
       long: 5.3.2
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
 
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:
@@ -3476,6 +4231,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-pkg-maps@1.0.0: {}
 
   retry@0.12.0: {}
@@ -3501,6 +4258,16 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.5
       '@rolldown/binding-win32-x64-msvc': 1.1.5
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
@@ -3509,11 +4276,66 @@ snapshots:
 
   scheduler@0.27.0: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -3541,6 +4363,13 @@ snapshots:
       nan: 2.28.0
 
   stackback@0.0.2: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
+  statuses@2.0.2: {}
 
   std-env@4.2.0: {}
 
@@ -3676,6 +4505,10 @@ snapshots:
 
   tmp@0.2.7: {}
 
+  toidentifier@1.0.1: {}
+
+  ts-algebra@2.0.0: {}
+
   tslib@2.8.1:
     optional: true
 
@@ -3686,6 +4519,12 @@ snapshots:
       fsevents: 2.3.3
 
   tweetnacl@0.14.5: {}
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typescript@5.9.3: {}
 
@@ -3701,9 +4540,13 @@ snapshots:
 
   undici@8.7.0: {}
 
+  unpipe@1.0.0: {}
+
   util-deprecate@1.0.2: {}
 
   uuid@13.0.2: {}
+
+  vary@1.1.2: {}
 
   vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
@@ -3841,5 +4684,9 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@4.4.3: {}


### PR DESCRIPTION
## What

Adds a **harness port** that lets a Funky session *be* a managed agent-SDK conversation (first driver: **Claude Code**, `@anthropic-ai/claude-agent-sdk`) — while keeping Funky's core promise intact: stateless workers, crash-resume as the normal path, and exactly-once command execution.

The agentic loop runs inside the vendor binary, but every command still funnels through Funky's sandbox (via an in-process MCP `exec` bridge), and the durable trajectory lives in Postgres, so any worker can resume any turn.

Full design and guarantees: [`packages/ports/harness/DESIGN.md`](packages/ports/harness/DESIGN.md).

## Highlights

- **`@funky/harness` port + Claude Code driver** — the driver is deliberately log-blind: it reports projected events through a caller-provided appender and executes through a caller-provided exec fn, so the crash-safety story lives in one place.
- **Fenced transcript store** — the SDK's `SessionStore` mirrors transcript entries to Postgres; a guarded INSERT against `sessions.harness_attempt` fences zombie workers. Every stored row belongs to a legitimate attempt, so the table itself records the resume lineage.
- **Exactly-once, preserved** — the exec decision is journaled to the event log *before* the sandbox sees it; its idemKey is its log position. Crash recovery attaches to the surviving execution or replays the journaled decision — never re-runs a side effect.
- **One turn shell, two strategies** — `runTurn` is now a thin shell (session gate, log read, shared append/terminalFail/exec, error mapping) that dispatches to a `TurnStrategy` selected by the pinned runtime: `nativeStrategy` (the existing loop) or `harnessStrategy`. The native loop is the degenerate strategy — no external transcript to reconcile, so it needs no fence/recovery-prepass/continuation-prompt.
- **SDK-neutral schema** — transcript columns use `sdk_session_id` (not Claude-specific), so a second driver can reuse the table unchanged.
- **UI** — the Console's Agent form and Quick Start gain a Runtime selector (Native / Claude Code); harness agents are badged and annotated in the session picker.
- **Selection is data** — agent behavior is versioned on `agent_config_versions.runtime`; a session pins its runtime for life. The worker builds the driver whenever `ANTHROPIC_API_KEY` is present.

## Testing

- Full monorepo suite green: **372 passed / 0 failed** (5 pre-existing skips), including the chaos suite that stress-tests crash-resume, fencing, and exactly-once across workers.
- Verified end-to-end against a live Claude Code subprocess in the docker stack (harness session provisions a sandbox, runs a command through the exec bridge, commits the transcript tip).
- Not covered offline: the real subprocess's message cadence / resume-id behavior — smoke-test once per SDK upgrade (tolerated by design; the resume tip accepts whatever session id entries land under).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
