### PR TITLE
Add trusted-proxy namespace selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,11 @@
 # Required. Any long random string:  openssl rand -hex 24
 FUNKY_AUTH_TOKEN=
 
+# Namespace selection defaults to "static" (all requests use "default"). "header" trusts
+# X-Funky-Namespace, so enable it only behind a proxy that strips and sets that header.
+# Header mode also requires FUNKY_AUTH=enabled.
+# FUNKY_NAMESPACE_SOURCE=header
+
 # Local development only — inside compose the services use the postgres service instead.
 DATABASE_URL=postgres://funky:funky@localhost:5432/funky
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,6 +3,7 @@
 import { Hono } from "hono";
 import type { AgentsService, AuthContext, EnvsService } from "@funky/configs";
 import type { EventStore, SessionsService } from "@funky/sessions";
+import type { NamespaceSource } from "./config";
 import { errorHandler, errorResponse } from "./http";
 import { auth } from "./middleware/auth";
 import { requestId } from "./middleware/request-id";
@@ -21,6 +22,7 @@ export type AppDeps = {
   bus: EventBus;
   /** null = auth disabled (dev only) */
   authToken: string | null;
+  namespaceSource: NamespaceSource;
   /** liveness of the DB, e.g. () => pool.query("SELECT 1") */
   ping: () => Promise<unknown>;
 };
@@ -42,7 +44,7 @@ export function buildApp(deps: AppDeps) {
   app.get("/health", async (c) => c.json(await health()));
   app.get("/healthz", async (c) => c.json(await health()));
 
-  app.use("/v1/*", auth(deps.authToken));
+  app.use("/v1/*", auth(deps.authToken, deps.namespaceSource));
   app.route("/v1/agents", agentRoutes(deps.agents));
   app.route("/v1/environments", envRoutes(deps.envs));
   app.route(

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -2,6 +2,8 @@
 // The only place process.env is read. dotenv is loaded by index.ts (entrypoint), not here.
 import { z } from "zod";
 
+export type NamespaceSource = "static" | "header";
+
 const EnvSchema = z
   .object({
     DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
@@ -9,12 +11,20 @@ const EnvSchema = z
     DB_POOL_MAX: z.coerce.number().int().min(1).default(10),
     FUNKY_AUTH: z.enum(["enabled", "disabled"]).default("enabled"),
     FUNKY_AUTH_TOKEN: z.string().min(16, "FUNKY_AUTH_TOKEN must be ≥16 chars").optional(),
+    FUNKY_NAMESPACE_SOURCE: z.enum(["static", "header"]).default("static"),
   })
   .refine((e) => e.FUNKY_AUTH === "disabled" || e.FUNKY_AUTH_TOKEN !== undefined, {
     message:
       "FUNKY_AUTH_TOKEN is required. Set it in the environment, " +
       "or set FUNKY_AUTH=disabled for local development (NOT for anything reachable).",
-  });
+  })
+  .refine(
+    (e) => e.FUNKY_AUTH !== "disabled" || e.FUNKY_NAMESPACE_SOURCE !== "header",
+    {
+      path: ["FUNKY_NAMESPACE_SOURCE"],
+      message: "FUNKY_NAMESPACE_SOURCE=header requires FUNKY_AUTH=enabled",
+    },
+  );
 
 export type Config = {
   databaseUrl: string;
@@ -22,6 +32,7 @@ export type Config = {
   dbPoolMax: number;
   /** null = auth explicitly disabled (dev only) */
   authToken: string | null;
+  namespaceSource: NamespaceSource;
 };
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
@@ -45,5 +56,6 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     port: e.PORT,
     dbPoolMax: e.DB_POOL_MAX,
     authToken: e.FUNKY_AUTH === "disabled" ? null : e.FUNKY_AUTH_TOKEN!,
+    namespaceSource: e.FUNKY_NAMESPACE_SOURCE,
   };
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -40,6 +40,7 @@ const app = buildApp({
   store,
   bus,
   authToken: cfg.authToken,
+  namespaceSource: cfg.namespaceSource,
   ping: () => pool.query("SELECT 1"),
 });
 

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,15 +1,17 @@
 // apps/api/src/middleware/auth.ts
 // Static-token authenticator (the OSS implementation of the auth port).
-// Managed swaps this middleware for key lookup → AuthContext{ns, scopes}.
+// A trusted managed gateway can select the namespace after authenticating with this token.
 import { createHash, timingSafeEqual } from "node:crypto";
 import { createMiddleware } from "hono/factory";
 import type { AuthContext } from "@funky/configs";
+import type { NamespaceSource } from "../config";
 import { errorResponse } from "../http";
 
 const STATIC_CONTEXT: AuthContext = { namespace: "default", principal: "token:default" };
+const VALID_NAMESPACE = /^[A-Za-z0-9_-]{1,64}$/;
 
 /** token === null means FUNKY_AUTH=disabled (dev only; config.ts already warned). */
-export const auth = (token: string | null) =>
+export const auth = (token: string | null, namespaceSource: NamespaceSource) =>
   createMiddleware(async (c, next) => {
     if (token !== null) {
       const header = c.req.header("authorization") ?? "";
@@ -18,7 +20,20 @@ export const auth = (token: string | null) =>
         return errorResponse(c, 401, "authentication_error", "invalid or missing API token");
       }
     }
-    c.set("auth", STATIC_CONTEXT);
+
+    if (namespaceSource === "static") {
+      c.set("auth", STATIC_CONTEXT);
+      await next();
+      return;
+    }
+
+    const namespaceHeader = c.req.header("X-Funky-Namespace");
+    const namespace = namespaceHeader ?? "default";
+    if (!VALID_NAMESPACE.test(namespace)) {
+      return errorResponse(c, 400, "invalid_request_error", "invalid X-Funky-Namespace");
+    }
+
+    c.set("auth", { namespace, principal: `token:${namespace}` });
     await next();
   });
 

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -1,8 +1,18 @@
 // Cross-cutting behavior wired up in app.ts: health probe, auth gate,
 // request-id middleware, the error envelope, and the not-found fallback.
 import { describe, it, expect, vi } from "vitest";
-import { ConflictError, NotFoundError } from "@funky/configs";
-import { AGENT_ID, UUID_V7, agentFixture, get, makeApp, post } from "./helpers";
+import { ConflictError, NotFoundError, type AuthContext } from "@funky/configs";
+import {
+  AGENT_ID,
+  CTX,
+  SESSION_ID,
+  UUID_V7,
+  agentFixture,
+  createBody,
+  get,
+  makeApp,
+  post,
+} from "./helpers";
 
 describe("GET /health", () => {
   it("returns ok and pings the database", async () => {
@@ -46,6 +56,7 @@ describe("GET /health", () => {
 
 describe("auth middleware", () => {
   const token = "super-secret-token-1234";
+  const bearer = { authorization: `Bearer ${token}` };
 
   it("rejects requests with no Authorization header", async () => {
     const { app, fake } = makeApp({ authToken: token });
@@ -95,6 +106,133 @@ describe("auth middleware", () => {
     const res = await get(app, `/v1/agents/${AGENT_ID}`); // no header
     expect(res.status).toBe(200);
     expect(fake.get).toHaveBeenCalledOnce();
+  });
+
+  it("uses a valid namespace header to isolate requests in header mode", async () => {
+    const agentsByNamespace = new Map<string, ReturnType<typeof agentFixture>[]>();
+    const { app } = makeApp({
+      authToken: token,
+      namespaceSource: "header",
+      agents: {
+        create: vi.fn(async (ctx: AuthContext) => {
+          const agent = agentFixture();
+          agentsByNamespace.set(ctx.namespace, [
+            ...(agentsByNamespace.get(ctx.namespace) ?? []),
+            agent,
+          ]);
+          return { agent, created: true };
+        }),
+        list: vi.fn(async (ctx: AuthContext) => ({
+          object: "list",
+          data: agentsByNamespace.get(ctx.namespace) ?? [],
+          has_more: false,
+        })),
+      },
+    });
+
+    const nsAHeaders = { ...bearer, "X-Funky-Namespace": "ns-a" };
+    const created = await post(app, "/v1/agents", createBody(), nsAHeaders);
+    expect(created.status).toBe(201);
+
+    const nsB = await get(app, "/v1/agents", {
+      ...bearer,
+      "X-Funky-Namespace": "ns-b",
+    });
+    expect((await nsB.json()).data).toEqual([]);
+
+    const nsA = await get(app, "/v1/agents", nsAHeaders);
+    expect((await nsA.json()).data).toHaveLength(1);
+  });
+
+  it("falls back to the default namespace when the namespace header is absent", async () => {
+    const { app, fake } = makeApp({
+      authToken: token,
+      namespaceSource: "header",
+      agents: { get: vi.fn().mockResolvedValue(agentFixture()) },
+    });
+
+    const res = await get(app, `/v1/agents/${AGENT_ID}`, bearer);
+
+    expect(res.status).toBe(200);
+    expect(fake.get).toHaveBeenCalledWith(CTX, AGENT_ID);
+  });
+
+  it.each([
+    ["empty", ""],
+    ["too long", "a".repeat(65)],
+    ["path-like", "ns/../x"],
+    ["unicode", "ténant"],
+  ])("rejects a %s namespace header", async (_label, namespace) => {
+    const { app, fake } = makeApp({ authToken: token, namespaceSource: "header" });
+
+    const res = await get(app, `/v1/agents/${AGENT_ID}`, {
+      ...bearer,
+      "X-Funky-Namespace": namespace,
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: { type: "invalid_request_error", message: "invalid X-Funky-Namespace" },
+    });
+    expect(fake.get).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["incorrect", "Bearer wrong-token"],
+  ])(
+    "checks a %s bearer token before validating the namespace",
+    async (_label, authorization) => {
+      const { app, fake } = makeApp({ authToken: token, namespaceSource: "header" });
+      const headers: Record<string, string> = { "X-Funky-Namespace": "invalid/value" };
+      if (authorization !== undefined) headers.authorization = authorization;
+
+      const res = await get(app, `/v1/agents/${AGENT_ID}`, headers);
+
+      expect(res.status).toBe(401);
+      expect((await res.json()).error.type).toBe("authentication_error");
+      expect(fake.get).not.toHaveBeenCalled();
+    },
+  );
+
+  it("ignores namespace headers in static mode", async () => {
+    const { app, fake } = makeApp({
+      authToken: token,
+      namespaceSource: "static",
+      agents: { get: vi.fn().mockResolvedValue(agentFixture()) },
+    });
+
+    const res = await get(app, `/v1/agents/${AGENT_ID}`, {
+      ...bearer,
+      "X-Funky-Namespace": "evil",
+    });
+
+    expect(res.status).toBe(200);
+    expect(fake.get).toHaveBeenCalledWith(CTX, AGENT_ID);
+  });
+
+  it("returns 404 before opening an SSE stream for the wrong namespace", async () => {
+    const getSession = vi.fn(async (ctx: AuthContext) => {
+      if (ctx.namespace !== "default") throw new NotFoundError("session not found");
+      return {};
+    });
+    const { app } = makeApp({
+      authToken: token,
+      namespaceSource: "header",
+      sessions: { get: getSession },
+    });
+
+    const res = await get(app, `/v1/sessions/${SESSION_ID}/events/stream`, {
+      ...bearer,
+      "X-Funky-Namespace": "wrong",
+    });
+
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    expect(getSession).toHaveBeenCalledWith(
+      { namespace: "wrong", principal: "token:wrong" },
+      SESSION_ID,
+    );
   });
 });
 

--- a/apps/api/test/config.test.ts
+++ b/apps/api/test/config.test.ts
@@ -31,6 +31,7 @@ describe("loadConfig — valid input", () => {
       port: 8080,
       dbPoolMax: 25,
       authToken: BASE.FUNKY_AUTH_TOKEN,
+      namespaceSource: "static",
     });
     expect(exitSpy).not.toHaveBeenCalled();
   });
@@ -39,6 +40,12 @@ describe("loadConfig — valid input", () => {
     const cfg = loadConfig(BASE);
     expect(cfg.port).toBe(3000);
     expect(cfg.dbPoolMax).toBe(10);
+    expect(cfg.namespaceSource).toBe("static");
+  });
+
+  it("parses header namespace source mode", () => {
+    const cfg = loadConfig({ ...BASE, FUNKY_NAMESPACE_SOURCE: "header" });
+    expect(cfg.namespaceSource).toBe("header");
   });
 
   it("returns a null token and warns when auth is disabled", () => {
@@ -63,6 +70,15 @@ describe("loadConfig — invalid input exits the process", () => {
     ["PORT not a number", { ...BASE, PORT: "notaport" }],
     ["DB_POOL_MAX below 1", { ...BASE, DB_POOL_MAX: "0" }],
     ["invalid FUNKY_AUTH value", { ...BASE, FUNKY_AUTH: "maybe" }],
+    ["invalid FUNKY_NAMESPACE_SOURCE value", { ...BASE, FUNKY_NAMESPACE_SOURCE: "query" }],
+    [
+      "header namespace source with auth disabled",
+      {
+        DATABASE_URL: BASE.DATABASE_URL,
+        FUNKY_AUTH: "disabled",
+        FUNKY_NAMESPACE_SOURCE: "header",
+      },
+    ],
   ])("exits on %s", (_label, env) => {
     expect(() => loadConfig(env as NodeJS.ProcessEnv)).toThrow("process.exit(1)");
     expect(exitSpy).toHaveBeenCalledWith(1);

--- a/apps/api/test/helpers.ts
+++ b/apps/api/test/helpers.ts
@@ -16,6 +16,7 @@ import type {
   SessionsService,
 } from "@funky/sessions";
 import { buildApp } from "../src/app";
+import type { NamespaceSource } from "../src/config";
 import type { EventBus } from "../src/sse";
 
 /** What the static auth middleware injects for every /v1 request. */
@@ -114,6 +115,7 @@ export type App = ReturnType<typeof buildApp>;
 export function makeApp(
   opts: {
     authToken?: string | null;
+    namespaceSource?: NamespaceSource;
     ping?: () => Promise<unknown>;
     agents?: Partial<FakeAgents>;
     envs?: Partial<FakeEnvs>;
@@ -130,6 +132,7 @@ export function makeApp(
     store: {} as unknown as EventStore,
     bus: {} as unknown as EventBus,
     authToken: opts.authToken ?? null, // auth disabled by default; auth tests opt in
+    namespaceSource: opts.namespaceSource ?? "static",
     ping: opts.ping ?? (async () => ({ rows: [{ "?column?": 1 }] })),
   });
   return { app, fake, fakeEnvs, fakeSessions };

--- a/apps/api/test/sessions.integration.test.ts
+++ b/apps/api/test/sessions.integration.test.ts
@@ -45,6 +45,7 @@ beforeAll(async () => {
     store,
     bus,
     authToken: null, // auth disabled → app.request needs no header
+    namespaceSource: "static",
     ping: () => pg.pool.query("SELECT 1"),
   });
 }, 120_000);


### PR DESCRIPTION
Adds `FUNKY_NAMESPACE_SOURCE` with a static default and an authenticated `X-Funky-Namespace` trusted-proxy mode. Validates namespaces after bearer-token authentication, preserves the default namespace fallback and static behavior, and rejects header mode when authentication is disabled. Adds configuration, isolation, malformed-header, authentication-ordering, static-regression, and SSE preflight coverage, plus the proxy trust caveat in `.env.example`.

Tests: `pnpm typecheck`; `pnpm test`