### PR TITLE
Use /health for API health checks

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -32,11 +32,15 @@ export function buildApp(deps: AppDeps) {
 
   app.use(requestId());
 
-  // unauthenticated by design (k8s probes, load balancers)
-  app.get("/healthz", async (c) => {
+  // Unauthenticated by design (probes and load balancers). `/healthz` remains as a
+  // compatibility alias for existing deployments while `/health` avoids platforms that
+  // reserve or intercept the conventional probe path.
+  const health = async () => {
     await deps.ping();
-    return c.json({ status: "ok" });
-  });
+    return { status: "ok" as const };
+  };
+  app.get("/health", async (c) => c.json(await health()));
+  app.get("/healthz", async (c) => c.json(await health()));
 
   app.use("/v1/*", auth(deps.authToken));
   app.route("/v1/agents", agentRoutes(deps.agents));

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -4,12 +4,12 @@ import { describe, it, expect, vi } from "vitest";
 import { ConflictError, NotFoundError } from "@funky/configs";
 import { AGENT_ID, UUID_V7, agentFixture, get, makeApp, post } from "./helpers";
 
-describe("GET /healthz", () => {
+describe("GET /health", () => {
   it("returns ok and pings the database", async () => {
     const ping = vi.fn(async () => ({ rows: [] }));
     const { app } = makeApp({ ping });
 
-    const res = await get(app, "/healthz");
+    const res = await get(app, "/health");
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ status: "ok" });
@@ -18,7 +18,7 @@ describe("GET /healthz", () => {
 
   it("is reachable without auth even when a token is configured", async () => {
     const { app } = makeApp({ authToken: "super-secret-token-1234" });
-    const res = await get(app, "/healthz"); // no Authorization header
+    const res = await get(app, "/health"); // no Authorization header
     expect(res.status).toBe(200);
   });
 
@@ -26,7 +26,7 @@ describe("GET /healthz", () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const { app } = makeApp({ ping: async () => Promise.reject(new Error("db down")) });
 
-    const res = await get(app, "/healthz");
+    const res = await get(app, "/health");
     const body = await res.json();
 
     expect(res.status).toBe(500);
@@ -34,6 +34,13 @@ describe("GET /healthz", () => {
     expect(res.headers.get("request-id")).toMatch(UUID_V7);
     expect(errSpy).toHaveBeenCalled(); // the failure is logged, not swallowed
     errSpy.mockRestore();
+  });
+
+  it("keeps /healthz as a compatibility alias", async () => {
+    const { app } = makeApp();
+    const res = await get(app, "/healthz");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "ok" });
   });
 });
 
@@ -94,7 +101,7 @@ describe("auth middleware", () => {
 describe("request-id middleware", () => {
   it("sets a uuid v7 request-id header on every response", async () => {
     const { app } = makeApp();
-    const res = await get(app, "/healthz");
+    const res = await get(app, "/health");
     expect(res.headers.get("request-id")).toMatch(UUID_V7);
   });
 
@@ -112,7 +119,7 @@ describe("request-id middleware", () => {
 
   it("issues a distinct id per request", async () => {
     const { app } = makeApp();
-    const [a, b] = await Promise.all([get(app, "/healthz"), get(app, "/healthz")]);
+    const [a, b] = await Promise.all([get(app, "/health"), get(app, "/health")]);
     expect(a.headers.get("request-id")).not.toBe(b.headers.get("request-id"));
   });
 });

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -39,7 +39,7 @@ pnpm -F web dev               # then open the printed URL (default http://localh
 ```
 
 If the backend isn't reachable, the console shows a blocking "Backend API not reachable"
-gate with the commands to start it, and recovers automatically once `/healthz` is green.
+gate with the commands to start it, and recovers automatically once `/health` is green.
 
 ## How it maps to the API
 

--- a/apps/web/src/console/data.ts
+++ b/apps/web/src/console/data.ts
@@ -38,7 +38,7 @@ export function useClickOutside<T extends HTMLElement>(active: boolean, onOutsid
 
 export type HealthStatus = 'checking' | 'ok' | 'down'
 
-/** Health gate: probe /healthz on mount, auto-retry while down, expose a manual retry. */
+/** Health gate: probe /health on mount, auto-retry while down, expose a manual retry. */
 export function useHealth() {
   const [status, setStatus] = useState<HealthStatus>('checking')
   const busy = useRef(false)

--- a/apps/web/src/console/parts.tsx
+++ b/apps/web/src/console/parts.tsx
@@ -231,8 +231,8 @@ export function HealthGate({ onRetry }: { onRetry: () => void }) {
           <h3 className="gate__title">Backend API not reachable</h3>
         </div>
         <p className="gate__body">
-          The console can&rsquo;t reach the Funky API at <code>localhost:3000/healthz</code>. Start
-          the stack, then retry:
+          The console can&rsquo;t reach the Funky API at <code>localhost:3000/health</code>. Start the
+          stack, then retry:
         </p>
         <pre className="gate__pre">
           {`cp .env.example .env        # set FUNKY_AUTH_TOKEN to any long random string

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -47,7 +47,7 @@ export async function checkHealth(timeoutMs = 2500): Promise<boolean> {
   const ctrl = new AbortController()
   const timer = setTimeout(() => ctrl.abort(), timeoutMs)
   try {
-    const res = await fetch('/healthz', { signal: ctrl.signal })
+    const res = await fetch('/health', { signal: ctrl.signal })
     if (!res.ok) return false
     const json = await res.json().catch(() => null)
     return json?.status === 'ok'

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -5,7 +5,7 @@ import react from '@vitejs/plugin-react'
 // The console is a browser app; the Funky API is bearer-authenticated and has no CORS
 // headers (by design — we don't touch the API for the UI's sake). So instead of calling
 // the API cross-origin from the browser, the dev server proxies same-origin `/v1/*` and
-// `/healthz` to the API and injects the Authorization header here. The token stays in the
+// `/health` to the API and injects the Authorization header here. The token stays in the
 // Node process and never ships in the browser bundle.
 //
 // Config is read from the *monorepo root* `.env` (the same file `docker compose` uses), so
@@ -48,7 +48,7 @@ export default defineConfig(({ mode }) => {
       allowedHosts: true,
       proxy: {
         '/v1': proxy,
-        '/healthz': proxy,
+        '/health': proxy,
       },
     },
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
           "CMD",
           "node",
           "-e",
-          "fetch('http://localhost:3000/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+          "fetch('http://localhost:3000/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
         ]
       interval: 5s
       timeout: 3s
@@ -128,7 +128,7 @@ services:
 
   # The developer console (apps/web) — a Vite + React browser UI over the API. SAME image as
   # the api/worker, different command. It serves same-origin: the Vite server proxies `/v1`
-  # and `/healthz` to the api and injects the bearer token, so the token never reaches the
+  # and `/health` to the api and injects the bearer token, so the token never reaches the
   # browser and the api needs no CORS (it stays untouched). Quickstart-grade — this is the
   # Vite dev server, matching the rest of the stack running from source. Open :5173 after boot.
   web:


### PR DESCRIPTION
## Summary
- expose `/health` as the canonical unauthenticated API health endpoint
- retain `/healthz` as a compatibility alias for existing Cloud Run probes
- point the web console and Docker API health check at `/health`

## Validation
- `pnpm -F api exec vitest run test/app.test.ts`
- `pnpm -F web build`
- `pnpm -F web lint`
- `docker compose config --quiet`
- `git diff --check`