### PR TITLE
Show configured API URL in health error

### DIFF
--- a/apps/web/src/console/parts.tsx
+++ b/apps/web/src/console/parts.tsx
@@ -8,6 +8,9 @@ import { useClickOutside } from './data'
 
 export type Tab = 'quickstart' | 'agents' | 'sessions' | 'environments'
 
+const API_URL =
+  typeof __FUNKY_API_URL__ !== 'undefined' ? __FUNKY_API_URL__ : 'http://localhost:3000'
+
 const NAV: { id: Tab; label: string; icon: ReactNode }[] = [
   { id: 'quickstart', label: 'Quick Start', icon: <Zap size={19} /> },
   { id: 'agents', label: 'Agents', icon: <Cpu size={19} /> },
@@ -231,8 +234,8 @@ export function HealthGate({ onRetry }: { onRetry: () => void }) {
           <h3 className="gate__title">Backend API not reachable</h3>
         </div>
         <p className="gate__body">
-          The console can&rsquo;t reach the Funky API at <code>localhost:3000/health</code>. Start the
-          stack, then retry:
+          The console can&rsquo;t reach the Funky API at <code>{API_URL}/health</code>. Start the stack,
+          then retry:
         </p>
         <pre className="gate__pre">
           {`cp .env.example .env        # set FUNKY_AUTH_TOKEN to any long random string

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -1,3 +1,6 @@
 // Injected by Vite `define` (see vite.config.ts): true when ANTHROPIC_API_KEY is set in the
 // root .env, so the model picker can offer real Claude models.
 declare const __ANTHROPIC_ENABLED__: boolean
+
+// Injected by Vite `define` from FUNKY_API_URL. The auth token remains server-side.
+declare const __FUNKY_API_URL__: string

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -40,6 +40,8 @@ export default defineConfig(({ mode }) => {
     plugins: [react()],
     define: {
       __ANTHROPIC_ENABLED__: JSON.stringify(anthropicEnabled),
+      // Safe to expose: this is the API location, never the bearer token.
+      __FUNKY_API_URL__: JSON.stringify(target.replace(/\/+$/, '')),
     },
     server: {
       // Bind all interfaces + allow any Host so the container's mapped port works; harmless


### PR DESCRIPTION
The console health error now displays the API URL configured through `FUNKY_API_URL` instead of hard-coding localhost. Vite exposes only the non-secret API location to the client while keeping the bearer token server-side.

Validation: `pnpm -F web build` and `pnpm -F web lint`.