### PR TITLE
Pause E2B sandboxes at timeout instead of killing them

### DIFF
--- a/packages/ports/sandbox/src/computesdk.test.ts
+++ b/packages/ports/sandbox/src/computesdk.test.ts
@@ -51,6 +51,36 @@ if (apiKey) {
   });
 }
 
+// The create options are the one part of the driver a passing TCK cannot cover: the fake
+// provider ignores them, so a wrong option name still runs green everywhere while silently
+// doing nothing in production. ComputeSDK's CreateSandboxOptions ends in `[key: string]: any`
+// and its e2b provider spreads unrecognised keys into E2BSandbox.create(), so tsc won't catch
+// a typo either. These assert the exact shape we hand the provider.
+describe("ComputeSDK sandbox lifecycle", () => {
+  it("asks the provider to pause on timeout, not kill", async () => {
+    let createOptions: CreateSandboxOptions | undefined;
+    const driver = new ComputeSdkDriver({
+      providerName: "e2b",
+      provider: localShellProvider((options) => {
+        createOptions = options;
+      }),
+      sandboxTimeoutMs: 30 * 60_000,
+    });
+
+    const handle = await driver.provision({ network: { type: "unrestricted" } }, randomUUID());
+    try {
+      // Matches the e2b SDK's SandboxOpts.lifecycle. `autoPause` — the name this used to
+      // pass — is NOT a field there; E2B ignored it and fell back to onTimeout:'kill',
+      // destroying the filesystem at the timeout instead of pausing it.
+      expect(createOptions?.lifecycle).toEqual({ onTimeout: "pause", autoResume: true });
+      expect(createOptions).not.toHaveProperty("autoPause");
+      expect(createOptions?.timeout).toBe(30 * 60_000);
+    } finally {
+      await driver.teardown(handle);
+    }
+  });
+});
+
 describe("ComputeSDK network policies", () => {
   it("maps a limited policy to E2B allowOut", async () => {
     let createOptions: CreateSandboxOptions | undefined;

--- a/packages/ports/sandbox/src/drivers/computesdk.ts
+++ b/packages/ports/sandbox/src/drivers/computesdk.ts
@@ -63,12 +63,22 @@ export class ComputeSdkDriver implements SandboxDriver {
       throw new Error(`${this.providerName} does not support limited network policies`);
     }
 
-    // autoPause makes the timeout a pause (disk persisted, resumed on connect) instead
-    // of a kill; that's what keeps reboot honest.
+    // lifecycle makes the timeout a pause (disk persisted, resumed on connect) instead of a
+    // kill; that's what keeps reboot honest. E2B's default is onTimeout:'kill', so getting
+    // this wrong DESTROYS the filesystem at sandboxTimeoutMs and every session older than it
+    // dies with "sandbox is gone (cannot reboot)". autoResume wakes a paused sandbox on
+    // inbound traffic, so connect() resumes it transparently; it also implies the default
+    // full-memory snapshot, which is what lets a detached runner survive the pause and keeps
+    // the idemKey attach protocol working across one.
+    //
+    // ComputeSDK types create options with an index signature and forwards unknown keys
+    // straight to the provider, so a wrong option name here is silent — neither tsc nor the
+    // provider complains, it just never takes effect. The lifecycle test in computesdk.test.ts
+    // pins the exact shape for that reason; keep it in sync with the e2b SDK's SandboxOpts.
     const sb = await this.manager.sandbox.create({
       timeout: this.sandboxTimeoutMs,
       metadata: { funky_session_id: sessionId },
-      autoPause: true,
+      lifecycle: { onTimeout: "pause", autoResume: true },
       ...(spec.network.type === "limited" && {
         network: { allowOut: spec.network.allowed_hosts },
       }),

--- a/packages/ports/sandbox/src/drivers/docker.ts
+++ b/packages/ports/sandbox/src/drivers/docker.ts
@@ -87,7 +87,7 @@ export function dockerProvider(opts: DockerProviderOptions): ComputeProvider {
     sandbox: {
       // `sleep infinity` (overriding the image CMD) keeps the container alive so later
       // `docker exec`s have something to attach to. --init reaps the detached nohup runners
-      // the protocol spawns. autoPause/timeout options don't map to Docker — a container
+      // the protocol spawns. lifecycle/timeout options don't map to Docker — a container
       // just runs until teardown — so they're ignored; the label aids `docker ps` triage.
       create: async (options?: CreateSandboxOptions): Promise<SandboxInterface> => {
         const session = options?.metadata?.funky_session_id;

--- a/packages/sessions/src/turn.ts
+++ b/packages/sessions/src/turn.ts
@@ -153,6 +153,16 @@ function selectStrategy(runtime: RuntimeConfig | null): TurnStrategy {
  *  anything it defers on lands here. */
 function mapError(err: unknown, shell: TurnShell): TurnOutcome | Promise<TurnOutcome> {
   if (err instanceof ErrConflict) return "conflict"; // someone else owns this turn
+  // TODO(sessions): SANDBOX_FATAL ends the TURN and should not end the SESSION. Losing the
+  // sandbox mid-exec is unrecoverable for *this* turn — the in-flight command's fate is
+  // unknowable, so it can be neither replayed nor safely re-run — but a later turn starts
+  // with nothing in flight, so it could re-provision and continue (no idemKey in flight ⇒
+  // no side effect to duplicate). Two things block that today: terminalFail leaves
+  // sessions.status alone, so the session keeps accepting messages and burns maxAttempts on
+  // each; and this branch cannot tell "destroyed" from "unreachable N times" (computesdk.ts
+  // maps both to one error), so it must not be made session-terminal before that distinction
+  // exists. Design: turn-start loss → re-provision + a sandbox_replaced event; mid-exec loss
+  // → fail the turn only.
   if (err instanceof SandboxUnavailableError) {
     return shell.lastAttempt ? shell.terminalFail("SANDBOX_FATAL", err.message) : "retry_later";
   }


### PR DESCRIPTION
`provision` passed `autoPause: true`, which is not a field on the e2b SDK's `SandboxOpts` (the real option is `lifecycle.onTimeout`, defaulting to `'kill'`) — and since ComputeSDK types create options with a `[key: string]: any` index signature and forwards unknown keys straight to the provider, it was silently dropped by every layer. Sandboxes were therefore destroyed at `FUNKY_E2B_SANDBOX_TIMEOUT_MS` (default 30 min) rather than paused, so resuming any session older than that failed with `sandbox <id> is gone (cannot reboot)`. This passes `lifecycle: { onTimeout: "pause", autoResume: true }` and pins the create-options shape in a new test, since neither the TCK nor tsc can catch this class of bug — the fake provider ignores create options and any key typechecks. It also adds a TODO in `mapError` for the open question this exposed: `SANDBOX_FATAL` ends the turn but never updates `sessions.status`, so a session whose sandbox is genuinely gone keeps accepting messages and burns `maxAttempts` on each.

Verified by reverting the source and confirming the new test fails; full suite (517 tests) and `tsc --noEmit` pass. **Not** verified against live E2B — that needs `E2B_API_KEY` and a TTL-expiry test, so this corrects the option per the SDK types rather than proving runtime pause/resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)