### PR TITLE
Remove reboot from the sandbox port; reconnect-and-retry in exec

### DIFF
--- a/apps/worker/test/worker.test.ts
+++ b/apps/worker/test/worker.test.ts
@@ -429,9 +429,6 @@ it("★ crash-resumes: worker B finishes the turn worker A abandoned, running th
     async provision() {
       return { driver: "subprocess", workdir: "/tmp/funky/unused" };
     },
-    async reboot(h) {
-      return h;
-    },
     async teardown() {},
     connect() {
       return {

--- a/packages/db/schema/sessions.ts
+++ b/packages/db/schema/sessions.ts
@@ -19,7 +19,7 @@ import {
 import { agentConfigs } from "./configs";
 import { envConfigs, type NetworkPolicy } from "./envs"; // ⚠ adjust if the env iteration named this file differently
 
-/** Snapshot captured at sandbox provision; reboots rebuild from THIS, never from the
+/** Snapshot captured at sandbox provision; replacements rebuild from THIS, never from the
  *  (mutable) env config. template_id is driver-specific (e.g. E2B template). */
 export type ResolvedEnv = {
   template_id?: string;

--- a/packages/ports/harness/src/port.ts
+++ b/packages/ports/harness/src/port.ts
@@ -20,7 +20,7 @@ export type { HarnessState };
  *  errors — same rule as the sandbox port. */
 export type ExecResult = { output: string; exitCode: number; truncated: boolean };
 
-/** Runs one tool call under an idemKey with the caller's full retry/reboot policy.
+/** Runs one tool call under an idemKey with the caller's full retry policy.
  *  Calling with an idemKey that already ran MUST NOT run the command twice — the
  *  caller wires this to the sandbox port's exec/attach protocol. */
 export type HarnessExecFn = (call: ToolCall, idemKey: string) => Promise<ExecResult>;

--- a/packages/ports/sandbox/src/drivers/computesdk.ts
+++ b/packages/ports/sandbox/src/drivers/computesdk.ts
@@ -66,9 +66,9 @@ export class ComputeSdkDriver implements SandboxDriver {
     }
 
     // lifecycle makes the timeout a pause (disk persisted, resumed on connect) instead of a
-    // kill; that's what keeps reboot honest. E2B's default is onTimeout:'kill', so getting
+    // kill; that's what keeps reconnect honest. E2B's default is onTimeout:'kill', so getting
     // this wrong DESTROYS the filesystem at sandboxTimeoutMs and every session older than it
-    // dies with "sandbox is gone (cannot reboot)". autoResume wakes a paused sandbox on
+    // dies as GONE. autoResume wakes a paused sandbox on
     // inbound traffic, so connect() resumes it transparently; it also implies the default
     // full-memory snapshot, which is what lets a detached runner survive the pause and keeps
     // the idemKey attach protocol working across one.
@@ -94,17 +94,6 @@ export class ComputeSdkDriver implements SandboxDriver {
       throw new Error(`sandbox workdir setup failed: ${(r.stderr || r.stdout).trim()}`);
     }
     return { driver: this.providerName, sandboxId: sb.sandboxId, workdir: m[1] };
-  }
-
-  // Reconnect: a paused sandbox auto-resumes with its filesystem intact, so the handle
-  // stays valid as-is. A sandbox that is fatally gone (killed, expired) cannot be rebuilt
-  // without losing the filesystem this method promises to keep — that is unavailability
-  // (the turn loop's error policy takes it from here), never a silent fresh provision.
-  async reboot(handle: SandboxHandle): Promise<SandboxHandle> {
-    const h = parseHandle(handle, this.providerName);
-    const sb = await this.manager.sandbox.getById(h.sandboxId).catch(() => null);
-    if (!sb) throw new SandboxGoneError(`sandbox ${h.sandboxId} is gone (cannot reboot)`);
-    return handle;
   }
 
   // ComputeSDK's destroy swallows provider errors (already-dead sandboxes included), so

--- a/packages/ports/sandbox/src/drivers/subprocess.ts
+++ b/packages/ports/sandbox/src/drivers/subprocess.ts
@@ -6,9 +6,9 @@
 // converge naturally — there is no subscriber registry, no in-memory coordination. Let
 // the filesystem be the bus.
 //
-// v1 simplifications (intentional, not gaps — see the handoff's non-goals): reboot is a
-// no-op (the FS is just a directory), and stderr is folded into stdout via `2>&1` (the
-// `stderr` ExecEvent variant exists for future drivers; subprocess emits stdout + exit).
+// v1 simplification (intentional, not a gap — see the handoff's non-goals): stderr is
+// folded into stdout via `2>&1` (the `stderr` ExecEvent variant exists for future
+// drivers; subprocess emits stdout + exit).
 
 import { spawn } from "node:child_process";
 import { type FileHandle, open } from "node:fs/promises";
@@ -29,11 +29,6 @@ export class SubprocessDriver implements SandboxDriver {
     const workdir = path.join(ROOT, sessionId);
     await fs.mkdir(workdir, { recursive: true });
     return { driver: "subprocess", workdir };
-  }
-
-  // Reboot is a no-op: the persistent FS is just `workdir`, so it survives trivially.
-  async reboot(handle: SandboxHandle): Promise<SandboxHandle> {
-    return handle;
   }
 
   // rm -rf, force ignores ENOENT → calling teardown twice never throws.

--- a/packages/ports/sandbox/src/port.ts
+++ b/packages/ports/sandbox/src/port.ts
@@ -29,9 +29,12 @@ export interface Executor {
 
 export interface SandboxDriver {
   provision(spec: ResolvedEnv, sessionId: string): Promise<SandboxHandle>;
-  reboot(handle: SandboxHandle): Promise<SandboxHandle>; // persistent FS survives
-  teardown(handle: SandboxHandle): Promise<void>; //         idempotent
-  connect(handle: SandboxHandle): Executor; //               sync; cheap; any worker from the handle
+  teardown(handle: SandboxHandle): Promise<void>; // idempotent
+  connect(handle: SandboxHandle): Executor; //       sync; cheap; any worker from the handle
+  // There is deliberately no reboot/repair operation: connect() must transparently reach
+  // a live-or-paused sandbox (drivers resume on inbound traffic), and a sandbox that is
+  // GONE cannot be repaired without losing the filesystem — that is SandboxGoneError,
+  // the caller's policy problem, never a driver-internal fresh provision.
 }
 
 /** Thrown when the Executor cannot OBSERVE a command's result — sandbox unreachable,

--- a/packages/ports/sandbox/src/tck.ts
+++ b/packages/ports/sandbox/src/tck.ts
@@ -126,13 +126,15 @@ export function runSandboxTck(
       );
     });
 
-    it("8. reboot preserves the filesystem", async () => {
+    it("8. a fresh connect() from the same handle sees the same filesystem", async () => {
+      // The handle is the only durable token: any worker holding it must reach the SAME
+      // sandbox (drivers resume a paused one transparently). This is what replaced the
+      // old reboot operation — reconnect, never repair.
       const { driver, handle } = await sandbox();
       const bytes = new TextEncoder().encode("persist me");
       await driver.connect(handle).writeFile("state.txt", bytes);
 
-      const rebooted = await driver.reboot(handle);
-      const read = await driver.connect(rebooted).readFile("state.txt");
+      const read = await driver.connect(handle).readFile("state.txt");
       expect(new TextDecoder().decode(read)).toBe("persist me");
     });
 

--- a/packages/sessions/src/exec.test.ts
+++ b/packages/sessions/src/exec.test.ts
@@ -1,0 +1,134 @@
+// packages/sessions/src/exec.test.ts — the single-retry policy, against pure fakes.
+//
+// makeExec's contract: a TRANSIENT unavailability earns exactly one reconnect-and-retry
+// by the same idemKey; a GONE sandbox propagates untouched (only turn.ts may decide what
+// a permanent loss means); everything else passes through. No Postgres, no sandbox.
+
+import { describe, expect, it } from "vitest";
+import {
+  type ExecEvent,
+  type Executor,
+  type SandboxDriver,
+  SandboxGoneError,
+  SandboxUnavailableError,
+  SandboxUnreachableError,
+} from "@funky/sandbox";
+import { makeExec } from "./exec";
+import type { ToolCall } from "./events";
+
+const call: ToolCall = { kind: "exec", cmd: "echo hi" };
+const handle = { driver: "fake" };
+
+/** A driver whose connect() returns the next scripted executor; records every idemKey. */
+function scriptedDriver(executors: Executor[]): { driver: SandboxDriver; connects: () => number } {
+  let connects = 0;
+  const driver: SandboxDriver = {
+    async provision() {
+      throw new Error("provision is not under test");
+    },
+    async teardown() {},
+    connect() {
+      const ex = executors[connects];
+      connects += 1;
+      if (!ex) throw new Error("connect called more times than scripted");
+      return ex;
+    },
+  };
+  return { driver, connects: () => connects };
+}
+
+function succeeding(seen: string[]): Executor {
+  return {
+    exec: (req) =>
+      (async function* (): AsyncGenerator<ExecEvent> {
+        seen.push(req.idemKey);
+        yield { kind: "stdout", data: "hi\n" };
+        yield { kind: "exit", code: 0, truncated: false };
+      })(),
+    attach: () => {
+      throw new Error("attach is not under test");
+    },
+    async readFile() {
+      throw new Error("readFile is not under test");
+    },
+    async writeFile() {},
+  };
+}
+
+function throwing(err: Error): Executor {
+  return {
+    exec: () =>
+      (async function* (): AsyncGenerator<ExecEvent> {
+        throw err;
+      })(),
+    attach: () => {
+      throw new Error("attach is not under test");
+    },
+    async readFile() {
+      throw new Error("readFile is not under test");
+    },
+    async writeFile() {},
+  };
+}
+
+describe("makeExec", () => {
+  it("a transient unavailability reconnects once and retries the SAME idemKey", async () => {
+    const seen: string[] = [];
+    const { driver, connects } = scriptedDriver([
+      throwing(new SandboxUnreachableError("blip")),
+      succeeding(seen),
+    ]);
+    const exec = makeExec({ sandbox: driver, handle });
+    const res = await exec(call, "k1");
+    expect(res).toEqual({ output: "hi\n", exitCode: 0, truncated: false });
+    expect(connects()).toBe(2);
+    expect(seen).toEqual(["k1"]); // the retry rode the same idemKey
+  });
+
+  it("a stream that ends without an exit event counts as transient and retries", async () => {
+    const seen: string[] = [];
+    const truncatedStream: Executor = {
+      ...succeeding([]),
+      exec: () =>
+        (async function* (): AsyncGenerator<ExecEvent> {
+          yield { kind: "stdout", data: "partial" }; // no exit event → unobservable
+        })(),
+    };
+    const { driver, connects } = scriptedDriver([truncatedStream, succeeding(seen)]);
+    const exec = makeExec({ sandbox: driver, handle });
+    const res = await exec(call, "k2");
+    expect(res.exitCode).toBe(0);
+    expect(connects()).toBe(2);
+  });
+
+  it("a GONE sandbox propagates immediately — no reconnect, no retry", async () => {
+    const { driver, connects } = scriptedDriver([throwing(new SandboxGoneError("destroyed"))]);
+    const exec = makeExec({ sandbox: driver, handle });
+    await expect(exec(call, "k3")).rejects.toBeInstanceOf(SandboxGoneError);
+    expect(connects()).toBe(1);
+  });
+
+  it("a second transient failure propagates to the caller's policy", async () => {
+    const { driver, connects } = scriptedDriver([
+      throwing(new SandboxUnreachableError("blip 1")),
+      throwing(new SandboxUnreachableError("blip 2")),
+    ]);
+    const exec = makeExec({ sandbox: driver, handle });
+    await expect(exec(call, "k4")).rejects.toBeInstanceOf(SandboxUnreachableError);
+    expect(connects()).toBe(2);
+  });
+
+  it("a non-sandbox error passes through without a retry", async () => {
+    const { driver, connects } = scriptedDriver([throwing(new Error("bug in the driver"))]);
+    const exec = makeExec({ sandbox: driver, handle });
+    await expect(exec(call, "k5")).rejects.toThrow("bug in the driver");
+    expect(connects()).toBe(1);
+  });
+
+  it("no sandbox handle → SandboxUnavailableError before any connect", async () => {
+    const { driver, connects } = scriptedDriver([]);
+    const exec = makeExec({ sandbox: driver, handle: null });
+    await expect(exec(call, "k6")).rejects.toBeInstanceOf(SandboxUnavailableError);
+    expect(connects()).toBe(0);
+  });
+});

--- a/packages/sessions/src/exec.ts
+++ b/packages/sessions/src/exec.ts
@@ -1,17 +1,15 @@
-// packages/sessions/src/exec.ts — exec collection + the single-reboot policy.
+// packages/sessions/src/exec.ts — exec collection + the single-retry policy.
 //
-// Extracted from turn.ts so the native loop and the harness loop (harness-turn.ts)
+// Extracted from turn.ts so the native loop and the harness loop (harness-strategy.ts)
 // share ONE implementation of "run a tool call in the sandbox": collect the stream,
-// treat a missing exit event as unobservable (never a zero exit), and on an
-// unobservable sandbox reboot ONCE and retry by the same idemKey — the idemKey
-// protocol re-attaches to a still-running command or re-runs it safely, so nothing
-// runs twice.
+// treat a missing exit event as unobservable (never a zero exit), and on a TRANSIENT
+// unavailability reconnect ONCE and retry by the same idemKey — the idemKey protocol
+// re-attaches to a still-running command or re-runs it safely, so nothing runs twice.
+// A GONE sandbox is not retried: no reconnect can reach it, and only the caller's
+// policy (turn.ts) may decide what its loss means.
 
-import { and, eq } from "drizzle-orm";
-import type { Db } from "@funky/db";
-import { sessions } from "@funky/db/schema";
 import type { Executor, SandboxDriver, SandboxHandle } from "@funky/sandbox";
-import { SandboxUnavailableError } from "@funky/sandbox";
+import { SandboxGoneError, SandboxUnavailableError } from "@funky/sandbox";
 import type { ToolCall } from "./events";
 
 export type ExecResult = { output: string; exitCode: number; truncated: boolean };
@@ -46,39 +44,26 @@ export async function runExec(
   return { output, exitCode, truncated };
 }
 
-/** Exec with a single reboot on an unobservable sandbox. The same idemKey re-attaches
- *  to a still-running command or re-runs it safely, so nothing runs twice. A second
- *  failure propagates to the caller's error policy. The rebooted handle is persisted
- *  so later workers reconnect to the same sandbox. */
-export function makeExecWithReboot(opts: {
-  db: Db;
+/** Exec with a single reconnect-and-retry on a transient unavailability. connect() is
+ *  cheap and re-resolves the sandbox fresh (resuming a paused one), and the same idemKey
+ *  re-attaches to a still-running command or re-runs it safely, so nothing runs twice.
+ *  A GONE sandbox propagates immediately — retrying cannot fix a permanent loss — and a
+ *  second transient failure propagates to the caller's error policy (the queue's backoff
+ *  owns further retries). */
+export function makeExec(opts: {
   sandbox: SandboxDriver;
-  ns: string;
-  sessionId: string;
   handle: SandboxHandle | null;
 }): (call: ToolCall, idemKey: string) => Promise<ExecResult> {
-  let handle = opts.handle;
   return async (call, idemKey) => {
+    const { sandbox, handle } = opts;
     if (!handle) throw new SandboxUnavailableError("session has no sandbox handle");
     try {
-      return await runExec(opts.sandbox.connect(handle), call, idemKey);
+      return await runExec(sandbox.connect(handle), call, idemKey);
     } catch (err) {
-      if (!(err instanceof SandboxUnavailableError)) throw err;
-      handle = await opts.sandbox.reboot(handle); // persistent FS survives the reboot
-      await persistHandle(opts.db, opts.ns, opts.sessionId, handle);
-      return await runExec(opts.sandbox.connect(handle), call, idemKey);
+      if (!(err instanceof SandboxUnavailableError) || err instanceof SandboxGoneError) {
+        throw err;
+      }
+      return await runExec(sandbox.connect(handle), call, idemKey);
     }
   };
-}
-
-export async function persistHandle(
-  db: Db,
-  ns: string,
-  sessionId: string,
-  handle: SandboxHandle,
-): Promise<void> {
-  await db
-    .update(sessions)
-    .set({ sandboxHandle: handle, updatedAt: new Date() })
-    .where(and(eq(sessions.namespace, ns), eq(sessions.id, sessionId)));
 }

--- a/packages/sessions/src/provision.ts
+++ b/packages/sessions/src/provision.ts
@@ -2,9 +2,9 @@
 //
 // Provision jobs (kind: "provision") ride the same queue and run on the same worker as
 // turns. The snapshot of the env config into `resolved_env` happens HERE and is never
-// re-read from the (mutable) env config: a sandbox reboot three days later must rebuild
-// the SAME environment the session started with, not whatever the config says today. The
-// snapshot makes reboots deterministic.
+// re-read from the (mutable) env config: a sandbox replacement three days later must
+// rebuild the SAME environment the session started with, not whatever the config says
+// today. The snapshot makes replacements deterministic.
 
 import { and, eq } from "drizzle-orm";
 import type { Db } from "@funky/db";

--- a/packages/sessions/src/strategy.ts
+++ b/packages/sessions/src/strategy.ts
@@ -42,8 +42,9 @@ export type TurnShell = {
   /** Record a terminal turn_failed. Returns "conflict" if even that append loses the
    *  race (another worker owns the turn); "retry_later" if it could not be recorded. */
   terminalFail: (errorClass: ErrorClass, message: string) => Promise<TurnOutcome>;
-  /** Run one tool call under an idemKey with the single-reboot policy (exec.ts), bound
-   *  to this session's sandbox handle. The same idemKey re-attaches, never re-runs. */
+  /** Run one tool call under an idemKey with the single reconnect-and-retry policy
+   *  (exec.ts), bound to this session's sandbox handle. The same idemKey re-attaches,
+   *  never re-runs. */
   exec: (call: ToolCall, idemKey: string) => Promise<ExecResult>;
 };
 

--- a/packages/sessions/src/turn.test.ts
+++ b/packages/sessions/src/turn.test.ts
@@ -283,8 +283,8 @@ describe("runTurn — error policy", () => {
 
   it("last-attempt escalation: sandbox unobservable on the final attempt → turn_failed(SANDBOX_FATAL)", async () => {
     await seedAgentVersion();
-    // A handle pointing at a workdir that does not exist → exec throws SandboxUnavailable.
-    // reboot is a subprocess no-op, so the retry throws again and the error escalates.
+    // A handle pointing at a workdir that does not exist → exec throws SandboxUnavailable,
+    // and on the last delivery the error must escalate to a terminal event.
     await seedSession({
       provision: false,
       handle: { driver: "subprocess", workdir: "/tmp/funky/does-not-exist-" + randomUUID() },
@@ -564,9 +564,6 @@ describe("runProvision", () => {
       async provision(): Promise<SandboxHandle> {
         throw new SandboxUnavailableError("cannot reach the sandbox host");
       },
-      async reboot(h) {
-        return h;
-      },
       async teardown() {},
       connect() {
         throw new Error("unreachable");
@@ -598,9 +595,6 @@ describe("runProvision", () => {
     const brokenSandbox: SandboxDriver = {
       async provision(): Promise<SandboxHandle> {
         throw new SandboxUnavailableError("transient host hiccup");
-      },
-      async reboot(h) {
-        return h;
       },
       async teardown() {},
       connect() {

--- a/packages/sessions/src/turn.ts
+++ b/packages/sessions/src/turn.ts
@@ -2,7 +2,7 @@
 //
 // runTurn is deliberately thin: it gates on session status, loads the PINNED agent
 // version, reads the log ONCE, builds the plumbing every runtime shares (the
-// conditional-append helper, terminalFail, exec-with-reboot), and hands a TurnShell to
+// conditional-append helper, terminalFail, exec-with-retry), and hands a TurnShell to
 // the TurnStrategy selected by the pinned runtime. The strategies own everything that
 // genuinely differs:
 //
@@ -23,7 +23,7 @@ import type { LlmPort } from "@funky/llm";
 import type { SandboxDriver, SandboxHandle } from "@funky/sandbox";
 import { SandboxUnavailableError } from "@funky/sandbox";
 import { type EventPayload, type EventType, makeEvent } from "./events";
-import { makeExecWithReboot } from "./exec";
+import { makeExec } from "./exec";
 import { harnessStrategy } from "./harness-strategy";
 import { nativeStrategy } from "./native-strategy";
 import type { Job } from "./queue";
@@ -77,7 +77,7 @@ export async function runTurn(job: Job, deps: TurnDeps): Promise<TurnOutcome> {
   // 3. The log IS the state. Read once; the shell's append keeps it current in memory.
   const events = await deps.store.readEvents(ns, sessionId);
 
-  // 4. Shared plumbing: conditional append, terminal-failure recorder, exec+reboot.
+  // 4. Shared plumbing: conditional append, terminal-failure recorder, exec+retry.
   const append = async <T extends EventType>(
     type: T,
     payload: EventPayload<T>,
@@ -99,11 +99,8 @@ export async function runTurn(job: Job, deps: TurnDeps): Promise<TurnOutcome> {
     return "failed";
   };
 
-  const exec = makeExecWithReboot({
-    db: deps.db,
+  const exec = makeExec({
     sandbox: deps.sandbox,
-    ns,
-    sessionId,
     handle: (session.sandboxHandle ?? null) as SandboxHandle | null,
   });
 

--- a/tests/chaos/src/fixtures.ts
+++ b/tests/chaos/src/fixtures.ts
@@ -164,9 +164,6 @@ export function alwaysFailSandbox(): SandboxDriver {
     async provision(_spec: ResolvedEnv, _sessionId: string): Promise<SandboxHandle> {
       return { driver: "subprocess", workdir: "/tmp/funky/chaos-unavailable" };
     },
-    async reboot(h: SandboxHandle) {
-      return h;
-    },
     async teardown() {},
     connect() {
       return executor;
@@ -183,7 +180,6 @@ export function alwaysFailSandbox(): SandboxDriver {
 export function spawnThenHangSandbox(real: SandboxDriver, onSpawned: () => void): SandboxDriver {
   return {
     provision: (spec, sid) => real.provision(spec, sid),
-    reboot: (h) => real.reboot(h),
     teardown: (h) => real.teardown(h),
     connect(handle) {
       const inner = real.connect(handle);


### PR DESCRIPTION
Part 2 of 4, stacked on #82.

`reboot()` never rebooted anything: the computesdk implementation was an existence check that returned the same handle, subprocess was a no-op, and pause/resume already rides `connect()` (`autoResume` wakes a paused sandbox on inbound traffic). The port now has **no repair operation at all** — `connect()` must transparently reach a live-or-paused sandbox, and a gone sandbox is the caller's policy problem, never a driver-internal fresh provision.

`makeExecWithReboot` becomes `makeExec`:
- **transient unavailability** → reconnect once and retry by the **same idemKey** (re-attach to a still-running command or safe re-run — nothing runs twice);
- **`SandboxGoneError`** → propagate immediately; no reconnect can fix a permanent loss;
- a second transient failure propagates to the turn loop's policy (the queue's backoff owns further retries).

The handle never changes anymore, so the `db`/`persistHandle` plumbing goes away with it. TCK case 8 now pins what actually replaced reboot: a fresh `connect()` from the same handle reaches the same filesystem. New pure-fake unit suite for the retry policy in `packages/sessions/src/exec.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)