### PR TITLE
Split sandbox unavailability into unreachable vs gone

### DIFF
--- a/packages/ports/sandbox/package.json
+++ b/packages/ports/sandbox/package.json
@@ -15,7 +15,8 @@
     "@computesdk/e2b": "^1.7.51",
     "@funky/db": "workspace:*",
     "@funky/sessions": "workspace:*",
-    "computesdk": "^4.1.3"
+    "computesdk": "^4.1.3",
+    "e2b": "^2.33.0"
   },
   "devDependencies": {
     "vitest": "^4.1.10"

--- a/packages/ports/sandbox/src/computesdk.test.ts
+++ b/packages/ports/sandbox/src/computesdk.test.ts
@@ -19,10 +19,11 @@ import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import { e2b } from "@computesdk/e2b";
 import type { CommandResult, CreateSandboxOptions, SandboxInterface } from "computesdk";
 import { describe, expect, it } from "vitest";
 import { type ComputeProvider, ComputeSdkDriver } from "./drivers/computesdk";
+import { e2bProvider } from "./drivers/e2b";
+import { SandboxGoneError, SandboxUnreachableError } from "./port";
 import { runSandboxTck } from "./tck";
 
 const sh = promisify(execFile);
@@ -40,7 +41,9 @@ if (apiKey) {
     () =>
       new ComputeSdkDriver({
         providerName: "e2b",
-        provider: e2b({ apiKey }),
+        // The production wrapper (drivers/e2b.ts), not @computesdk/e2b directly — TCK
+        // case 7 (destroyed ⇒ GONE) only passes with its disambiguating getById.
+        provider: e2bProvider({ apiKey }),
         sandboxTimeoutMs: 5 * 60_000, // TCK sandboxes are short-lived
       }),
     { timeoutMs: 120_000 },
@@ -78,6 +81,73 @@ describe("ComputeSDK sandbox lifecycle", () => {
     } finally {
       await driver.teardown(handle);
     }
+  });
+});
+
+// The gone-vs-unreachable split rests on the provider contract: getById returns null
+// ONLY on positive does-not-exist evidence and rejects on transport failures. These pin
+// how the driver maps each side of that contract (TCK case 7 covers the real drivers).
+describe("ComputeSDK error taxonomy", () => {
+  const collect = async (it: AsyncIterable<unknown>) => {
+    for await (const _ of it) {
+      // drain
+    }
+  };
+
+  function driverWith(sandbox: Partial<ComputeProvider["sandbox"]>): ComputeSdkDriver {
+    return new ComputeSdkDriver({
+      providerName: "fake-local",
+      provider: {
+        name: "fake-local",
+        sandbox: {
+          create: async () => {
+            throw new Error("create is not under test");
+          },
+          getById: async () => null,
+          destroy: async () => {},
+          ...sandbox,
+        },
+      },
+    });
+  }
+
+  const handle = { driver: "fake-local", sandboxId: "sb-1", workdir: "/home/user/funky" };
+
+  it("getById → null maps to SandboxGoneError", async () => {
+    const driver = driverWith({ getById: async () => null });
+    await expect(
+      collect(driver.connect(handle).exec({ cmd: "echo hi", idemKey: "k1" })),
+    ).rejects.toBeInstanceOf(SandboxGoneError);
+  });
+
+  it("getById → rejection maps to SandboxUnreachableError", async () => {
+    const driver = driverWith({
+      getById: async () => {
+        throw new Error("ECONNRESET");
+      },
+    });
+    await expect(
+      collect(driver.connect(handle).exec({ cmd: "echo hi", idemKey: "k1" })),
+    ).rejects.toBeInstanceOf(SandboxUnreachableError);
+  });
+
+  it("a wrapper transport failure (exit 127) maps to SandboxUnreachableError, never gone", async () => {
+    // The sandbox connected fine, then runCommand hit the provider's caught-transport-error
+    // path. The wrapper cannot say WHY, so the driver must not claim gone.
+    const sb = {
+      sandboxId: "sb-1",
+      provider: "fake-local",
+      runCommand: async (): Promise<CommandResult> => ({
+        stdout: "",
+        stderr: "socket hang up",
+        exitCode: 127,
+        durationMs: 0,
+      }),
+    } as unknown as SandboxInterface;
+    const driver = driverWith({ getById: async () => sb });
+    await expect(
+      collect(driver.connect(handle).exec({ cmd: "echo hi", idemKey: "k1" })),
+    ).rejects.toBeInstanceOf(SandboxUnreachableError);
   });
 });
 

--- a/packages/ports/sandbox/src/drivers/computesdk.ts
+++ b/packages/ports/sandbox/src/drivers/computesdk.ts
@@ -27,7 +27,9 @@ import {
   type Executor,
   type SandboxDriver,
   type SandboxHandle,
+  SandboxGoneError,
   SandboxUnavailableError,
+  SandboxUnreachableError,
 } from "../port";
 
 type Manager = ReturnType<CallableCompute>;
@@ -101,7 +103,7 @@ export class ComputeSdkDriver implements SandboxDriver {
   async reboot(handle: SandboxHandle): Promise<SandboxHandle> {
     const h = parseHandle(handle, this.providerName);
     const sb = await this.manager.sandbox.getById(h.sandboxId).catch(() => null);
-    if (!sb) throw new SandboxUnavailableError(`sandbox ${h.sandboxId} is gone (cannot reboot)`);
+    if (!sb) throw new SandboxGoneError(`sandbox ${h.sandboxId} is gone (cannot reboot)`);
     return handle;
   }
 
@@ -128,18 +130,20 @@ class ComputeSdkExecutor implements Executor {
     private readonly workdir: string,
   ) {}
 
-  // getById returns null for a dead sandbox AND for transport failures — both mean the
-  // same thing here: we cannot observe anything, so SandboxUnavailableError.
+  // The provider contract this driver relies on (docker.ts enforces it for containers,
+  // index.ts's transparent e2b wrapper for E2B): getById returns null ONLY when the
+  // provider positively reported the sandbox does not exist, and REJECTS on transport
+  // failures. So null ⇒ gone, rejection ⇒ unreachable.
   private sandbox(): Promise<SandboxInterface> {
     this.sb ??= this.manager.sandbox.getById(this.sandboxId).then(
       (sb) => {
         if (sb) return sb;
         this.sb = null;
-        throw new SandboxUnavailableError(`sandbox ${this.sandboxId} is gone`);
+        throw new SandboxGoneError(`sandbox ${this.sandboxId} is gone`);
       },
       (err) => {
         this.sb = null;
-        throw new SandboxUnavailableError(
+        throw new SandboxUnreachableError(
           `sandbox ${this.sandboxId} is unreachable: ${err instanceof Error ? err.message : String(err)}`,
         );
       },
@@ -165,9 +169,11 @@ class ComputeSdkExecutor implements Executor {
     return (async function* () {
       const sb = await self.sandbox();
       const dir = keyDir(self.workdir, idemKey);
-      // Nothing recorded under this idemKey → no result to observe. `test -d` failing
-      // for transport reasons lands in the same class: unobservable.
+      // Exit 127 is the provider's caught-transport-error marker (see readFile); a real
+      // `test -d` on a missing dir exits 1 — the sandbox answered, nothing is recorded
+      // under this idemKey, and neither subclass fits that: base unavailability.
       const r = await sb.runCommand(`test -d ${shq(dir)}`);
+      if (r.exitCode === 127) throw unavailable(self.sandboxId, r);
       if (r.exitCode !== 0) throw new SandboxUnavailableError(`no running command for idemKey: ${idemKey}`);
       yield* tail(sb, self.sandboxId, dir);
     })();
@@ -284,8 +290,11 @@ function keyDir(workdir: string, idemKey: string): string {
   return posix.join(workdir, ".funky", idemKey);
 }
 
-function unavailable(sandboxId: string, r: { exitCode: number; stderr: string }): SandboxUnavailableError {
-  return new SandboxUnavailableError(
+// A failed wrapper cannot say WHY the sandbox was unobservable (the provider folds its
+// caught transport errors into exit 127), so this is unreachable, never gone: a retry
+// reconnects through getById, which CAN tell — and never terminal on ambiguous evidence.
+function unavailable(sandboxId: string, r: { exitCode: number; stderr: string }): SandboxUnreachableError {
+  return new SandboxUnreachableError(
     `sandbox ${sandboxId} unreachable (wrapper exit ${r.exitCode}): ${r.stderr.trim()}`,
   );
 }

--- a/packages/ports/sandbox/src/drivers/docker.ts
+++ b/packages/ports/sandbox/src/drivers/docker.ts
@@ -103,11 +103,15 @@ export function dockerProvider(opts: DockerProviderOptions): ComputeProvider {
       },
       // `docker start` is idempotent on a running container AND resumes a stopped one with
       // its filesystem intact — so a container that was paused (or survived a daemon
-      // restart) "auto-resumes" here, exactly the semantics ComputeSdkDriver.reboot expects.
-      // A missing container → non-zero → null (the driver reads that as unavailable).
+      // restart) "auto-resumes" here. The driver's provider contract: null ONLY on positive
+      // evidence the container no longer exists ("No such container" — the daemon answered),
+      // and a THROW for everything else (daemon unreachable, docker binary absent), which
+      // ComputeSdkDriver reads as unreachable-but-retryable.
       getById: async (id: string): Promise<SandboxInterface | null> => {
         const r = await run(docker, ["start", id]);
-        return r.code === 0 ? makeSandbox(id) : null;
+        if (r.code === 0) return makeSandbox(id);
+        if (/No such container/i.test(r.stderr)) return null;
+        throw new Error(`docker start ${id} failed: ${r.stderr.trim() || `exit ${r.code}`}`);
       },
       // rm -f removes a running or stopped container; run() never rejects and rm -f on a
       // missing container is a no-op error we swallow, so teardown stays idempotent.

--- a/packages/ports/sandbox/src/drivers/e2b.ts
+++ b/packages/ports/sandbox/src/drivers/e2b.ts
@@ -1,0 +1,50 @@
+// packages/ports/sandbox/src/drivers/e2b.ts — error-transparent E2B provider.
+//
+// @computesdk/e2b's getById does `catch { return null }`: it folds EVERY failure —
+// a destroyed sandbox AND a transport blip — into null. ComputeSdkDriver's provider
+// contract needs those apart (null ⇒ positively gone, throw ⇒ unreachable), because
+// the turn loop's error policy treats "gone" as terminal. This wrapper restores the
+// distinction with one raw e2b SDK probe on the null path only: Sandbox.connect()
+// throws SandboxNotFoundError exactly when the API answered 404 (the sandbox no
+// longer exists) and rejects with anything else on transport/API failures. The happy
+// path stays a single provider call; connect() on a paused sandbox resumes it, which
+// is the reconnect path's job anyway.
+
+import { e2b } from "@computesdk/e2b";
+import { Sandbox as E2BSandbox, SandboxNotFoundError } from "e2b";
+import type { ComputeProvider } from "./computesdk";
+
+export type E2bProviderOptions = { apiKey: string };
+
+/** The probe seam: resolves if the sandbox exists (resuming it if paused), throws
+ *  SandboxNotFoundError if the API positively reported it gone, rejects otherwise. */
+export type E2bProbe = (sandboxId: string) => Promise<unknown>;
+
+export function e2bProvider(opts: E2bProviderOptions): ComputeProvider {
+  return withProbedGetById(
+    e2b({ apiKey: opts.apiKey }),
+    (id) => E2BSandbox.connect(id, { apiKey: opts.apiKey }),
+  );
+}
+
+/** The wrap itself, split from e2bProvider so tests can inject both seams. */
+export function withProbedGetById(base: ComputeProvider, probe: E2bProbe): ComputeProvider {
+  return {
+    ...base,
+    sandbox: {
+      ...base.sandbox,
+      getById: async (sandboxId) => {
+        const sb = await base.sandbox.getById(sandboxId);
+        if (sb) return sb;
+        try {
+          await probe(sandboxId);
+        } catch (err) {
+          if (err instanceof SandboxNotFoundError) return null; // positively gone
+          throw err; // transport / API failure → the driver reads this as unreachable
+        }
+        // The probe reached it, so the base provider's null was itself a swallowed blip.
+        throw new Error(`e2b sandbox ${sandboxId} exists but the provider could not attach to it`);
+      },
+    },
+  };
+}

--- a/packages/ports/sandbox/src/drivers/subprocess.ts
+++ b/packages/ports/sandbox/src/drivers/subprocess.ts
@@ -15,7 +15,7 @@ import { type FileHandle, open } from "node:fs/promises";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { ResolvedEnv } from "@funky/db/schema";
-import { type ExecEvent, type Executor, type SandboxDriver, type SandboxHandle, SandboxUnavailableError } from "../port";
+import { type ExecEvent, type Executor, type SandboxDriver, type SandboxHandle, SandboxGoneError, SandboxUnavailableError } from "../port";
 
 const ROOT = "/tmp/funky";
 const MAX_OUTPUT_BYTES = 200_000;
@@ -52,9 +52,9 @@ class SubprocessExecutor implements Executor {
   exec(req: { cmd: string; idemKey: string; timeoutMs?: number }): AsyncIterable<ExecEvent> {
     const { workdir } = this;
     return (async function* () {
-      // No workdir → torn down / unreachable: we can't observe a result, so this is an
-      // infrastructure error (throw), never a synthesized exit code.
-      if (!(await exists(workdir))) throw new SandboxUnavailableError("sandbox is not provisioned");
+      // No workdir → torn down (or never provisioned). The local filesystem answered
+      // definitively, so this is GONE — positive evidence, never a synthesized exit code.
+      if (!(await exists(workdir))) throw new SandboxGoneError("sandbox is not provisioned");
       const funkyRoot = path.join(workdir, ".funky");
       await fs.mkdir(funkyRoot, { recursive: true });
       const dir = path.join(funkyRoot, req.idemKey);

--- a/packages/ports/sandbox/src/e2b.test.ts
+++ b/packages/ports/sandbox/src/e2b.test.ts
@@ -1,0 +1,56 @@
+// The e2b wrapper's whole job is disambiguating the base provider's swallowed-into-null
+// getById (see drivers/e2b.ts). These pin the three probe outcomes on the null path and
+// that a live base result skips the probe entirely.
+
+import { SandboxNotFoundError } from "e2b";
+import type { SandboxInterface } from "computesdk";
+import { describe, expect, it } from "vitest";
+import type { ComputeProvider } from "./drivers/computesdk";
+import { withProbedGetById } from "./drivers/e2b";
+
+function baseReturning(result: SandboxInterface | null): ComputeProvider {
+  return {
+    name: "e2b",
+    sandbox: {
+      create: async () => {
+        throw new Error("create is not under test");
+      },
+      getById: async () => result,
+      destroy: async () => {},
+    },
+  };
+}
+
+const liveSandbox = { sandboxId: "sb-1", provider: "e2b" } as unknown as SandboxInterface;
+
+describe("e2b withProbedGetById", () => {
+  it("a live base result passes through without probing", async () => {
+    let probed = false;
+    const provider = withProbedGetById(baseReturning(liveSandbox), async () => {
+      probed = true;
+    });
+    expect(await provider.sandbox.getById("sb-1")).toBe(liveSandbox);
+    expect(probed).toBe(false);
+  });
+
+  it("null + probe 404 → null (positively gone)", async () => {
+    const provider = withProbedGetById(baseReturning(null), async (id) => {
+      throw new SandboxNotFoundError(`sandbox ${id} not found`);
+    });
+    expect(await provider.sandbox.getById("sb-1")).toBeNull();
+  });
+
+  it("null + probe transport failure → rejects (unreachable, NOT gone)", async () => {
+    const provider = withProbedGetById(baseReturning(null), async () => {
+      throw new Error("ETIMEDOUT");
+    });
+    await expect(provider.sandbox.getById("sb-1")).rejects.toThrow("ETIMEDOUT");
+  });
+
+  it("null + probe success → rejects (the base's null was a swallowed blip)", async () => {
+    const provider = withProbedGetById(baseReturning(null), async () => {});
+    await expect(provider.sandbox.getById("sb-1")).rejects.toThrow(
+      "exists but the provider could not attach",
+    );
+  });
+});

--- a/packages/ports/sandbox/src/index.ts
+++ b/packages/ports/sandbox/src/index.ts
@@ -2,7 +2,7 @@
 // The worker (Phase E) imports the port; the entrypoint selects a driver by config.
 
 export type { ExecEvent, Executor, SandboxDriver, SandboxHandle } from "./port";
-export { SandboxUnavailableError } from "./port";
+export { SandboxGoneError, SandboxUnavailableError, SandboxUnreachableError } from "./port";
 // SubprocessDriver is NOT a production sandbox option (see makeSandbox / SandboxConfig): it
 // runs commands in the worker's own container with no isolation. It stays exported purely as
 // the fast, offline in-process driver the test suites — including the chaos warranty — run
@@ -10,11 +10,12 @@ export { SandboxUnavailableError } from "./port";
 export { SubprocessDriver } from "./drivers/subprocess";
 export { ComputeSdkDriver, type ComputeSdkDriverOptions, type ComputeProvider } from "./drivers/computesdk";
 export { dockerProvider, type DockerProviderOptions } from "./drivers/docker";
+export { e2bProvider, type E2bProviderOptions } from "./drivers/e2b";
 export { runSandboxTck } from "./tck";
 
-import { e2b } from "@computesdk/e2b";
 import { ComputeSdkDriver } from "./drivers/computesdk";
 import { dockerProvider } from "./drivers/docker";
+import { e2bProvider } from "./drivers/e2b";
 import type { SandboxDriver } from "./port";
 
 export type SandboxConfig =
@@ -34,9 +35,11 @@ export function makeSandbox(cfg: SandboxConfig): SandboxDriver {
         provider: dockerProvider({ image: cfg.image }),
       });
     case "e2b":
+      // e2bProvider, not @computesdk/e2b directly: it restores the gone-vs-unreachable
+      // distinction the raw provider's getById erases (see drivers/e2b.ts).
       return new ComputeSdkDriver({
         providerName: "e2b",
-        provider: e2b({ apiKey: cfg.apiKey }),
+        provider: e2bProvider({ apiKey: cfg.apiKey }),
         sandboxTimeoutMs: cfg.sandboxTimeoutMs,
       });
     default: {

--- a/packages/ports/sandbox/src/port.ts
+++ b/packages/ports/sandbox/src/port.ts
@@ -41,8 +41,27 @@ export interface SandboxDriver {
  *
  *  The rule is mechanical: exit code exists ⇒ yield it; no exit code ⇒ throw this. Never
  *  synthesize a fake exit code for an infrastructure failure — that lies to the model,
- *  telling it a command failed when it may have succeeded. Phase D handles this throw by
- *  retrying the exec by idemKey (→ attach) and rebooting if the sandbox is fatally gone. */
+ *  telling it a command failed when it may have succeeded.
+ *
+ *  Two subclasses split unavailability by what a retry can do about it. Throw the base
+ *  class only when neither applies — evidence is genuinely ambiguous. The caller's policy
+ *  keys on the subclass, so a driver must never claim `gone` without positive evidence
+ *  (the provider answered and said the sandbox does not exist): misclassifying a network
+ *  blip as `gone` turns a retryable hiccup into a terminal failure. */
 export class SandboxUnavailableError extends Error {
-  readonly kind = "sandbox_unavailable" as const;
+  readonly kind: "sandbox_unavailable" | "sandbox_unreachable" | "sandbox_gone" =
+    "sandbox_unavailable";
+}
+
+/** The sandbox most likely still exists but THIS attempt could not reach it (transport
+ *  failure, provider API error). Retrying against the same handle can succeed — the
+ *  idemKey protocol makes that retry safe. */
+export class SandboxUnreachableError extends SandboxUnavailableError {
+  override readonly kind = "sandbox_unreachable";
+}
+
+/** The provider positively reported the sandbox does not exist (destroyed, expired past
+ *  recovery). Its filesystem is lost; no retry against this handle can ever succeed. */
+export class SandboxGoneError extends SandboxUnavailableError {
+  override readonly kind = "sandbox_gone";
 }

--- a/packages/ports/sandbox/src/tck.ts
+++ b/packages/ports/sandbox/src/tck.ts
@@ -9,7 +9,7 @@
 
 import { randomUUID } from "node:crypto";
 import { afterEach, describe, expect, it as baseIt } from "vitest";
-import { type ExecEvent, type Executor, type SandboxDriver, SandboxUnavailableError } from "./port";
+import { type ExecEvent, type Executor, type SandboxDriver, SandboxGoneError, SandboxUnavailableError } from "./port";
 import type { ResolvedEnv } from "@funky/db/schema";
 
 const SPEC: ResolvedEnv = {
@@ -115,12 +115,14 @@ export function runSandboxTck(
       expect(r.stdout.length).toBe(200_000);
     });
 
-    it("7. teardown is idempotent; exec after teardown throws SandboxUnavailableError", async () => {
+    it("7. teardown is idempotent; exec after teardown throws SandboxGoneError", async () => {
       const { driver, handle, exec } = await sandbox();
       await driver.teardown(handle);
       await driver.teardown(handle); // twice → no throw
+      // GONE, not merely unavailable: after a teardown the driver has positive evidence
+      // the sandbox no longer exists, and the caller's policy keys on that distinction.
       await expect(collect(exec.exec({ cmd: "echo hi", idemKey: "k7" }))).rejects.toBeInstanceOf(
-        SandboxUnavailableError,
+        SandboxGoneError,
       );
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,9 @@ importers:
       computesdk:
         specifier: ^4.1.3
         version: 4.1.3
+      e2b:
+        specifier: ^2.33.0
+        version: 2.33.0
     devDependencies:
       vitest:
         specifier: ^4.1.10


### PR DESCRIPTION
Part 1 of 4 of the sandbox-failure-handling simplification (principle: **the runtime only fixes transient errors**).

`SandboxUnavailableError` gains two subclasses the caller's policy can key on:

- **`SandboxUnreachableError`** — transport failure; a retry against the same handle can succeed.
- **`SandboxGoneError`** — the provider **positively** reported the sandbox does not exist; no retry can ever succeed.

The rule is asymmetric on purpose: a driver must never claim `gone` without positive evidence, because misclassifying a network blip as gone would turn a retryable hiccup into a terminal failure (once #3 in this stack lands).

Per driver:
- **computesdk**: `getById` null ⇒ gone, rejection ⇒ unreachable; wrapper exit 127 ⇒ unreachable (a failed wrapper cannot say why — the reconnect's `getById` can).
- **docker provider**: `getById` returns null only on `No such container` (the daemon answered); daemon-unreachable / binary-absent now throw ⇒ unreachable.
- **e2b**: new `e2bProvider` wrapper — `@computesdk/e2b`'s `getById` swallows *every* error into null, so on the null path we disambiguate with one raw `e2b` SDK probe (`Sandbox.connect`: 404 ⇒ gone, anything else ⇒ unreachable). Happy path stays one provider call.
- **subprocess**: missing workdir ⇒ gone (the local fs answered).

TCK case 7 is tightened: exec after teardown must now throw `SandboxGoneError` — pinned for all drivers.

No downstream behavior change: every existing catch site checks the base class, which both subclasses still are. The policy changes ride the next PRs in the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)