### PR TITLE
Instrument the worker with OpenTelemetry metrics (FUNKY_METRICS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,19 @@ DATABASE_URL=postgres://funky:funky@localhost:5432/funky
 # ANTHROPIC_API_KEY (independent of FUNKY_LLM). See packages/ports/harness/DESIGN.md.
 # FUNKY_HARNESS_SCRATCH_ROOT=/dev/shm/funky-harness  # disposable per-attempt local copy; use RAM-backed storage
 # FUNKY_HARNESS_CWD_ROOT=/tmp/funky-harness-cwd      # MUST be identical across all workers
+
+# --- worker metrics ---
+# Comma-separated list of metric exporters (default "prometheus"):
+#   prometheus  serve GET /metrics on the worker health port (:9090) for scraping — no change
+#               from previous releases; this is what self-hosted Prometheus should use.
+#   otlp        push over OTLP/HTTP. Configure with the STANDARD OTel env vars — Funky
+#               invents none: OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_HEADERS,
+#               OTEL_METRIC_EXPORT_INTERVAL (ms, default 60000), OTEL_SERVICE_NAME,
+#               OTEL_RESOURCE_ATTRIBUTES. Works with any OTLP receiver (otel-collector,
+#               Grafana, Datadog, Honeycomb, Google's OTLP ingest, ...).
+#   gcm         push directly to Google Cloud Monitoring (uses ambient GCP credentials).
+# The metric names and label sets are a STABLE CONTRACT across all exporters:
+#   funky_queue_depth{state}, funky_worker_turns_inflight,
+#   funky_worker_jobs_total{outcome}, funky_worker_append_conflicts_total
+# FUNKY_METRICS=prometheus,otlp
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318

--- a/README.md
+++ b/README.md
@@ -152,6 +152,31 @@ and the Claude Code transcript is stored in Funky's Postgres — so a session su
 crashes and can be resumed by any worker, keeping turns fully stateless. Design and
 guarantees: [`packages/ports/harness/DESIGN.md`](packages/ports/harness/DESIGN.md).
 
+### Worker metrics (Prometheus scrape or OpenTelemetry push)
+
+The worker is instrumented with the OpenTelemetry metrics API; `FUNKY_METRICS` picks the
+export mechanism (comma-separated to combine):
+
+```bash
+# in .env
+FUNKY_METRICS=prometheus       # default: serve GET /metrics on the health port (:9090)
+FUNKY_METRICS=otlp             # push OTLP/HTTP to any receiver — configure with the
+                               # standard OTel env vars (OTEL_EXPORTER_OTLP_ENDPOINT,
+                               # OTEL_EXPORTER_OTLP_HEADERS, OTEL_METRIC_EXPORT_INTERVAL,
+                               # OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES)
+FUNKY_METRICS=gcm              # push directly to Google Cloud Monitoring
+FUNKY_METRICS=prometheus,otlp  # both at once
+```
+
+The default is unchanged from previous releases: self-hosted Prometheus keeps scraping
+`:9090/metrics`, and `/healthz` is untouched. `otlp` is the vendor-neutral push path for
+runtimes with no scraper (serverless workers) — it works with an otel-collector, Grafana,
+Datadog, Honeycomb, Google's OTLP ingest, or anything else that speaks OTLP.
+
+The metric names and label sets are a **stable contract** across all exporters — dashboards
+and alerts can key on them: `funky_queue_depth{state}`, `funky_worker_turns_inflight`,
+`funky_worker_jobs_total{outcome}`, `funky_worker_append_conflicts_total`.
+
 ### Tear down
 
 ```bash

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -16,6 +16,12 @@
   "dependencies": {
     "@funky/db": "workspace:*",
     "@funky/harness": "workspace:*",
+    "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.21.0",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.221.0",
+    "@opentelemetry/exporter-prometheus": "^0.221.0",
+    "@opentelemetry/resources": "^2.10.0",
+    "@opentelemetry/sdk-metrics": "^2.10.0",
     "@funky/llm": "workspace:*",
     "@funky/sandbox": "workspace:*",
     "@funky/sessions": "workspace:*",

--- a/apps/worker/src/config.ts
+++ b/apps/worker/src/config.ts
@@ -2,6 +2,7 @@
 // The only place process.env is read. dotenv is loaded by index.ts (entrypoint), not here.
 // Mirrors apps/api/src/config.ts: zod, fail-fast via process.exit(1); never boot half-configured.
 import { z } from "zod";
+import { METRICS_MODES, type MetricsMode } from "./telemetry";
 
 // Compose interpolation (`${VAR:-}`) delivers an UNSET optional secret as an EMPTY
 // STRING, not as a missing variable — treat "" as absent so the zero-key path boots.
@@ -15,6 +16,25 @@ const EnvSchema = z
     DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
     FUNKY_WORKER_CONCURRENCY: z.coerce.number().int().min(1).default(50),
     FUNKY_WORKER_HEALTH_PORT: z.coerce.number().int().min(1).max(65535).default(9090),
+    // Comma-separated metric exporters: "prometheus" (default; GET /metrics on the health
+    // port), "otlp" (push via OTEL_EXPORTER_OTLP_* env vars), "gcm" (direct to Google
+    // Cloud Monitoring). E.g. FUNKY_METRICS=prometheus,otlp.
+    FUNKY_METRICS: z.preprocess(
+      (v) => (v === "" ? undefined : v), // compose `${VAR:-}` sends "" for unset — use the default
+      z
+        .string()
+        .default("prometheus")
+        .transform((s) => [...new Set(s.split(",").map((m) => m.trim()).filter(Boolean))])
+        .pipe(
+          z
+            .array(
+              z.enum(METRICS_MODES, {
+                error: `FUNKY_METRICS entries must be one of: ${METRICS_MODES.join(", ")}`,
+              }),
+            )
+            .min(1, "FUNKY_METRICS must name at least one exporter"),
+        ),
+    ),
     FUNKY_LLM: z.enum(["fake", "ai-sdk"]).default("fake"),
     // docker (default): an isolated container per session on the local daemon — no account.
     // e2b: an isolated remote sandbox per session. (The in-process subprocess driver still
@@ -58,6 +78,8 @@ export type Config = {
   databaseUrl: string;
   concurrency: number;
   healthPort: number;
+  /** Metric exporters, deduped, in FUNKY_METRICS order. Default ["prometheus"]. */
+  metricsModes: MetricsMode[];
   llm: "fake" | "ai-sdk";
   sandbox: "docker" | "e2b";
   /** null = fake driver; no key needed. */
@@ -87,6 +109,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     databaseUrl: e.DATABASE_URL,
     concurrency: e.FUNKY_WORKER_CONCURRENCY,
     healthPort: e.FUNKY_WORKER_HEALTH_PORT,
+    metricsModes: e.FUNKY_METRICS,
     llm: e.FUNKY_LLM,
     sandbox: e.FUNKY_SANDBOX,
     anthropicApiKey: e.ANTHROPIC_API_KEY ?? null,

--- a/apps/worker/src/health.ts
+++ b/apps/worker/src/health.ts
@@ -1,18 +1,17 @@
-// apps/worker/src/health.ts — Phase E: liveness probe + Prometheus metrics.
+// apps/worker/src/health.ts — Phase E: liveness probe + metrics mount point.
 //
 // Plain node:http — NO Hono. This is plumbing, not an API. There is no readiness concept
 // for a worker: nothing routes to it, so /healthz is liveness only (a SELECT 1).
+// Metrics rendering lives in telemetry.ts (OTel); when prometheus mode is on, its
+// request handler is mounted here so /healthz and /metrics share one port, one server.
 
-import { createServer, type ServerResponse } from "node:http";
-import type { Metrics } from "./worker";
-
-export type QueueDepth = { queued: number; running: number; dead: number };
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 
 export type HealthDeps = {
   port: number;
   ping: () => Promise<unknown>; // SELECT 1 — liveness only
-  metrics: Metrics;
-  depth: () => Promise<QueueDepth>; // queue.depth() — the autoscaling signal
+  /** GET /metrics handler (telemetry.ts, prometheus mode). Absent → /metrics 404s. */
+  metricsHandler?: (req: IncomingMessage, res: ServerResponse) => void;
 };
 
 export type HealthServer = {
@@ -32,12 +31,8 @@ export function startHealthServer(deps: HealthDeps): Promise<HealthServer> {
         .catch(() => sendJson(res, 503, { status: "error" }));
       return;
     }
-    if (path === "/metrics") {
-      // Never let a transient depth() failure blank the worker's own counters.
-      deps
-        .depth()
-        .then((d) => sendText(res, 200, renderPrometheus(deps.metrics, d)))
-        .catch(() => sendText(res, 200, renderPrometheus(deps.metrics, null)));
+    if (path === "/metrics" && deps.metricsHandler) {
+      deps.metricsHandler(req, res);
       return;
     }
     sendJson(res, 404, { error: "not found" });
@@ -58,51 +53,7 @@ export function startHealthServer(deps: HealthDeps): Promise<HealthServer> {
   });
 }
 
-/** Render the minimum metric set in Prometheus text format. depth === null when the
- *  queue.depth() probe failed — the worker's own counters still render. */
-export function renderPrometheus(metrics: Metrics, depth: QueueDepth | null): string {
-  const lines: string[] = [];
-  const family = (name: string, type: string, help: string, samples: string[]) => {
-    lines.push(`# HELP ${name} ${help}`, `# TYPE ${name} ${type}`, ...samples);
-  };
-
-  family("funky_worker_turns_inflight", "gauge", "Turns currently in flight.", [
-    `funky_worker_turns_inflight ${metrics.inFlight}`,
-  ]);
-
-  family(
-    "funky_worker_jobs_total",
-    "counter",
-    "Jobs processed, by queue outcome.",
-    (Object.keys(metrics.jobs) as Array<keyof Metrics["jobs"]>).map(
-      (outcome) => `funky_worker_jobs_total{outcome="${outcome}"} ${metrics.jobs[outcome]}`,
-    ),
-  );
-
-  family(
-    "funky_worker_append_conflicts_total",
-    "counter",
-    "Conditional-append races lost to another worker (split-brain smoke detector).",
-    [`funky_worker_append_conflicts_total ${metrics.appendConflicts}`],
-  );
-
-  if (depth) {
-    family("funky_queue_depth", "gauge", "Jobs in the queue by state (autoscaling signal).", [
-      `funky_queue_depth{state="queued"} ${depth.queued}`,
-      `funky_queue_depth{state="running"} ${depth.running}`,
-      `funky_queue_depth{state="dead"} ${depth.dead}`,
-    ]);
-  }
-
-  return `${lines.join("\n")}\n`;
-}
-
 function sendJson(res: ServerResponse, status: number, body: unknown): void {
   res.writeHead(status, { "content-type": "application/json" });
   res.end(JSON.stringify(body));
-}
-
-function sendText(res: ServerResponse, status: number, body: string): void {
-  res.writeHead(status, { "content-type": "text/plain; version=0.0.4; charset=utf-8" });
-  res.end(body);
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -11,6 +11,7 @@ import { makeSandbox, type SandboxConfig } from "@funky/sandbox";
 import { EventStore, JobQueue } from "@funky/sessions";
 import { type Config, loadConfig } from "./config";
 import { startHealthServer } from "./health";
+import { startTelemetry } from "./telemetry";
 import { createMetrics, startWorker } from "./worker";
 
 // repo root .env, resolved from this file's location (cwd-independent), like apps/api.
@@ -41,6 +42,16 @@ const harness: HarnessPort | undefined = cfg.anthropicApiKey
     })
   : undefined;
 
+// OTel bridge over the shared metrics object; exporters per FUNKY_METRICS. The standard
+// OTEL_* env vars (endpoint, headers, interval, resource attributes) are read here and
+// natively by the SDK — index.ts is still the only funky file touching process.env.
+const telemetry = await startTelemetry({
+  modes: cfg.metricsModes,
+  metrics,
+  depth: () => queue.depth(),
+  env: process.env,
+});
+
 const worker = startWorker({
   queue,
   store,
@@ -56,13 +67,12 @@ const worker = startWorker({
 const health = await startHealthServer({
   port: cfg.healthPort,
   ping: () => pool.query("SELECT 1"),
-  metrics,
-  depth: () => queue.depth(),
+  ...(telemetry.metricsHandler ? { metricsHandler: telemetry.metricsHandler } : {}),
 });
 
 console.log(
   `funky-worker: concurrency=${cfg.concurrency} health=:${health.port} ` +
-    `llm=${cfg.llm} sandbox=${cfg.sandbox}`,
+    `llm=${cfg.llm} sandbox=${cfg.sandbox} metrics=${cfg.metricsModes.join(",")}`,
 );
 
 // The fake driver needs no API key: with no registered scripts every session runs the
@@ -101,6 +111,7 @@ async function shutdown(sig: string): Promise<void> {
   // safety net: if drain hasn't finished in 120s, exit anyway.
   setTimeout(() => process.exit(1), 120_000).unref();
   await worker.stop();
+  await telemetry.shutdown(); // final push-mode flush — while the pool is still alive
   await health.close();
   await listenClient.end();
   await pool.end();

--- a/apps/worker/src/telemetry.ts
+++ b/apps/worker/src/telemetry.ts
@@ -1,0 +1,218 @@
+// apps/worker/src/telemetry.ts — OpenTelemetry metrics: one MeterProvider, N exporters.
+//
+// The pull loop stays dumb: it mutates the plain `Metrics` object (worker.ts) and this
+// module bridges it to OTel with observable instruments, read lazily at export time.
+// Which exporters run is deploy-time configuration (FUNKY_METRICS, parsed in config.ts):
+//
+//   prometheus (default) — pull: a request handler for GET /metrics on the health server.
+//   otlp                 — push over OTLP/HTTP; endpoint/headers/interval come from the
+//                          standard OTEL_EXPORTER_OTLP_* / OTEL_METRIC_EXPORT_INTERVAL
+//                          env vars (the SDK reads them natively — no invented config).
+//   gcm                  — push straight to Google Cloud Monitoring; the exporter is
+//                          dynamic-imported so non-Google deploys never load it.
+//
+// METRIC NAMES AND LABEL SETS ARE A STABLE CONTRACT — downstream dashboards and alerts
+// key on them. The four series: funky_queue_depth{state}, funky_worker_turns_inflight,
+// funky_worker_jobs_total{outcome}, funky_worker_append_conflicts_total.
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { diag, DiagConsoleLogger, DiagLogLevel, type Meter } from "@opentelemetry/api";
+import { PrometheusExporter } from "@opentelemetry/exporter-prometheus";
+import {
+  detectResources,
+  envDetector,
+  defaultResource,
+  resourceFromAttributes,
+  type Resource,
+} from "@opentelemetry/resources";
+import {
+  MeterProvider,
+  PeriodicExportingMetricReader,
+  type IMetricReader,
+} from "@opentelemetry/sdk-metrics";
+import type { Metrics } from "./worker";
+
+export const METRICS_MODES = ["prometheus", "otlp", "gcm"] as const;
+export type MetricsMode = (typeof METRICS_MODES)[number];
+
+export type QueueDepth = { queued: number; running: number; dead: number };
+
+export type TelemetryDeps = {
+  modes: readonly MetricsMode[];
+  metrics: Metrics; // shared mutable counters — the source of truth, owned by the pull loop
+  depth: () => Promise<QueueDepth>; // queue.depth() — the autoscaling signal
+  /** OTEL_* standard vars. Only index.ts passes process.env here (and the OTel SDK
+   *  additionally reads its own OTEL_* config from process.env natively). */
+  env?: NodeJS.ProcessEnv;
+  /** Test seam: where the GCP metadata server lives. */
+  metadataBaseUrl?: string;
+};
+
+export type Telemetry = {
+  /** Present iff "prometheus" mode is on. Mount at GET /metrics on the health server. */
+  metricsHandler?: (req: IncomingMessage, res: ServerResponse) => void;
+  /** Final flush (push modes) + release. Call while the DB pool is still alive. */
+  shutdown(): Promise<void>;
+};
+
+export async function startTelemetry(deps: TelemetryDeps): Promise<Telemetry> {
+  const env = deps.env ?? {};
+  // Export failures must be visible but bounded and non-fatal: the SDK routes them
+  // through diag, one line per failed export — never an exception into the pull loop.
+  diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ERROR);
+
+  const resource = await buildResource({ env, ...(deps.metadataBaseUrl ? { metadataBaseUrl: deps.metadataBaseUrl } : {}) });
+
+  const readers: IMetricReader[] = [];
+  let metricsHandler: Telemetry["metricsHandler"];
+  for (const mode of deps.modes) {
+    switch (mode) {
+      case "prometheus": {
+        // withoutScopeInfo: label sets are frozen — no otel_scope_name on the series.
+        // (target_info stays: a new, additive family that breaks no existing query.)
+        const exporter = new PrometheusExporter({ preventServerStart: true, withoutScopeInfo: true });
+        readers.push(exporter);
+        metricsHandler = (req, res) => void exporter.getMetricsRequestHandler(req, res);
+        break;
+      }
+      case "otlp": {
+        const { OTLPMetricExporter } = await import("@opentelemetry/exporter-metrics-otlp-http");
+        readers.push(
+          new PeriodicExportingMetricReader({
+            exporter: new OTLPMetricExporter(), // endpoint/headers/timeout from OTEL_EXPORTER_OTLP_*
+            exportIntervalMillis: exportIntervalMs(env),
+          }),
+        );
+        break;
+      }
+      case "gcm": {
+        // Optional convenience for Google deploys; dynamic import keeps the module —
+        // and its transitive google-auth machinery — out of every other deploy's boot.
+        const { MetricExporter } = await import(
+          "@google-cloud/opentelemetry-cloud-monitoring-exporter"
+        );
+        readers.push(
+          new PeriodicExportingMetricReader({
+            exporter: new MetricExporter(),
+            exportIntervalMillis: exportIntervalMs(env),
+          }),
+        );
+        break;
+      }
+    }
+  }
+
+  const provider = new MeterProvider({ resource, readers });
+  registerInstruments(provider.getMeter("funky-worker"), deps.metrics, deps.depth);
+
+  return {
+    ...(metricsHandler ? { metricsHandler } : {}),
+    shutdown: () => provider.shutdown(),
+  };
+}
+
+/** Resource identity is set EXPLICITLY — never inferred from platform env vars like
+ *  K_SERVICE (Cloud Run worker pools don't get them; that failure is why this module
+ *  exists). On GCP the metadata server is the authority for region/instance; elsewhere
+ *  the probe silently misses. OTEL_SERVICE_NAME / OTEL_RESOURCE_ATTRIBUTES merge last,
+ *  so any deploy can override or extend. */
+export async function buildResource(opts: {
+  env: NodeJS.ProcessEnv;
+  metadataBaseUrl?: string;
+}): Promise<Resource> {
+  const gcp = await probeGcpMetadata(opts.metadataBaseUrl);
+  const explicit = resourceFromAttributes({
+    "service.name": "funky-worker",
+    ...(gcp
+      ? {
+          "cloud.region": gcp.region,
+          "service.instance.id": gcp.instanceId,
+          "faas.instance": gcp.instanceId,
+        }
+      : {}),
+  });
+  // envDetector reads OTEL_RESOURCE_ATTRIBUTES + OTEL_SERVICE_NAME from process.env.
+  // Merged last: the operator's env wins over our defaults.
+  return defaultResource().merge(explicit).merge(detectResources({ detectors: [envDetector] }));
+}
+
+const GCP_METADATA_BASE = "http://metadata.google.internal";
+
+/** Works identically on Cloud Run services, jobs, and worker pools. Short timeout,
+ *  null on any failure — off GCP this must cost almost nothing and never throw. */
+async function probeGcpMetadata(
+  baseUrl: string = GCP_METADATA_BASE,
+): Promise<{ region: string; instanceId: string } | null> {
+  const get = async (path: string): Promise<string> => {
+    const res = await fetch(`${baseUrl}/computeMetadata/v1/instance/${path}`, {
+      headers: { "Metadata-Flavor": "Google" },
+      signal: AbortSignal.timeout(1_000),
+    });
+    if (!res.ok) throw new Error(`metadata ${path}: ${res.status}`);
+    return res.text();
+  };
+  try {
+    const [regionPath, instanceId] = await Promise.all([get("region"), get("id")]);
+    // region arrives as "projects/<num>/regions/<region>" — keep the last segment.
+    const region = regionPath.split("/").pop() || regionPath;
+    return { region, instanceId };
+  } catch {
+    return null;
+  }
+}
+
+/** OTEL_METRIC_EXPORT_INTERVAL (ms) — the standard env var; spec default 60s.
+ *  The JS SDK only applies it inside NodeSDK, so the standalone reader reads it here. */
+function exportIntervalMs(env: NodeJS.ProcessEnv): number {
+  const n = Number(env.OTEL_METRIC_EXPORT_INTERVAL);
+  return Number.isFinite(n) && n > 0 ? n : 60_000;
+}
+
+/** Observable instruments over the shared Metrics object. Counter instruments are named
+ *  WITHOUT the `_total` suffix — the OTel→Prometheus renderer appends it to monotonic
+ *  counters, so "funky_worker_jobs" is exactly what ships as funky_worker_jobs_total
+ *  (naming it with the suffix would ship funky_worker_jobs_total_total). */
+function registerInstruments(
+  meter: Meter,
+  metrics: Metrics,
+  depth: () => Promise<QueueDepth>,
+): void {
+  meter
+    .createObservableGauge("funky_worker_turns_inflight", {
+      description: "Turns currently in flight.",
+    })
+    .addCallback((r) => r.observe(metrics.inFlight));
+
+  meter
+    .createObservableCounter("funky_worker_jobs", {
+      description: "Jobs processed, by queue outcome.",
+    })
+    .addCallback((r) => {
+      for (const outcome of Object.keys(metrics.jobs) as Array<keyof Metrics["jobs"]>) {
+        r.observe(metrics.jobs[outcome], { outcome });
+      }
+    });
+
+  meter
+    .createObservableCounter("funky_worker_append_conflicts", {
+      description:
+        "Conditional-append races lost to another worker (split-brain smoke detector).",
+    })
+    .addCallback((r) => r.observe(metrics.appendConflicts));
+
+  meter
+    .createObservableGauge("funky_queue_depth", {
+      description: "Jobs in the queue by state (autoscaling signal).",
+    })
+    .addCallback(async (r) => {
+      try {
+        const d = await depth();
+        r.observe(d.queued, { state: "queued" });
+        r.observe(d.running, { state: "running" });
+        r.observe(d.dead, { state: "dead" });
+      } catch {
+        // Probe failed: skip the observation — never report zeros that lie. The
+        // worker's own counters still export.
+      }
+    });
+}

--- a/apps/worker/test/config.test.ts
+++ b/apps/worker/test/config.test.ts
@@ -25,6 +25,7 @@ describe("loadConfig — valid input", () => {
       databaseUrl: BASE.DATABASE_URL,
       concurrency: 50,
       healthPort: 9090,
+      metricsModes: ["prometheus"],
       llm: "fake",
       sandbox: "docker",
       anthropicApiKey: null,
@@ -54,6 +55,22 @@ describe("loadConfig — valid input", () => {
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
+  it("parses FUNKY_METRICS: default, single, comma list (spaces ok), dedupe, '' as unset", () => {
+    expect(loadConfig(BASE).metricsModes).toEqual(["prometheus"]);
+    expect(loadConfig({ ...BASE, FUNKY_METRICS: "otlp" }).metricsModes).toEqual(["otlp"]);
+    expect(loadConfig({ ...BASE, FUNKY_METRICS: "prometheus, otlp" }).metricsModes).toEqual([
+      "prometheus",
+      "otlp",
+    ]);
+    expect(loadConfig({ ...BASE, FUNKY_METRICS: "otlp,otlp,gcm" }).metricsModes).toEqual([
+      "otlp",
+      "gcm",
+    ]);
+    // compose `${VAR:-}` sends "" for unset — falls back to the default
+    expect(loadConfig({ ...BASE, FUNKY_METRICS: "" }).metricsModes).toEqual(["prometheus"]);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
   it("parses a fully-specified environment", () => {
     const cfg = loadConfig({
       ...BASE,
@@ -67,11 +84,13 @@ describe("loadConfig — valid input", () => {
       FUNKY_E2B_SANDBOX_TIMEOUT_MS: "600000",
       FUNKY_HARNESS_CWD_ROOT: "/var/funky/cwd",
       FUNKY_HARNESS_SCRATCH_ROOT: "/dev/shm/funky",
+      FUNKY_METRICS: "prometheus,otlp",
     });
     expect(cfg).toEqual({
       databaseUrl: BASE.DATABASE_URL,
       concurrency: 8,
       healthPort: 9191,
+      metricsModes: ["prometheus", "otlp"],
       llm: "ai-sdk",
       sandbox: "e2b",
       anthropicApiKey: "sk-ant-secret",
@@ -103,6 +122,9 @@ describe("loadConfig — invalid input exits the process", () => {
     ["unknown FUNKY_SANDBOX", { ...BASE, FUNKY_SANDBOX: "podman" }],
     ["subprocess is not a production sandbox option", { ...BASE, FUNKY_SANDBOX: "subprocess" }],
     ["DB_POOL_MAX below 1", { ...BASE, DB_POOL_MAX: "0" }],
+    ["unknown FUNKY_METRICS mode", { ...BASE, FUNKY_METRICS: "statsd" }],
+    ["unknown mode mixed into a valid list", { ...BASE, FUNKY_METRICS: "prometheus,statsd" }],
+    ["FUNKY_METRICS with no modes at all", { ...BASE, FUNKY_METRICS: "," }],
   ])("exits on %s", (_label, env) => {
     expect(() => loadConfig(env as NodeJS.ProcessEnv)).toThrow("process.exit(1)");
     expect(exitSpy).toHaveBeenCalledWith(1);

--- a/apps/worker/test/health.test.ts
+++ b/apps/worker/test/health.test.ts
@@ -1,37 +1,8 @@
-// health.ts is plumbing: a plain node:http server + a pure Prometheus renderer. No DB here
-// — the renderer is exercised directly, and the server with fake ping/depth probes.
+// health.ts is plumbing: a plain node:http server with /healthz (liveness) and an
+// injected /metrics handler (telemetry.ts owns rendering). Exercised with fakes here;
+// the real prometheus handler is covered in telemetry.test.ts.
 import { afterEach, describe, expect, it } from "vitest";
-import { type HealthServer, renderPrometheus, startHealthServer } from "../src/health";
-import { createMetrics } from "../src/worker";
-
-const okDepth = async () => ({ queued: 0, running: 0, dead: 0 });
-
-describe("renderPrometheus", () => {
-  it("emits every required metric family", () => {
-    const m = createMetrics();
-    m.inFlight = 3;
-    m.jobs.completed = 10;
-    m.jobs.retry_later = 2;
-    m.appendConflicts = 1;
-    const out = renderPrometheus(m, { queued: 4, running: 3, dead: 0 });
-
-    expect(out).toContain("# TYPE funky_worker_turns_inflight gauge");
-    expect(out).toContain("funky_worker_turns_inflight 3");
-    expect(out).toContain("# TYPE funky_worker_jobs_total counter");
-    expect(out).toContain('funky_worker_jobs_total{outcome="completed"} 10');
-    expect(out).toContain('funky_worker_jobs_total{outcome="retry_later"} 2');
-    expect(out).toContain('funky_worker_jobs_total{outcome="conflict"} 0');
-    expect(out).toContain("funky_worker_append_conflicts_total 1");
-    expect(out).toContain('funky_queue_depth{state="queued"} 4');
-    expect(out).toContain('funky_queue_depth{state="running"} 3');
-  });
-
-  it("omits queue depth when the probe is unavailable", () => {
-    const out = renderPrometheus(createMetrics(), null);
-    expect(out).not.toContain("funky_queue_depth");
-    expect(out).toContain("funky_worker_turns_inflight 0");
-  });
-});
+import { type HealthServer, startHealthServer } from "../src/health";
 
 describe("health server", () => {
   let server: HealthServer | undefined;
@@ -41,12 +12,7 @@ describe("health server", () => {
   });
 
   it("returns 200 {status:ok} on /healthz when ping resolves", async () => {
-    server = await startHealthServer({
-      port: 0,
-      ping: async () => 1,
-      metrics: createMetrics(),
-      depth: okDepth,
-    });
+    server = await startHealthServer({ port: 0, ping: async () => 1 });
     const res = await fetch(`http://localhost:${server.port}/healthz`);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ status: "ok" });
@@ -58,37 +24,33 @@ describe("health server", () => {
       ping: async () => {
         throw new Error("db down");
       },
-      metrics: createMetrics(),
-      depth: okDepth,
     });
     const res = await fetch(`http://localhost:${server.port}/healthz`);
     expect(res.status).toBe(503);
   });
 
-  it("serves /metrics as Prometheus text", async () => {
-    const m = createMetrics();
-    m.inFlight = 2;
+  it("dispatches /metrics to the injected handler", async () => {
     server = await startHealthServer({
       port: 0,
       ping: async () => 1,
-      metrics: m,
-      depth: async () => ({ queued: 5, running: 2, dead: 1 }),
+      metricsHandler: (_req, res) => {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("funky_worker_turns_inflight 2\n");
+      },
     });
     const res = await fetch(`http://localhost:${server.port}/metrics`);
     expect(res.status).toBe(200);
-    expect(res.headers.get("content-type")).toContain("text/plain");
-    const body = await res.text();
-    expect(body).toContain("funky_worker_turns_inflight 2");
-    expect(body).toContain('funky_queue_depth{state="dead"} 1');
+    expect(await res.text()).toContain("funky_worker_turns_inflight 2");
+  });
+
+  it("404s /metrics when no handler is mounted (otlp-only deploys)", async () => {
+    server = await startHealthServer({ port: 0, ping: async () => 1 });
+    const res = await fetch(`http://localhost:${server.port}/metrics`);
+    expect(res.status).toBe(404);
   });
 
   it("404s unknown paths", async () => {
-    server = await startHealthServer({
-      port: 0,
-      ping: async () => 1,
-      metrics: createMetrics(),
-      depth: okDepth,
-    });
+    server = await startHealthServer({ port: 0, ping: async () => 1 });
     const res = await fetch(`http://localhost:${server.port}/nope`);
     expect(res.status).toBe(404);
   });

--- a/apps/worker/test/telemetry.test.ts
+++ b/apps/worker/test/telemetry.test.ts
@@ -1,0 +1,212 @@
+// telemetry.ts bridges the plain Metrics object to OTel exporters. The metric names and
+// label sets are a FROZEN contract (dashboards/alerts key on them) — the prometheus tests
+// here are the guard: they pin the four exact families, including the OTel→Prometheus
+// rule that a counter instrument named funky_worker_jobs renders as funky_worker_jobs_total.
+import { createServer, type Server } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildResource, startTelemetry, type Telemetry } from "../src/telemetry";
+import { createMetrics } from "../src/worker";
+
+const okDepth = async () => ({ queued: 4, running: 3, dead: 0 });
+
+const cleanups: Array<() => Promise<unknown> | void> = [];
+afterEach(async () => {
+  // LIFO: telemetry shuts down (final push-mode flush) BEFORE its receiver closes —
+  // flushing at a dead endpoint burns seconds in exporter retries.
+  for (const c of cleanups.splice(0).reverse()) await c();
+  for (const k of ["OTEL_SERVICE_NAME", "OTEL_RESOURCE_ATTRIBUTES", "OTEL_EXPORTER_OTLP_ENDPOINT"]) {
+    delete process.env[k];
+  }
+});
+
+/** A 200-OK OTLP/HTTP receiver capturing request bodies (the -http exporter sends JSON). */
+async function otlpReceiver(): Promise<{ bodies: string[]; port: number }> {
+  const bodies: string[] = [];
+  const srv: Server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (c) => (body += c));
+    req.on("end", () => {
+      bodies.push(body);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end("{}");
+    });
+  });
+  await new Promise<void>((r) => srv.listen(0, () => r()));
+  const addr = srv.address();
+  const port = addr && typeof addr === "object" ? addr.port : 0;
+  cleanups.push(() => new Promise<void>((r) => srv.close(() => r())));
+  return { bodies, port };
+}
+
+/** Serve a telemetry's prometheus handler on an ephemeral port; return a scrape fn. */
+async function serveMetrics(t: Telemetry): Promise<() => Promise<string>> {
+  const srv = createServer((req, res) => t.metricsHandler?.(req, res));
+  await new Promise<void>((r) => srv.listen(0, () => r()));
+  const addr = srv.address();
+  const port = addr && typeof addr === "object" ? addr.port : 0;
+  cleanups.push(() => new Promise<void>((r) => srv.close(() => r())));
+  return async () => (await fetch(`http://localhost:${port}/metrics`)).text();
+}
+
+describe("prometheus mode — the frozen name/label contract", () => {
+  it("renders exactly the four families, byte-identical names and labels", async () => {
+    const m = createMetrics();
+    m.inFlight = 3;
+    m.jobs.completed = 10;
+    m.jobs.retry_later = 2;
+    m.appendConflicts = 1;
+    const t = await startTelemetry({ modes: ["prometheus"], metrics: m, depth: okDepth });
+    cleanups.push(() => t.shutdown());
+    const scrape = await serveMetrics(t);
+    const out = await scrape();
+
+    expect(out).toContain("# TYPE funky_worker_turns_inflight gauge");
+    expect(out).toContain("funky_worker_turns_inflight 3");
+    expect(out).toContain("# TYPE funky_worker_jobs_total counter");
+    expect(out).toContain('funky_worker_jobs_total{outcome="completed"} 10');
+    expect(out).toContain('funky_worker_jobs_total{outcome="retry_later"} 2');
+    expect(out).toContain('funky_worker_jobs_total{outcome="conflict"} 0');
+    expect(out).toContain("# TYPE funky_worker_append_conflicts_total counter");
+    expect(out).toContain("funky_worker_append_conflicts_total 1");
+    expect(out).toContain("# TYPE funky_queue_depth gauge");
+    expect(out).toContain('funky_queue_depth{state="queued"} 4');
+    expect(out).toContain('funky_queue_depth{state="running"} 3');
+    expect(out).toContain('funky_queue_depth{state="dead"} 0');
+
+    // The naming rule this file exists to guard: instrument "funky_worker_jobs" must
+    // ship as funky_worker_jobs_total — and never doubled.
+    expect(out).not.toContain("_total_total");
+    // Frozen label sets: no otel_scope_name smuggled onto the series.
+    expect(out).not.toContain("otel_scope_name");
+  });
+
+  it("reflects live mutation of the shared Metrics object (the OTel path, end to end)", async () => {
+    const m = createMetrics();
+    const t = await startTelemetry({ modes: ["prometheus"], metrics: m, depth: okDepth });
+    cleanups.push(() => t.shutdown());
+    const scrape = await serveMetrics(t);
+
+    expect(await scrape()).toContain('funky_worker_jobs_total{outcome="completed"} 0');
+    m.jobs.completed += 1;
+    expect(await scrape()).toContain('funky_worker_jobs_total{outcome="completed"} 1');
+  });
+
+  it("omits funky_queue_depth when the probe fails — the worker's own counters still render", async () => {
+    const t = await startTelemetry({
+      modes: ["prometheus"],
+      metrics: createMetrics(),
+      depth: async () => {
+        throw new Error("db down");
+      },
+    });
+    cleanups.push(() => t.shutdown());
+    const out = await (await serveMetrics(t))();
+    expect(out).not.toContain("funky_queue_depth{");
+    expect(out).toContain("funky_worker_turns_inflight 0");
+  });
+
+  it("exposes no prometheus handler in otlp-only mode", async () => {
+    const { port } = await otlpReceiver();
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = `http://localhost:${port}`;
+    const t = await startTelemetry({ modes: ["otlp"], metrics: createMetrics(), depth: okDepth });
+    cleanups.push(() => t.shutdown());
+    expect(t.metricsHandler).toBeUndefined();
+  });
+});
+
+describe("otlp mode", () => {
+  it("pushes the four series with service.name=funky-worker to an OTLP/HTTP receiver", async () => {
+    const { bodies, port } = await otlpReceiver();
+
+    // The standard env vars are the interface — no invented config.
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = `http://localhost:${port}`;
+    const m = createMetrics();
+    m.jobs.completed = 7;
+    const t = await startTelemetry({
+      modes: ["otlp"],
+      metrics: m,
+      depth: okDepth,
+      env: { OTEL_METRIC_EXPORT_INTERVAL: "50" },
+    });
+    cleanups.push(() => t.shutdown());
+
+    const deadline = Date.now() + 5_000;
+    while (bodies.length === 0 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(bodies.length).toBeGreaterThan(0);
+
+    const payload = JSON.parse(bodies[0] as string);
+    const rm = payload.resourceMetrics[0];
+    const resourceAttrs = Object.fromEntries(
+      rm.resource.attributes.map((a: { key: string; value: { stringValue?: string } }) => [
+        a.key,
+        a.value.stringValue,
+      ]),
+    );
+    expect(resourceAttrs["service.name"]).toBe("funky-worker");
+
+    const metricsByName = new Map<string, { name: string; sum?: unknown; gauge?: unknown }>();
+    for (const sm of rm.scopeMetrics) {
+      for (const metric of sm.metrics) metricsByName.set(metric.name, metric);
+    }
+    // Over OTLP the instrument name travels un-suffixed; the backend's Prometheus
+    // renderer appends _total to the monotonic sums.
+    expect([...metricsByName.keys()].sort()).toEqual([
+      "funky_queue_depth",
+      "funky_worker_append_conflicts",
+      "funky_worker_jobs",
+      "funky_worker_turns_inflight",
+    ]);
+    expect(metricsByName.get("funky_worker_jobs")?.sum).toMatchObject({ isMonotonic: true });
+  });
+});
+
+describe("buildResource — explicit identity, no platform env guessing", () => {
+  /** A fake GCP metadata server (Cloud Run worker pools have one; K_SERVICE they don't). */
+  async function fakeMetadataServer(): Promise<string> {
+    const srv = createServer((req, res) => {
+      if (req.headers["metadata-flavor"] !== "Google") {
+        res.writeHead(403).end();
+        return;
+      }
+      if (req.url?.endsWith("/instance/region")) {
+        res.writeHead(200).end("projects/12345/regions/us-central1");
+      } else if (req.url?.endsWith("/instance/id")) {
+        res.writeHead(200).end("instance-abc-123");
+      } else {
+        res.writeHead(404).end();
+      }
+    });
+    await new Promise<void>((r) => srv.listen(0, () => r()));
+    const addr = srv.address();
+    const port = addr && typeof addr === "object" ? addr.port : 0;
+    cleanups.push(() => new Promise<void>((r) => srv.close(() => r())));
+    return `http://localhost:${port}`;
+  }
+
+  it("stamps region + instance id from the metadata server when present", async () => {
+    const base = await fakeMetadataServer();
+    const r = await buildResource({ env: {}, metadataBaseUrl: base });
+    expect(r.attributes["service.name"]).toBe("funky-worker");
+    expect(r.attributes["cloud.region"]).toBe("us-central1");
+    expect(r.attributes["service.instance.id"]).toBe("instance-abc-123");
+    expect(r.attributes["faas.instance"]).toBe("instance-abc-123");
+  });
+
+  it("silently skips GCP attributes when the metadata server is absent", async () => {
+    const r = await buildResource({ env: {}, metadataBaseUrl: "http://127.0.0.1:1" });
+    expect(r.attributes["service.name"]).toBe("funky-worker");
+    expect(r.attributes["cloud.region"]).toBeUndefined();
+    expect(r.attributes["faas.instance"]).toBeUndefined();
+  });
+
+  it("honors OTEL_SERVICE_NAME and merges OTEL_RESOURCE_ATTRIBUTES (operator wins)", async () => {
+    process.env.OTEL_SERVICE_NAME = "renamed-worker";
+    process.env.OTEL_RESOURCE_ATTRIBUTES = "deployment.environment=prod,cloud.region=eu-west1";
+    const r = await buildResource({ env: process.env, metadataBaseUrl: "http://127.0.0.1:1" });
+    expect(r.attributes["service.name"]).toBe("renamed-worker");
+    expect(r.attributes["deployment.environment"]).toBe("prod");
+    expect(r.attributes["cloud.region"]).toBe("eu-west1");
+  });
+});

--- a/apps/worker/test/worker.test.ts
+++ b/apps/worker/test/worker.test.ts
@@ -24,6 +24,8 @@ import type { LlmPort } from "@funky/llm";
 import { FakeLlm } from "@funky/llm";
 import { type SandboxDriver, SubprocessDriver } from "@funky/sandbox";
 import { EventStore, JobQueue, makeEvent, textContent } from "@funky/sessions";
+import { startHealthServer } from "../src/health";
+import { startTelemetry } from "../src/telemetry";
 import { createMetrics, startWorker, type WorkerHandle } from "../src/worker";
 
 // testcontainers' Ryuk reaper pulls its own image; disable it and rely on afterAll.
@@ -259,6 +261,32 @@ it("respects the concurrency limit (backpressure)", async () => {
 
   expect(maxInFlight).toBeGreaterThan(0);
   expect(maxInFlight).toBeLessThanOrEqual(2); // turns_inflight never exceeds the limit
+});
+
+it("exports a completed turn through the OTel prometheus path (frozen-name contract, end to end)", async () => {
+  const { metrics } = await startTestWorker({ llm: doneLlm() });
+  const telemetry = await startTelemetry({
+    modes: ["prometheus"],
+    metrics,
+    depth: () => queue.depth(),
+  });
+  cleanups.push(() => telemetry.shutdown());
+  const health = await startHealthServer({
+    port: 0,
+    ping: async () => 1,
+    ...(telemetry.metricsHandler ? { metricsHandler: telemetry.metricsHandler } : {}),
+  });
+  cleanups.push(() => health.close());
+
+  const sid = await seedSession();
+  await appendUser(sid);
+  await insertTurnJob(sid);
+  await waitFor(() => metrics.jobs.completed >= 1, 15_000, "turn completed");
+
+  const body = await (await fetch(`http://localhost:${health.port}/metrics`)).text();
+  expect(body).toContain('funky_worker_jobs_total{outcome="completed"} 1');
+  expect(body).toContain("funky_worker_turns_inflight 0");
+  expect(body).toContain('funky_queue_depth{state="queued"}'); // live probe, same DB
 });
 
 it("NACKs a retry_later outcome (job stays queued with a future run_at)", async () => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,14 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-} # empty unless the user sets it
       E2B_API_KEY: ${E2B_API_KEY:-} # empty unless the user sets it
       FUNKY_E2B_SANDBOX_TIMEOUT_MS: ${FUNKY_E2B_SANDBOX_TIMEOUT_MS:-1800000}
+      # Metric exporters: "prometheus" (default, scrape :9090/metrics), "otlp" (push via
+      # the standard OTEL_* env vars below), "gcm", or a comma-separated combination.
+      FUNKY_METRICS: ${FUNKY_METRICS:-}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      OTEL_EXPORTER_OTLP_HEADERS: ${OTEL_EXPORTER_OTLP_HEADERS:-}
+      OTEL_METRIC_EXPORT_INTERVAL: ${OTEL_METRIC_EXPORT_INTERVAL:-}
+      OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-}
+      OTEL_RESOURCE_ATTRIBUTES: ${OTEL_RESOURCE_ATTRIBUTES:-}
       # Harness (agents with runtime=claude-code). CWD_ROOT must be identical across
       # every worker replica — the transcript store's key derives from it.
       FUNKY_HARNESS_SCRATCH_ROOT: /dev/shm/funky-harness

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   apps/web:
     dependencies:
@@ -118,6 +118,24 @@ importers:
       '@funky/sessions':
         specifier: workspace:*
         version: link:../../packages/sessions
+      '@google-cloud/opentelemetry-cloud-monitoring-exporter':
+        specifier: ^0.21.0
+        version: 0.21.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+      '@opentelemetry/exporter-metrics-otlp-http':
+        specifier: ^0.221.0
+        version: 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-prometheus':
+        specifier: ^0.221.0
+        version: 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: ^2.10.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics':
+        specifier: ^2.10.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
       dotenv:
         specifier: ^17.2.0
         version: 17.4.2
@@ -148,7 +166,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   packages/configs:
     dependencies:
@@ -157,7 +175,7 @@ importers:
         version: link:../db
       drizzle-orm:
         specifier: ^1.0.0-beta.2
-        version: 1.0.0-rc.4-5d5b77c(@electric-sql/pglite@0.5.4)(@types/pg@8.20.0)(pg@8.22.0)(zod@4.4.3)
+        version: 1.0.0-rc.4-5d5b77c(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)(zod@4.4.3)
       uuid:
         specifier: ^13.0.0
         version: 13.0.2
@@ -167,13 +185,13 @@ importers:
         version: 0.5.4
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   packages/db:
     dependencies:
       drizzle-orm:
         specifier: ^1.0.0-beta.2
-        version: 1.0.0-rc.4-5d5b77c(@electric-sql/pglite@0.5.4)(@types/pg@8.20.0)(pg@8.22.0)(zod@4.4.3)
+        version: 1.0.0-rc.4-5d5b77c(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)(zod@4.4.3)
       pg:
         specifier: ^8.22.0
         version: 8.22.0
@@ -192,7 +210,7 @@ importers:
         version: 1.0.0-rc.4-ca0f029
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   packages/ports/harness:
     dependencies:
@@ -210,7 +228,7 @@ importers:
         version: link:../../sessions
       drizzle-orm:
         specifier: ^1.0.0-beta.2
-        version: 1.0.0-rc.4-5d5b77c(@electric-sql/pglite@0.5.4)(@types/pg@8.20.0)(pg@8.22.0)(zod@4.4.3)
+        version: 1.0.0-rc.4-5d5b77c(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)(zod@4.4.3)
       zod:
         specifier: ^4.0.0
         version: 4.4.3
@@ -226,7 +244,7 @@ importers:
         version: 8.22.0
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   packages/ports/llm:
     dependencies:
@@ -251,7 +269,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   packages/ports/sandbox:
     dependencies:
@@ -270,7 +288,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   packages/sessions:
     dependencies:
@@ -291,7 +309,7 @@ importers:
         version: link:../ports/sandbox
       drizzle-orm:
         specifier: ^1.0.0-beta.2
-        version: 1.0.0-rc.4-5d5b77c(@electric-sql/pglite@0.5.4)(@types/pg@8.20.0)(pg@8.22.0)(zod@4.4.3)
+        version: 1.0.0-rc.4-5d5b77c(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)(zod@4.4.3)
       pg:
         specifier: ^8.22.0
         version: 8.22.0
@@ -310,7 +328,7 @@ importers:
         version: 8.20.0
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   tests/chaos:
     dependencies:
@@ -347,7 +365,7 @@ importers:
         version: 8.20.0
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
 packages:
 
@@ -793,6 +811,26 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@google-cloud/opentelemetry-cloud-monitoring-exporter@0.21.0':
+    resolution: {integrity: sha512-+lAew44pWt6rA4l8dQ1gGhH7Uo95wZKfq/GBf9aEyuNDDLQ2XppGEEReu6ujesSqTtZ8ueQFt73+7SReSHbwqg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^2.0.0
+      '@opentelemetry/resources': ^2.0.0
+      '@opentelemetry/sdk-metrics': ^2.0.0
+
+  '@google-cloud/opentelemetry-resource-util@3.0.0':
+    resolution: {integrity: sha512-CGR/lNzIfTKlZoZFfS6CkVzx+nsC9gzy6S8VcyaLegfEJbiPjxbMLP7csyhJTvZe/iRRcQJxSk0q8gfrGqD3/Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/core': ^2.0.0
+      '@opentelemetry/resources': ^2.0.0
+
+  '@google-cloud/precise-date@4.0.0':
+    resolution: {integrity: sha512-1TUx3KdaU3cN7nfCdNf+UVqA/PSX29Cjcox3fZZBtINlRrXVTmUkQnCKv2MbBUbCopbK4olAT1IHl76uZyCiVA==}
+    engines: {node: '>=14.0.0'}
+
   '@grpc/grpc-js@1.14.4':
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
@@ -865,6 +903,72 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@opentelemetry/api-logs@0.221.0':
+    resolution: {integrity: sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.221.0':
+    resolution: {integrity: sha512-sRfCKbOzgy8xZQV2as0RzIZlnCmCseCKZGLfRcrpo2CBngJDr+rPtX0zkG0+oUCV5kfQPUoW3W3C96Ag3Y/Clg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-prometheus@0.221.0':
+    resolution: {integrity: sha512-kW79a20qWESIuAdDrxzg9WKM98twV/NBWBFRAH57ap/+ssZhiCo0hckzKT0zpuwR/gSHrFAQhJL0bYDrnEM34g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.221.0':
+    resolution: {integrity: sha512-UFPIq80OH3Ns/oPFHRj14d4DTOxUo+MUFU8hUiCq5jTqFhdeJnfVSANHT+xp92409cA+oxzvlZCe6NM1wvCuBA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.221.0':
+    resolution: {integrity: sha512-lg6lkOU08Az23jVcn/0Els9HP+V8PnR4Km6p0KgpTggS0n/WuhnmY64rSh83Of9iR9nD+dpWr6adlcX8KzAwjg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.221.0':
+    resolution: {integrity: sha512-FaDcazjyMp7TZZZAsqbo4IkovP0UegoCu0EBkiNt+qCqvUf7FPAsfcrZ3+ZEkKgXZ/jHafop+JoGPDk3A0SmLg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.10.0':
+    resolution: {integrity: sha512-t6r1VSvXNtSDnPXU1FbZeetJb7yyovHmgu0wRSoftxtE0g2rSNhQZQUy69sRUCL+iioJpX8SN/S6wq6ZtvLySQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
@@ -1219,6 +1323,10 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ai@7.0.22:
     resolution: {integrity: sha512-iAXYwQtR18qN7GXwNmGVAQM4uSJOh2+nZ5RP9NtDXfH5d4tlYyYzAM133O3U+eVcyWrvNRzecN9yW58xpCdfMg==}
     engines: {node: '>=22'}
@@ -1331,6 +1439,9 @@ packages:
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -1348,6 +1459,9 @@ packages:
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -1633,6 +1747,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -1721,6 +1838,9 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1769,6 +1889,14 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gaxios@6.7.1:
+    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
+    engines: {node: '>=14'}
+
+  gcp-metadata@6.1.1:
+    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
+    engines: {node: '>=14'}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -1799,12 +1927,32 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  google-auth-library@9.15.1:
+    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
+    engines: {node: '>=14'}
+
+  google-logging-utils@0.0.2:
+    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+
+  googleapis-common@7.2.0:
+    resolution: {integrity: sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==}
+    engines: {node: '>=14.0.0'}
+
+  googleapis@137.1.0:
+    resolution: {integrity: sha512-2L7SzN0FLHyQtFmyIxrcXhgust77067pkkduqkbIpDuj9JzVnByxsRrcRfUMFQam3rQkWW2B0f1i40IwKDWIVQ==}
+    engines: {node: '>=14.0.0'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gtoken@7.1.0:
+    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
+    engines: {node: '>=14.0.0'}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -1821,6 +1969,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   iconv-lite@0.7.3:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
@@ -1874,6 +2026,9 @@ packages:
   jsbi@4.3.2:
     resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
@@ -1886,6 +2041,12 @@ packages:
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
@@ -2047,6 +2208,15 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -2429,6 +2599,9 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
@@ -2478,11 +2651,19 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  url-template@2.0.8:
+    resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   uuid@13.0.2:
     resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vary@1.1.2:
@@ -2578,6 +2759,12 @@ packages:
 
   vscode-languageserver-types@3.18.0:
     resolution: {integrity: sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2921,6 +3108,32 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
+  '@google-cloud/opentelemetry-cloud-monitoring-exporter@0.21.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))
+      '@google-cloud/precise-date': 4.0.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      google-auth-library: 9.15.1
+      googleapis: 137.1.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@google-cloud/opentelemetry-resource-util@3.0.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      gcp-metadata: 6.1.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@google-cloud/precise-date@4.0.0': {}
+
   '@grpc/grpc-js@1.14.4':
     dependencies:
       '@grpc/proto-loader': 0.8.1
@@ -3010,6 +3223,79 @@ snapshots:
       '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.3
     optional: true
+
+  '@opentelemetry/api-logs@0.221.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-prometheus@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/otlp-exporter-base@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@oxc-project/types@0.139.0': {}
 
@@ -3288,6 +3574,8 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  agent-base@7.1.4: {}
+
   ai@7.0.22(zod@4.4.3):
     dependencies:
       '@ai-sdk/gateway': 4.0.16(zod@4.4.3)
@@ -3391,6 +3679,8 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
+  bignumber.js@9.3.1: {}
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -3420,6 +3710,8 @@ snapshots:
       balanced-match: 4.0.4
 
   buffer-crc32@1.0.0: {}
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer@5.7.1:
     dependencies:
@@ -3572,9 +3864,10 @@ snapshots:
       get-tsconfig: 4.14.0
       jiti: 2.7.0
 
-  drizzle-orm@1.0.0-rc.4-5d5b77c(@electric-sql/pglite@0.5.4)(@types/pg@8.20.0)(pg@8.22.0)(zod@4.4.3):
+  drizzle-orm@1.0.0-rc.4-5d5b77c(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)(zod@4.4.3):
     optionalDependencies:
       '@electric-sql/pglite': 0.5.4
+      '@opentelemetry/api': 1.9.1
       '@types/pg': 8.20.0
       pg: 8.22.0
       zod: 4.4.3
@@ -3600,6 +3893,10 @@ snapshots:
       undici: 7.28.0
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -3750,6 +4047,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extend@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
@@ -3788,6 +4087,26 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gaxios@6.7.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      is-stream: 2.0.1
+      node-fetch: 2.7.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  gcp-metadata@6.1.1:
+    dependencies:
+      gaxios: 6.7.1
+      google-logging-utils: 0.0.2
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   get-caller-file@2.0.5: {}
 
@@ -3833,9 +4152,51 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
 
+  google-auth-library@9.15.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 6.7.1
+      gcp-metadata: 6.1.1
+      gtoken: 7.1.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  google-logging-utils@0.0.2: {}
+
+  googleapis-common@7.2.0:
+    dependencies:
+      extend: 3.0.2
+      gaxios: 6.7.1
+      google-auth-library: 9.15.1
+      qs: 6.15.3
+      url-template: 2.0.8
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  googleapis@137.1.0:
+    dependencies:
+      google-auth-library: 9.15.1
+      googleapis-common: 7.2.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  gtoken@7.1.0:
+    dependencies:
+      gaxios: 6.7.1
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   has-symbols@1.1.0: {}
 
@@ -3852,6 +4213,13 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   iconv-lite@0.7.3:
     dependencies:
@@ -3891,6 +4259,10 @@ snapshots:
 
   jsbi@4.3.2: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-schema-to-ts@3.1.1:
     dependencies:
       '@babel/runtime': 7.29.7
@@ -3901,6 +4273,17 @@ snapshots:
   json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   lazystream@1.0.1:
     dependencies:
@@ -4015,6 +4398,10 @@ snapshots:
   nanoid@3.3.15: {}
 
   negotiator@1.0.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   normalize-path@3.0.0: {}
 
@@ -4507,6 +4894,8 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  tr46@0.0.3: {}
+
   ts-algebra@2.0.0: {}
 
   tslib@2.8.1:
@@ -4542,9 +4931,13 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  url-template@2.0.8: {}
+
   util-deprecate@1.0.2: {}
 
   uuid@13.0.2: {}
+
+  uuid@9.0.1: {}
 
   vary@1.1.2: {}
 
@@ -4578,7 +4971,7 @@ snapshots:
       tsx: 4.23.0
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -4601,11 +4994,12 @@ snapshots:
       vite: 8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 22.20.1
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -4628,6 +5022,7 @@ snapshots:
       vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 24.13.3
     transitivePeerDependencies:
       - msw
@@ -4635,6 +5030,13 @@ snapshots:
   vscode-languageserver-textdocument@1.0.12: {}
 
   vscode-languageserver-types@3.18.0: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
Replaces the worker's hand-rolled Prometheus renderer with the OpenTelemetry metrics API, making export a deploy-time choice via `FUNKY_METRICS`: `prometheus` (default — `GET /metrics` on the health port, unchanged for self-hosters), `otlp` (push over OTLP/HTTP configured purely by the standard `OTEL_EXPORTER_OTLP_*` / `OTEL_METRIC_EXPORT_INTERVAL` env vars), `gcm` (dynamic-imported Google Cloud Monitoring exporter), or comma-separated combinations.

The four metric names and label sets are a frozen contract (`funky_queue_depth{state}`, `funky_worker_turns_inflight`, `funky_worker_jobs_total{outcome}`, `funky_worker_append_conflicts_total`), guarded by snapshot tests covering the OTel→Prometheus `_total` naming rule and `withoutScopeInfo` so no `otel_scope_name` label leaks onto the series. Resource identity is set explicitly — `service.name=funky-worker`, region/instance read from the GCP metadata server when present (works on Cloud Run services, jobs, and worker pools), `OTEL_SERVICE_NAME`/`OTEL_RESOURCE_ATTRIBUTES` merged last — never inferred from platform env vars. Export failures log one bounded line per interval and never block or crash the pull loop; `/healthz` is untouched. Also updates README, `.env.example`, and docker-compose env passthrough, with new unit/integration coverage including a real turn asserted through the OTel path against a mock OTLP receiver and testcontainers Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)