### PR TITLE
Add Together AI provider and web model options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,9 +13,11 @@ DATABASE_URL=postgres://funky:funky@localhost:5432/funky
 
 # --- optional ---
 # "fake" (default): a scripted agent that runs a real command in the sandbox. No API key.
-# "ai-sdk": a real model. Requires ANTHROPIC_API_KEY.
+# "ai-sdk": a real model. Set the key matching the provider used by your agent.
 # FUNKY_LLM=ai-sdk
 # ANTHROPIC_API_KEY=sk-ant-...
+# OPENAI_API_KEY=sk-...
+# TOGETHER_API_KEY=...
 
 # "docker" (default): a real, isolated container per session on the local Docker daemon. No
 #           cloud account. `docker compose up` builds the base image (docker/sandbox.Dockerfile)

--- a/README.md
+++ b/README.md
@@ -67,17 +67,35 @@ event: turn_completed
 
 <img width="1462" height="753" alt="Screenshot 2026-07-16 at 10 22 12 AM" src="https://github.com/user-attachments/assets/46dd31b9-0388-46bf-a12d-f28abdb6a263" />
 
-### Using a real model (e.g. sonnet-5)
+### Using a real model
 
 ```bash
 # in .env
 FUNKY_LLM=ai-sdk
+# set the key matching the provider in your agent's model config
 ANTHROPIC_API_KEY=sk-ant-...
+# OPENAI_API_KEY=sk-...
+# TOGETHER_API_KEY=...
 ```
 ```bash
 docker compose up -d --build worker
 ```
-Now the same curl commands drive a real Claude, writing and running its own shell commands.
+Now the same curl commands drive a real model, writing and running its own shell commands.
+The native runtime supports Anthropic, OpenAI, and Together AI through their direct AI SDK
+providers. For example, a Together AI agent uses:
+
+```json
+{
+  "model": {
+    "provider": "togetherai",
+    "model": "openai/gpt-oss-20b"
+  }
+}
+```
+
+Use a current Together model with function-calling support, since Funky's native agent loop
+exposes its sandbox through an `exec` tool. See Together's
+[serverless model catalog](https://docs.together.ai/docs/serverless/models).
 
 ### Using a remote sandbox (e.g. E2B)
 

--- a/apps/api/test/agents.test.ts
+++ b/apps/api/test/agents.test.ts
@@ -40,6 +40,22 @@ describe("POST /v1/agents (create)", () => {
     expect(fake.create).toHaveBeenCalledWith(CTX, body);
   });
 
+  it("accepts a Together AI model for the native runtime", async () => {
+    const agent = agentFixture();
+    const { app, fake } = makeApp({
+      agents: { create: vi.fn().mockResolvedValue({ agent, created: true }) },
+    });
+    const body = createBody({
+      model: { provider: "togetherai", model: "openai/gpt-oss-20b" },
+      runtime: { type: "native" },
+    });
+
+    const res = await post(app, "/v1/agents", body);
+
+    expect(res.status).toBe(201);
+    expect(fake.create).toHaveBeenCalledWith(CTX, body);
+  });
+
   it("returns 200 for an idempotent (already-exists) create", async () => {
     const agent = agentFixture();
     const { app } = makeApp({

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -23,6 +23,8 @@ no CORS to configure (the API is left untouched). Config is read from the **mono
 | --- | --- | --- |
 | `FUNKY_API_URL` | where the API listens | `http://localhost:3000` |
 | `FUNKY_AUTH_TOKEN` | bearer token; leave unset if the API runs `FUNKY_AUTH=disabled` | — |
+| `ANTHROPIC_API_KEY` | enables Anthropic models in the model picker | — |
+| `TOGETHER_API_KEY` | enables Together AI models in the model picker | — |
 
 `docker compose up --build` (from the repo root) now brings the console up **with** the
 backend — it's the `web` service, running this same dev server in a container:
@@ -46,8 +48,8 @@ gate with the commands to start it, and recovers automatically once `/health` is
 The UI is intentionally simpler than the API; a few fields are filled in for you:
 
 - **Model** — the dropdown labels map to the API's `{ provider, model }` shape
-  (`src/lib/models.ts`). With the default zero-key `fake` LLM any choice works; with
-  `FUNKY_LLM=ai-sdk` + `ANTHROPIC_API_KEY`, pick the Claude option.
+  (`src/lib/models.ts`). Options appear when the matching provider key is configured.
+  Together AI models use the native runtime; Claude Code remains Anthropic-only.
 - **Environment** — the create form asks for name, description, and network access. There
   is no image to pick: the sandbox runtime is the backend's concern (the dev driver runs
   commands in the worker container), so the environment is just identity + network policy.

--- a/apps/web/src/console/Agents.tsx
+++ b/apps/web/src/console/Agents.tsx
@@ -25,6 +25,11 @@ export function Agents({
   const [prompt, setPrompt] = useState('')
   const [saving, setSaving] = useState(false)
 
+  function chooseModel(next: string) {
+    setModel(next)
+    if (modelConfigFor(next).provider !== 'anthropic') setRuntime('native')
+  }
+
   async function create() {
     if (!name.trim() || !prompt.trim()) {
       notify('Name and system prompt are required.')
@@ -119,8 +124,12 @@ export function Agents({
       >
         <div className="modal__form">
           <Input label="Agent name" placeholder="Name your agent" value={name} onChange={setName} />
-          <ModelField value={model} onChange={setModel} />
-          <RuntimeField value={runtime} onChange={setRuntime} />
+          <ModelField value={model} onChange={chooseModel} />
+          <RuntimeField
+            value={runtime}
+            onChange={setRuntime}
+            modelProvider={modelConfigFor(model).provider}
+          />
           <Textarea
             label="System prompt"
             rows={4}

--- a/apps/web/src/console/QuickStart.tsx
+++ b/apps/web/src/console/QuickStart.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Check } from 'lucide-react'
 import { agents as agentsApi, environments as envsApi, sessions as sessApi } from '../lib/api'
-import { modelConfigFor } from '../lib/models'
+import { DEFAULT_MODEL_LABEL, modelConfigFor } from '../lib/models'
 import { networkPolicy, networkSummary, type NetworkMode } from '../lib/network'
 import { errMsg, initials } from '../lib/format'
 import { Avatar, Badge, Button, CodeBlock, Input, Textarea } from '../ui/ui'
@@ -15,7 +15,7 @@ const STEP_LABELS = ['Create agent', 'Configure environment', 'Start session', '
 export function QuickStart({ onLaunch }: { onLaunch: (sessionId: string) => Promise<void> }) {
   const [step, setStep] = useState(1)
   const [agentName, setAgentName] = useState('Funky Assistant')
-  const [model, setModel] = useState('Sonnet 5')
+  const [model, setModel] = useState(DEFAULT_MODEL_LABEL)
   const [runtime, setRuntime] = useState<'native' | 'claude-code'>('native')
   const [systemPrompt, setSystemPrompt] = useState(DEFAULT_PROMPT)
   const [envName, setEnvName] = useState('basic')
@@ -28,6 +28,11 @@ export function QuickStart({ onLaunch }: { onLaunch: (sessionId: string) => Prom
 
   const next = () => setStep((s) => Math.min(4, s + 1))
   const back = () => setStep((s) => Math.max(1, s - 1))
+
+  function chooseModel(nextModel: string) {
+    setModel(nextModel)
+    if (modelConfigFor(nextModel).provider !== 'anthropic') setRuntime('native')
+  }
 
   function guardStep1() {
     if (!agentName.trim() || !systemPrompt.trim()) {
@@ -101,8 +106,12 @@ export function QuickStart({ onLaunch }: { onLaunch: (sessionId: string) => Prom
                 <p className="qs-form__sub">Who it is and which model powers it.</p>
               </div>
               <Input label="Agent name" placeholder="Name your agent" value={agentName} onChange={setAgentName} />
-              <ModelField value={model} onChange={setModel} />
-              <RuntimeField value={runtime} onChange={setRuntime} />
+              <ModelField value={model} onChange={chooseModel} />
+              <RuntimeField
+                value={runtime}
+                onChange={setRuntime}
+                modelProvider={modelConfigFor(model).provider}
+              />
               <Textarea label="System prompt" rows={5} value={systemPrompt} onChange={setSystemPrompt} />
               <div className="qs-foot qs-foot--end">
                 <Button variant="accent" size="lg" onClick={guardStep1}>

--- a/apps/web/src/console/parts.tsx
+++ b/apps/web/src/console/parts.tsx
@@ -2,7 +2,8 @@ import type { ReactNode } from 'react'
 import { useState } from 'react'
 import { AlertTriangle, Archive, Cpu, Layers, MessageSquare, MoreVertical, X, Zap } from 'lucide-react'
 import { Button, Select, Textarea } from '../ui/ui'
-import { ANTHROPIC_ENABLED, MODEL_OPTIONS } from '../lib/models'
+import { MODEL_OPTIONS } from '../lib/models'
+import type { Provider } from '../lib/types'
 import type { NetworkMode } from '../lib/network'
 import { useClickOutside } from './data'
 
@@ -80,16 +81,17 @@ export function EmptyState({
 }
 
 /**
- * The Model picker. With an ANTHROPIC_API_KEY present it offers the Claude models; without
- * one there's nothing usable to pick, so it points the user at their .env instead.
+ * The model picker only exposes providers whose worker key was present at Vite startup.
+ * Unreleased models can remain visible as disabled options.
  */
 export function ModelField({ value, onChange }: { value: string; onChange: (v: string) => void }) {
-  if (!ANTHROPIC_ENABLED) {
+  if (MODEL_OPTIONS.length === 0) {
     return (
       <div className="field">
         <span className="field__label">Model</span>
         <p className="model-hint">
-          Please specify <code>ANTHROPIC_API_KEY</code> in your <code>.env</code> file.
+          Please specify <code>ANTHROPIC_API_KEY</code> or <code>TOGETHER_API_KEY</code> in
+          your <code>.env</code> file.
         </p>
       </div>
     )
@@ -98,21 +100,28 @@ export function ModelField({ value, onChange }: { value: string; onChange: (v: s
     <Select
       label="Model"
       value={value}
-      options={MODEL_OPTIONS.map((m) => ({ value: m.label, label: m.label }))}
+      options={MODEL_OPTIONS.map((m) => ({
+        value: m.label,
+        label: m.label,
+        disabled: m.disabled,
+      }))}
       onChange={onChange}
     />
   )
 }
 
-// How the agent runs its turns. claude-code (the harness) requires an anthropic model,
-// which the UI's model picker always is — so the choice is always valid here.
+// How the agent runs its turns. Claude Code is only valid for Anthropic models; Together
+// models use Funky's provider-neutral native loop.
 export function RuntimeField({
   value,
   onChange,
+  modelProvider,
 }: {
   value: 'native' | 'claude-code'
   onChange: (v: 'native' | 'claude-code') => void
+  modelProvider: Provider
 }) {
+  const claudeCodeAvailable = modelProvider === 'anthropic'
   return (
     <div className="field">
       <Select
@@ -120,7 +129,11 @@ export function RuntimeField({
         value={value}
         options={[
           { value: 'native', label: 'Native — Funky’s built-in agent loop' },
-          { value: 'claude-code', label: 'Claude Code — run turns inside the Claude Agent SDK' },
+          {
+            value: 'claude-code',
+            label: 'Claude Code — run turns inside the Claude Agent SDK',
+            disabled: !claudeCodeAvailable,
+          },
         ]}
         onChange={(v) => onChange(v as 'native' | 'claude-code')}
       />
@@ -128,6 +141,8 @@ export function RuntimeField({
         <p className="model-hint">
           Runs each turn inside Claude Code; needs <code>ANTHROPIC_API_KEY</code> on the worker.
         </p>
+      ) : !claudeCodeAvailable ? (
+        <p className="model-hint">Together AI models run with the Native runtime.</p>
       ) : null}
     </div>
   )

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -1,6 +1,7 @@
-// Injected by Vite `define` (see vite.config.ts): true when ANTHROPIC_API_KEY is set in the
-// root .env, so the model picker can offer real Claude models.
+// Injected by Vite `define` (see vite.config.ts): true when the corresponding provider key
+// is set in the root .env, so the picker can offer its models without exposing credentials.
 declare const __ANTHROPIC_ENABLED__: boolean
+declare const __TOGETHER_ENABLED__: boolean
 
 // Injected by Vite `define` from FUNKY_API_URL. The auth token remains server-side.
 declare const __FUNKY_API_URL__: string

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -1,36 +1,81 @@
-import type { ModelConfig } from './types'
+import type { ModelConfig, Provider } from './types'
 
-// True when the worker has an ANTHROPIC_API_KEY (injected by Vite from the root .env). Only
-// then does the model picker offer real Claude models; otherwise it tells the user to set
-// the key. Falls back to false if the define somehow didn't run (e.g. non-Vite contexts).
+// Provider availability is injected by Vite from the root .env. Only booleans reach the
+// browser bundle; API keys stay in the dev-server/worker processes.
 export const ANTHROPIC_ENABLED: boolean =
   typeof __ANTHROPIC_ENABLED__ !== 'undefined' ? __ANTHROPIC_ENABLED__ : false
+export const TOGETHER_ENABLED: boolean =
+  typeof __TOGETHER_ENABLED__ !== 'undefined' ? __TOGETHER_ENABLED__ : false
 
-// The Claude models offered when a key is present. Labels are what the UI shows; `model` is
-// the API model id. Provider is always anthropic.
-export type ModelOption = { label: string; model: string }
+export type AvailableModelOption = {
+  label: string
+  provider: Provider
+  model: string
+  disabled?: false
+}
+export type UnavailableModelOption = {
+  label: string
+  disabled: true
+}
+export type ModelOption = AvailableModelOption | UnavailableModelOption
 
-export const MODEL_OPTIONS: ModelOption[] = [
-  { label: 'Opus 4.8', model: 'claude-opus-4-8' },
-  { label: 'Sonnet 5', model: 'claude-sonnet-5' },
+const ANTHROPIC_MODELS: AvailableModelOption[] = [
+  { label: 'Opus 4.8', provider: 'anthropic', model: 'claude-opus-4-8' },
+  { label: 'Sonnet 5', provider: 'anthropic', model: 'claude-sonnet-5' },
 ]
 
-// The first option is the default; declared explicitly so it's never `undefined` under
-// noUncheckedIndexedAccess.
-const DEFAULT_MODEL: ModelOption = MODEL_OPTIONS[0] ?? {
+const TOGETHER_MODELS: ModelOption[] = [
+  // Together lists Kimi K3 in its model library but marks its Serverless API endpoint as
+  // coming soon. Keep it visible without creating agents that fail at inference time.
+  { label: 'Kimi K3 — coming soon', disabled: true },
+  { label: 'GLM-5.2', provider: 'togetherai', model: 'zai-org/GLM-5.2' },
+  {
+    label: 'DeepSeek V4 Pro',
+    provider: 'togetherai',
+    model: 'deepseek-ai/DeepSeek-V4-Pro',
+  },
+  { label: 'Qwen3.7 Max', provider: 'togetherai', model: 'Qwen/Qwen3.7-Max' },
+  {
+    label: 'Gemma 4 31B IT',
+    provider: 'togetherai',
+    model: 'google/gemma-4-31B-it',
+  },
+]
+
+export const MODEL_OPTIONS: ModelOption[] = [
+  ...(ANTHROPIC_ENABLED ? ANTHROPIC_MODELS : []),
+  ...(TOGETHER_ENABLED ? TOGETHER_MODELS : []),
+]
+
+function isAvailable(option: ModelOption): option is AvailableModelOption {
+  return option.disabled !== true
+}
+
+// The first enabled option is the default. The fallback is only used outside Vite or when
+// no provider key is configured; ModelField renders a setup hint instead of a picker then.
+const DEFAULT_MODEL: AvailableModelOption = MODEL_OPTIONS.find(isAvailable) ?? {
   label: 'Opus 4.8',
+  provider: 'anthropic',
   model: 'claude-opus-4-8',
 }
 
 export const DEFAULT_MODEL_LABEL = DEFAULT_MODEL.label
 
 export function modelConfigFor(label: string): ModelConfig {
-  const opt = MODEL_OPTIONS.find((m) => m.label === label) ?? DEFAULT_MODEL
-  return { provider: 'anthropic', model: opt.model }
+  const opt = MODEL_OPTIONS.find(
+    (candidate): candidate is AvailableModelOption =>
+      candidate.label === label && isAvailable(candidate),
+  ) ?? DEFAULT_MODEL
+  return { provider: opt.provider, model: opt.model }
 }
 
 // Friendly label for a stored agent's model, falling back to the raw id (e.g. agents
 // created before this list changed).
 export function modelLabel(model: ModelConfig): string {
-  return MODEL_OPTIONS.find((m) => m.model === model.model)?.label ?? model.model
+  return MODEL_OPTIONS.find(
+    (option) =>
+      isAvailable(option) &&
+      option.provider === model.provider &&
+      option.model === model.model,
+  )?.label ?? model.model
 }

--- a/apps/web/src/ui/ui.tsx
+++ b/apps/web/src/ui/ui.tsx
@@ -77,14 +77,14 @@ export function Select({
 }: {
   label?: string
   value: string
-  options: { value: string; label: string }[]
+  options: { value: string; label: string; disabled?: boolean }[]
   onChange: (v: string) => void
 }) {
   return (
     <Field label={label}>
       <select className="control" value={value} onChange={(e) => onChange(e.target.value)}>
         {options.map((o) => (
-          <option key={o.value} value={o.value}>
+          <option key={o.value} value={o.value} disabled={o.disabled}>
             {o.label}
           </option>
         ))}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -23,10 +23,11 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, repoRoot, '')
   const target = env.FUNKY_API_URL || process.env.FUNKY_API_URL || 'http://localhost:3000'
   const token = env.FUNKY_AUTH_TOKEN || process.env.FUNKY_AUTH_TOKEN
-  // Real Claude models are only offered when the worker has a key. We expose a *boolean*
-  // (never the key itself) so the model picker can gate on it. Reflects the root .env at
-  // dev-server start — restart `pnpm dev` after changing it.
+  // Real models are only offered when the worker has the matching key. We expose booleans
+  // (never the keys themselves) so the model picker can gate on them. Reflects the root
+  // .env at dev-server start — restart `pnpm dev` after changing it.
   const anthropicEnabled = Boolean((env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_API_KEY || '').trim())
+  const togetherEnabled = Boolean((env.TOGETHER_API_KEY || process.env.TOGETHER_API_KEY || '').trim())
 
   const proxyHeaders = token ? { Authorization: `Bearer ${token}` } : undefined
   const proxy = {
@@ -40,6 +41,7 @@ export default defineConfig(({ mode }) => {
     plugins: [react()],
     define: {
       __ANTHROPIC_ENABLED__: JSON.stringify(anthropicEnabled),
+      __TOGETHER_ENABLED__: JSON.stringify(togetherEnabled),
       // Safe to expose: this is the API location, never the bearer token.
       __FUNKY_API_URL__: JSON.stringify(target.replace(/\/+$/, '')),
     },

--- a/apps/worker/src/config.ts
+++ b/apps/worker/src/config.ts
@@ -40,9 +40,13 @@ const EnvSchema = z
     // e2b: an isolated remote sandbox per session. (The in-process subprocess driver still
     // exists for the offline test suites, but is not a production sandbox option.)
     FUNKY_SANDBOX: z.enum(["docker", "e2b"]).default("docker"),
-    // Required when FUNKY_LLM=ai-sdk, and for agents with runtime=claude-code (the
+    // Used by the direct Anthropic provider and by agents with runtime=claude-code (the
     // harness driver is only constructed when this key is present).
     ANTHROPIC_API_KEY: optionalSecret,
+    // Direct AI SDK provider credentials. At least one supported provider key is required
+    // when the real driver is enabled; each agent still selects its own provider/model.
+    OPENAI_API_KEY: optionalSecret,
+    TOGETHER_API_KEY: optionalSecret,
     // Harness (claude-code) knobs. CWD_ROOT must be identical across the worker
     // fleet — the harness derives the transcript store's projectKey from it.
     // SCRATCH_ROOT holds the disposable per-attempt local session copy; point it at
@@ -61,12 +65,20 @@ const EnvSchema = z
       .default(30 * 60_000),
     DB_POOL_MAX: z.coerce.number().int().min(1).default(10),
   })
-  .refine((e) => e.FUNKY_LLM !== "ai-sdk" || e.ANTHROPIC_API_KEY !== undefined, {
-    message:
-      "ANTHROPIC_API_KEY is required when FUNKY_LLM=ai-sdk. " +
-      "Set it, or leave FUNKY_LLM=fake for local development.",
-    path: ["ANTHROPIC_API_KEY"],
-  })
+  .refine(
+    (e) =>
+      e.FUNKY_LLM !== "ai-sdk" ||
+      e.ANTHROPIC_API_KEY !== undefined ||
+      e.OPENAI_API_KEY !== undefined ||
+      e.TOGETHER_API_KEY !== undefined,
+    {
+      message:
+        "ANTHROPIC_API_KEY, OPENAI_API_KEY, or TOGETHER_API_KEY is required when " +
+        "FUNKY_LLM=ai-sdk. Set the key for your model provider, or leave FUNKY_LLM=fake " +
+        "for local development.",
+      path: ["FUNKY_LLM"],
+    },
+  )
   .refine((e) => e.FUNKY_SANDBOX !== "e2b" || e.E2B_API_KEY !== undefined, {
     message:
       "E2B_API_KEY is required when FUNKY_SANDBOX=e2b. " +
@@ -82,8 +94,10 @@ export type Config = {
   metricsModes: MetricsMode[];
   llm: "fake" | "ai-sdk";
   sandbox: "docker" | "e2b";
-  /** null = fake driver; no key needed. */
+  /** null = this provider is unavailable (and, for Anthropic, no Claude Code harness). */
   anthropicApiKey: string | null;
+  openaiApiKey: string | null;
+  togetherApiKey: string | null;
   harnessCwdRoot: string;
   harnessScratchRoot: string;
   /** null = docker driver; no key needed. */
@@ -113,6 +127,8 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     llm: e.FUNKY_LLM,
     sandbox: e.FUNKY_SANDBOX,
     anthropicApiKey: e.ANTHROPIC_API_KEY ?? null,
+    openaiApiKey: e.OPENAI_API_KEY ?? null,
+    togetherApiKey: e.TOGETHER_API_KEY ?? null,
     harnessCwdRoot: e.FUNKY_HARNESS_CWD_ROOT,
     harnessScratchRoot: e.FUNKY_HARNESS_SCRATCH_ROOT,
     e2bApiKey: e.E2B_API_KEY ?? null,

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -80,7 +80,14 @@ console.log(
 // FUNKY_LLM=ai-sdk.
 function llmConfig(c: Config): LlmConfig {
   return c.llm === "ai-sdk"
-    ? { driver: "ai-sdk" }
+    ? {
+        driver: "ai-sdk",
+        credentials: {
+          ...(c.anthropicApiKey ? { anthropicApiKey: c.anthropicApiKey } : {}),
+          ...(c.openaiApiKey ? { openaiApiKey: c.openaiApiKey } : {}),
+          ...(c.togetherApiKey ? { togetherApiKey: c.togetherApiKey } : {}),
+        },
+      }
     : { driver: "fake", instance: new FakeLlm({ scripts: {} }) };
 }
 

--- a/apps/worker/test/config.test.ts
+++ b/apps/worker/test/config.test.ts
@@ -29,6 +29,8 @@ describe("loadConfig — valid input", () => {
       llm: "fake",
       sandbox: "docker",
       anthropicApiKey: null,
+      openaiApiKey: null,
+      togetherApiKey: null,
       e2bApiKey: null,
       e2bSandboxTimeoutMs: 30 * 60_000,
       dockerImage: "funky-sandbox:trixie",
@@ -49,9 +51,28 @@ describe("loadConfig — valid input", () => {
   });
 
   it("treats empty-string secrets as absent (compose `${VAR:-}` sends '' for unset keys)", () => {
-    const cfg = loadConfig({ ...BASE, ANTHROPIC_API_KEY: "", E2B_API_KEY: "" });
+    const cfg = loadConfig({
+      ...BASE,
+      ANTHROPIC_API_KEY: "",
+      OPENAI_API_KEY: "",
+      TOGETHER_API_KEY: "",
+      E2B_API_KEY: "",
+    });
     expect(cfg.anthropicApiKey).toBeNull();
+    expect(cfg.openaiApiKey).toBeNull();
+    expect(cfg.togetherApiKey).toBeNull();
     expect(cfg.e2bApiKey).toBeNull();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["Anthropic", "ANTHROPIC_API_KEY", "sk-ant-secret", "anthropicApiKey"],
+    ["OpenAI", "OPENAI_API_KEY", "sk-openai-secret", "openaiApiKey"],
+    ["Together AI", "TOGETHER_API_KEY", "together-secret", "togetherApiKey"],
+  ] as const)("allows the ai-sdk driver with only a %s key", (_provider, key, value, property) => {
+    const cfg = loadConfig({ ...BASE, FUNKY_LLM: "ai-sdk", [key]: value });
+    expect(cfg.llm).toBe("ai-sdk");
+    expect(cfg[property]).toBe(value);
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
@@ -94,6 +115,8 @@ describe("loadConfig — valid input", () => {
       llm: "ai-sdk",
       sandbox: "e2b",
       anthropicApiKey: "sk-ant-secret",
+      openaiApiKey: null,
+      togetherApiKey: null,
       e2bApiKey: "e2b_secret",
       e2bSandboxTimeoutMs: 600_000,
       dockerImage: "funky-sandbox:trixie",
@@ -108,7 +131,7 @@ describe("loadConfig — invalid input exits the process", () => {
   it.each([
     ["missing DATABASE_URL", {}],
     ["empty DATABASE_URL", { DATABASE_URL: "" }],
-    ["ai-sdk without ANTHROPIC_API_KEY", { ...BASE, FUNKY_LLM: "ai-sdk" }],
+    ["ai-sdk without a supported provider API key", { ...BASE, FUNKY_LLM: "ai-sdk" }],
     ["e2b without E2B_API_KEY", { ...BASE, FUNKY_SANDBOX: "e2b" }],
     ["e2b with empty E2B_API_KEY", { ...BASE, FUNKY_SANDBOX: "e2b", E2B_API_KEY: "" }],
     [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,8 @@ services:
       # avoids "why does the worker behave differently" confusion.
       FUNKY_LLM: ${FUNKY_LLM:-fake}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-} # empty unless the user sets it
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      TOGETHER_API_KEY: ${TOGETHER_API_KEY:-}
     depends_on:
       migrate:
         condition: service_completed_successfully
@@ -95,6 +97,8 @@ services:
       FUNKY_DOCKER_IMAGE: ${FUNKY_DOCKER_IMAGE:-funky-sandbox:trixie} # built by the sandbox-image service
       FUNKY_WORKER_CONCURRENCY: ${FUNKY_WORKER_CONCURRENCY:-10}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-} # empty unless the user sets it
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      TOGETHER_API_KEY: ${TOGETHER_API_KEY:-}
       E2B_API_KEY: ${E2B_API_KEY:-} # empty unless the user sets it
       FUNKY_E2B_SANDBOX_TIMEOUT_MS: ${FUNKY_E2B_SANDBOX_TIMEOUT_MS:-1800000}
       # Metric exporters: "prometheus" (default, scrape :9090/metrics), "otlp" (push via
@@ -141,6 +145,7 @@ services:
       FUNKY_API_URL: http://api:3000 # ← service name, not localhost (proxy target on the compose network)
       FUNKY_AUTH_TOKEN: ${FUNKY_AUTH_TOKEN:?set FUNKY_AUTH_TOKEN in .env — any long random string}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-} # presence flips the console's Claude model option on
+      TOGETHER_API_KEY: ${TOGETHER_API_KEY:-} # presence flips the console's Together model options on
     depends_on:
       api:
         condition: service_healthy

--- a/packages/ports/llm/package.json
+++ b/packages/ports/llm/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^4.0.0",
     "@ai-sdk/openai": "^4.0.0",
+    "@ai-sdk/togetherai": "^3.0.17",
     "@funky/db": "workspace:*",
     "@funky/sessions": "workspace:*",
     "ai": "^7.0.0",

--- a/packages/ports/llm/src/ai-sdk.mock.test.ts
+++ b/packages/ports/llm/src/ai-sdk.mock.test.ts
@@ -17,6 +17,7 @@ import { getCounter, resetCounters } from "./metrics";
 import type { ChatMessage } from "./port";
 
 const MODEL: ModelConfig = { provider: "anthropic", model: "claude-sonnet-5" };
+const CREDENTIALS = { anthropicApiKey: "sk-ant-test" };
 const MSGS: ChatMessage[] = [{ role: "user", content: "do three things" }];
 
 function mockResult(toolCalls: Array<{ toolName: string; input: unknown }>) {
@@ -41,7 +42,7 @@ describe("AiSdkLlm parallel-tool-call cap", () => {
       { toolName: "exec", input: { cmd: "whoami" } },
     ]);
 
-    const r = await new AiSdkLlm().complete({ model: MODEL, messages: MSGS });
+    const r = await new AiSdkLlm(CREDENTIALS).complete({ model: MODEL, messages: MSGS });
 
     expect(r.toolCall).toEqual({ kind: "exec", cmd: "ls" });
     expect(getCounter("llm_tool_calls_dropped_total")).toBe(2); // 3 returned − 1 kept
@@ -50,7 +51,7 @@ describe("AiSdkLlm parallel-tool-call cap", () => {
   it("does not count drops when the provider returns a single call", async () => {
     mockResult([{ toolName: "exec", input: { cmd: "ls" } }]);
 
-    const r = await new AiSdkLlm().complete({ model: MODEL, messages: MSGS });
+    const r = await new AiSdkLlm(CREDENTIALS).complete({ model: MODEL, messages: MSGS });
 
     expect(r.toolCall).toEqual({ kind: "exec", cmd: "ls" });
     expect(getCounter("llm_tool_calls_dropped_total")).toBe(0);
@@ -59,10 +60,31 @@ describe("AiSdkLlm parallel-tool-call cap", () => {
   it("requests provider-side disable of parallel tool use", async () => {
     mockResult([]);
 
-    await new AiSdkLlm().complete({ model: MODEL, messages: MSGS });
+    await new AiSdkLlm(CREDENTIALS).complete({ model: MODEL, messages: MSGS });
 
     const call = vi.mocked(generateText).mock.calls[0]![0];
     expect(call.providerOptions).toEqual({ anthropic: { disableParallelToolUse: true } });
+  });
+
+  it("resolves Together AI models and disables parallel tool calls on its compatible API", async () => {
+    mockResult([]);
+    const model: ModelConfig = {
+      provider: "togetherai",
+      model: "openai/gpt-oss-20b",
+    };
+
+    await new AiSdkLlm({ togetherApiKey: "together-test" }).complete({
+      model,
+      messages: MSGS,
+    });
+
+    const call = vi.mocked(generateText).mock.calls[0]![0];
+    const resolved = call.model as Exclude<typeof call.model, string>;
+    expect(resolved.provider).toBe("togetherai.chat");
+    expect(resolved.modelId).toBe(model.model);
+    expect(call.providerOptions).toEqual({
+      togetherai: { parallel_tool_calls: false },
+    });
   });
 
   // ai@7 rejects system-role messages in `messages` ("Use the instructions option instead").
@@ -70,7 +92,7 @@ describe("AiSdkLlm parallel-tool-call cap", () => {
   it("routes the system prompt to `instructions`, never into `messages`", async () => {
     mockResult([]);
 
-    await new AiSdkLlm().complete({
+    await new AiSdkLlm(CREDENTIALS).complete({
       model: MODEL,
       messages: [
         { role: "system", content: "You are a helpful engineer." },
@@ -91,7 +113,7 @@ describe("AiSdkLlm parallel-tool-call cap", () => {
   it("sanitizes the tool_use id (no colons) and keeps call/result paired", async () => {
     mockResult([]);
 
-    await new AiSdkLlm().complete({
+    await new AiSdkLlm(CREDENTIALS).complete({
       model: MODEL,
       messages: [
         { role: "user", content: "run something" },

--- a/packages/ports/llm/src/ai-sdk.test.ts
+++ b/packages/ports/llm/src/ai-sdk.test.ts
@@ -12,7 +12,7 @@ describe.skipIf(!hasKey)("AiSdkLlm (real anthropic round-trip)", () => {
   const model: ModelConfig = { provider: "anthropic", model: "claude-sonnet-5", maxTokens: 1024 };
 
   it("returns an exec ToolCall when the prompt requires a shell command", async () => {
-    const llm = new AiSdkLlm();
+    const llm = new AiSdkLlm({ anthropicApiKey: process.env.ANTHROPIC_API_KEY! });
     const messages: ChatMessage[] = [
       {
         role: "system",
@@ -35,7 +35,7 @@ describe.skipIf(!hasKey)("AiSdkLlm (real anthropic round-trip)", () => {
   // its tool_result, keyed by our idemKey (`sessionId:seq:index`). Anthropic rejects a
   // tool_use.id containing colons, so this round-trip only succeeds once the id is sanitized.
   it("accepts a replayed tool_use/tool_result history (idemKey has colons)", async () => {
-    const llm = new AiSdkLlm();
+    const llm = new AiSdkLlm({ anthropicApiKey: process.env.ANTHROPIC_API_KEY! });
     const messages: ChatMessage[] = [
       { role: "system", content: "You control a Linux sandbox. Use the exec tool for shell commands." },
       { role: "user", content: "run: echo hi" },

--- a/packages/ports/llm/src/ai-sdk.together.test.ts
+++ b/packages/ports/llm/src/ai-sdk.together.test.ts
@@ -1,0 +1,64 @@
+// Offline contract test for the Together AI adapter. This exercises the real AI SDK
+// provider up to the HTTP boundary and verifies the model id, credential, tools, and
+// single-tool-call option that Funky's native loop relies on.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ModelConfig } from "@funky/db/schema";
+import { AiSdkLlm } from "./drivers/ai-sdk";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("AiSdkLlm (Together AI HTTP contract)", () => {
+  it("sends a Together chat completion with the exec tool and parallel calls disabled", async () => {
+    const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      return new Response(
+        JSON.stringify({
+          id: "completion-test",
+          object: "chat.completion",
+          created: 1,
+          model: "openai/gpt-oss-20b",
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: "done" },
+              finish_reason: "stop",
+            },
+          ],
+          usage: { prompt_tokens: 7, completion_tokens: 2, total_tokens: 9 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const model: ModelConfig = {
+      provider: "togetherai",
+      model: "openai/gpt-oss-20b",
+    };
+    const result = await new AiSdkLlm({ togetherApiKey: "together-test-key" }).complete({
+      model,
+      messages: [{ role: "user", content: "say done" }],
+    });
+
+    expect(result.content).toBe("done");
+    expect(result.usage).toEqual({ inputTokens: 7, outputTokens: 2 });
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toMatch(/\/v1\/chat\/completions$/);
+    expect(new Headers(init?.headers).get("authorization")).toBe(
+      "Bearer together-test-key",
+    );
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body.model).toBe(model.model);
+    expect(body.parallel_tool_calls).toBe(false);
+    expect(body.tools).toEqual([
+      expect.objectContaining({
+        type: "function",
+        function: expect.objectContaining({ name: "exec" }),
+      }),
+    ]);
+  });
+});

--- a/packages/ports/llm/src/drivers/ai-sdk.ts
+++ b/packages/ports/llm/src/drivers/ai-sdk.ts
@@ -7,6 +7,7 @@
 
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { createOpenAI } from "@ai-sdk/openai";
+import { createTogetherAI } from "@ai-sdk/togetherai";
 import {
   APICallError,
   type LanguageModel,
@@ -32,6 +33,12 @@ import {
 const EXEC_TOOL = "exec";
 const MAX_ATTEMPTS = 3;
 
+export type AiSdkCredentials = {
+  anthropicApiKey?: string;
+  openaiApiKey?: string;
+  togetherApiKey?: string;
+};
+
 // No `execute`: the model's exec call is returned and generation stops after one step
 // (generateText's default). The worker runs the command in the sandbox, not the SDK.
 const execTool = tool({
@@ -50,8 +57,10 @@ const execTool = tool({
 });
 
 export class AiSdkLlm implements LlmPort {
+  constructor(private readonly credentials: AiSdkCredentials) {}
+
   async complete(req: LlmRequest): Promise<LlmResult> {
-    const model = resolveModel(req.model);
+    const model = resolveModel(req.model, this.credentials);
     const { instructions, messages } = toModelMessages(req.messages);
     const providerOptions = parallelToolUseOff(req.model);
 
@@ -88,27 +97,33 @@ export class AiSdkLlm implements LlmPort {
   }
 }
 
-function resolveModel(cfg: ModelConfig): LanguageModel {
+function resolveModel(cfg: ModelConfig, credentials: AiSdkCredentials): LanguageModel {
   switch (cfg.provider) {
     case "anthropic":
-      return createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })(cfg.model);
+      return createAnthropic({ apiKey: credentials.anthropicApiKey })(cfg.model);
     case "openai":
-      return createOpenAI({ apiKey: process.env.OPENAI_API_KEY })(cfg.model);
+      return createOpenAI({ apiKey: credentials.openaiApiKey })(cfg.model);
+    case "togetherai":
+      return createTogetherAI({ apiKey: credentials.togetherApiKey })(cfg.model);
     default:
-      // v1 ships anthropic + openai; the others are wired identically when needed.
+      // The remaining ModelConfig providers are accepted at the API edge for forward
+      // compatibility; add their AI SDK adapters here as they become runtime-supported.
       throw new LlmPermanentError(`llm provider not supported in v1: ${cfg.provider}`);
   }
 }
 
 // Layer 1 of the v1 tool-call cap: tell the provider to plan sequentially so it never
 // emits a batch in the first place — no intent is dropped. Anthropic and OpenAI spell it
-// differently; both go through the AI SDK's per-provider providerOptions.
+// differently; Together uses the OpenAI-compatible wire name. All go through the AI SDK's
+// per-provider providerOptions.
 function parallelToolUseOff(cfg: ModelConfig): Record<string, Record<string, boolean>> | undefined {
   switch (cfg.provider) {
     case "anthropic":
       return { anthropic: { disableParallelToolUse: true } };
     case "openai":
       return { openai: { parallelToolCalls: false } };
+    case "togetherai":
+      return { togetherai: { parallel_tool_calls: false } };
     default:
       return undefined;
   }

--- a/packages/ports/llm/src/index.ts
+++ b/packages/ports/llm/src/index.ts
@@ -3,24 +3,26 @@
 
 export * from "./port";
 export { FakeLlm, type FakeTurn } from "./drivers/fake";
-export { AiSdkLlm } from "./drivers/ai-sdk";
+export { AiSdkLlm, type AiSdkCredentials } from "./drivers/ai-sdk";
 export { getCounter, incrCounter, resetCounters } from "./metrics";
 
 import type { LlmPort } from "./port";
-import { AiSdkLlm } from "./drivers/ai-sdk";
+import { AiSdkLlm, type AiSdkCredentials } from "./drivers/ai-sdk";
 import type { FakeLlm } from "./drivers/fake";
 
 // Fake construction args come from test setup, not env — so the factory takes the
 // already-built driver in tests. The worker entrypoint reads FUNKY_LLM and builds the
 // ai-sdk driver from env.
-export type LlmConfig = { driver: "fake"; instance: FakeLlm } | { driver: "ai-sdk" };
+export type LlmConfig =
+  | { driver: "fake"; instance: FakeLlm }
+  | { driver: "ai-sdk"; credentials: AiSdkCredentials };
 
 export function makeLlm(cfg: LlmConfig): LlmPort {
   switch (cfg.driver) {
     case "fake":
       return cfg.instance;
     case "ai-sdk":
-      return new AiSdkLlm();
+      return new AiSdkLlm(cfg.credentials);
     default: {
       const never: never = cfg;
       throw new Error(`unknown llm driver: ${JSON.stringify(never)}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^4.0.0
         version: 4.0.11(zod@4.4.3)
+      '@ai-sdk/togetherai':
+        specifier: ^3.0.17
+        version: 3.0.17(zod@4.4.3)
       '@funky/db':
         specifier: workspace:*
         version: link:../../db
@@ -381,8 +384,20 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/openai-compatible@3.0.16':
+    resolution: {integrity: sha512-beXoYtlCnI02BYZU6oGfOPI40xC8MJx+Ek0SM8XZ8RcBBP7SaQ0qIV5DO3Y1euHMLMD92zE7nNHM0WcnnnX58A==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/openai@4.0.11':
     resolution: {integrity: sha512-2PLnVPBsdJusgquPVYgPWd3ox4lbUFkp7DVUSmM0lQ4VISQoNxdgo6TvFAHgwQn9wJ/ckVYVRLU7+BvHc7T8ww==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.14':
+    resolution: {integrity: sha512-HW+Ys98cr2BRQzP6jTlp2bRKIqt+oAjYNLm9gqUUQkLz7QERtaPgDZOoXHz9IXSXoOtz175p4Q17qKQdEX0Hag==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -396,6 +411,16 @@ packages:
   '@ai-sdk/provider@4.0.3':
     resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
     engines: {node: '>=22'}
+
+  '@ai-sdk/provider@4.0.4':
+    resolution: {integrity: sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/togetherai@3.0.17':
+    resolution: {integrity: sha512-9m8jkgucCOfb7idm2OZntUXtVEqqmxRBUu0WzDTSjiZ39figGEpCIa0ZkwGfBLnEL9Ud1S1B9TMCLa0cLRa9+Q==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.214':
     resolution: {integrity: sha512-vAAOeVtlXs3p7MpFVfvfu9ja32eaKtB+MDZnPxCbdzxJk5nofCHlNsHa1UJwXHOsP9lOnFYNIccYztsZ4DNaJA==}
@@ -2839,10 +2864,24 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
+  '@ai-sdk/openai-compatible@3.0.16(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.4
+      '@ai-sdk/provider-utils': 5.0.14(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/openai@4.0.11(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.3
       '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.14(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.4
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@5.0.7(zod@4.4.3)':
@@ -2856,6 +2895,17 @@ snapshots:
   '@ai-sdk/provider@4.0.3':
     dependencies:
       json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.4':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/togetherai@3.0.17(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/openai-compatible': 3.0.16(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.4
+      '@ai-sdk/provider-utils': 5.0.14(zod@4.4.3)
+      zod: 4.4.3
 
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.214':
     optional: true


### PR DESCRIPTION
## Summary
Adds direct Together AI support through `@ai-sdk/togetherai`, explicit provider credential plumbing, Compose/env documentation, and offline HTTP contract coverage.
Extends worker startup validation to accept Anthropic, OpenAI, or Together credentials and verifies Together agent configs at the API edge.
Adds provider-aware web options for GLM-5.2, DeepSeek V4 Pro, Qwen3.7 Max, and Gemma 4 31B IT, with Kimi K3 shown as coming soon and Claude Code restricted to Anthropic models.

## Testing
- `pnpm typecheck`
- `pnpm -F @funky/llm test`
- `pnpm -F worker exec vitest run test/config.test.ts`
- `pnpm -F api exec vitest run test/agents.test.ts`
- `pnpm -F web lint`
- `TOGETHER_API_KEY=test-key ANTHROPIC_API_KEY= pnpm -F web build`
- `docker compose config --quiet`
- `git diff --check`