### PR TITLE
Fail the turn fast when the sandbox is gone

### DIFF
--- a/packages/sessions/src/strategy.ts
+++ b/packages/sessions/src/strategy.ts
@@ -53,8 +53,9 @@ export interface TurnStrategy {
    *  shell's shared error map. */
   run(shell: TurnShell): Promise<TurnOutcome>;
   /** Classify a strategy-specific error into an outcome. Return null to DEFER to the
-   *  shell's shared mapping (ErrConflict → conflict, SandboxUnavailable → SANDBOX_FATAL
-   *  / retry, else INTERNAL / retry). Runs inside the shell's catch, so terminalFail
-   *  and lastAttempt are reached through `shell`. */
+   *  shell's shared mapping (ErrConflict → conflict, SandboxGone → immediate
+   *  SANDBOX_FATAL, other SandboxUnavailable → SANDBOX_FATAL / retry, else INTERNAL /
+   *  retry). Runs inside the shell's catch, so terminalFail and lastAttempt are
+   *  reached through `shell`. */
   mapError?(err: unknown, shell: TurnShell): TurnOutcome | Promise<TurnOutcome> | null;
 }

--- a/packages/sessions/src/turn.test.ts
+++ b/packages/sessions/src/turn.test.ts
@@ -23,10 +23,12 @@ import {
   LlmPermanentError,
 } from "@funky/llm";
 import {
+  type Executor,
   type SandboxDriver,
   type SandboxHandle,
   SubprocessDriver,
   SandboxUnavailableError,
+  SandboxUnreachableError,
 } from "@funky/sandbox";
 import {
   type EventPayload,
@@ -281,10 +283,11 @@ describe("runTurn — error policy", () => {
     expect((await log()).map((e) => e.type)).toEqual(["user_message"]);
   });
 
-  it("last-attempt escalation: sandbox unobservable on the final attempt → turn_failed(SANDBOX_FATAL)", async () => {
+  it("a GONE sandbox → turn_failed(SANDBOX_FATAL) on the FIRST attempt, no retries", async () => {
     await seedAgentVersion();
-    // A handle pointing at a workdir that does not exist → exec throws SandboxUnavailable,
-    // and on the last delivery the error must escalate to a terminal event.
+    // A handle pointing at a workdir that does not exist → the subprocess driver reports
+    // GONE (positive evidence). Every further delivery would fail identically, so the
+    // terminal event lands immediately instead of burning the remaining attempts.
     await seedSession({
       provision: false,
       handle: { driver: "subprocess", workdir: "/tmp/funky/does-not-exist-" + randomUUID() },
@@ -292,8 +295,8 @@ describe("runTurn — error policy", () => {
     await seedUserMessage();
 
     const llm = scriptLlm([{ content: "", toolCall: exec("echo hi") }]);
-    const outcome = await runTurn(job({ attempts: 5, maxAttempts: 5 }), deps(llm));
-    expect(outcome).toBe("failed"); // never a silent hang: the session gets a terminal event
+    const outcome = await runTurn(job({ attempts: 1, maxAttempts: 5 }), deps(llm));
+    expect(outcome).toBe("failed"); // fail fast: attempts 1 of 5, terminal anyway
 
     const events = await log();
     const last = events.at(-1) as SessionEvent<"turn_failed">;
@@ -303,16 +306,13 @@ describe("runTurn — error policy", () => {
     expect(events.some((e) => e.type === "assistant_message")).toBe(true);
   });
 
-  it("non-final sandbox failure → 'retry_later' (no terminal event, the queue backs off)", async () => {
+  it("non-final UNREACHABLE sandbox → 'retry_later' (no terminal event, the queue backs off)", async () => {
     await seedAgentVersion();
-    await seedSession({
-      provision: false,
-      handle: { driver: "subprocess", workdir: "/tmp/funky/does-not-exist-" + randomUUID() },
-    });
+    await seedSession();
     await seedUserMessage();
 
     const llm = scriptLlm([{ content: "", toolCall: exec("echo hi") }]);
-    const outcome = await runTurn(job({ attempts: 1, maxAttempts: 5 }), deps(llm));
+    const outcome = await runTurn(job({ attempts: 1, maxAttempts: 5 }), deps(llm, unreachableSandbox()));
     expect(outcome).toBe("retry_later");
 
     const events = await log();
@@ -320,7 +320,49 @@ describe("runTurn — error policy", () => {
     expect(events.some((e) => e.type === "turn_failed")).toBe(false);
     expect(events.some((e) => e.type === "assistant_message")).toBe(true);
   });
+
+  it("UNREACHABLE on the final attempt → turn_failed(SANDBOX_FATAL), never a silent hang", async () => {
+    await seedAgentVersion();
+    await seedSession();
+    await seedUserMessage();
+
+    const llm = scriptLlm([{ content: "", toolCall: exec("echo hi") }]);
+    const outcome = await runTurn(job({ attempts: 5, maxAttempts: 5 }), deps(llm, unreachableSandbox()));
+    expect(outcome).toBe("failed");
+
+    const last = (await log()).at(-1) as SessionEvent<"turn_failed">;
+    expect(last.type).toBe("turn_failed");
+    expect(last.payload.error_class).toBe("SANDBOX_FATAL");
+  });
 });
+
+/** A sandbox whose every exec is a transport failure — transient by classification, so
+ *  the turn loop must lean on the queue's backoff rather than fail the session. */
+function unreachableSandbox(): SandboxDriver {
+  const executor: Executor = {
+    exec: () =>
+      (async function* () {
+        throw new SandboxUnreachableError("host unreachable");
+      })(),
+    attach: () =>
+      (async function* () {
+        throw new SandboxUnreachableError("host unreachable");
+      })(),
+    async readFile(): Promise<Uint8Array> {
+      throw new SandboxUnreachableError("host unreachable");
+    },
+    async writeFile() {
+      throw new SandboxUnreachableError("host unreachable");
+    },
+  };
+  return {
+    async provision() {
+      throw new Error("provision is not under test");
+    },
+    async teardown() {},
+    connect: () => executor,
+  };
+}
 
 // ================================================================= conflict
 

--- a/packages/sessions/src/turn.ts
+++ b/packages/sessions/src/turn.ts
@@ -21,7 +21,7 @@ import { type RuntimeConfig, agentConfigVersions, sessions } from "@funky/db/sch
 import type { HarnessPort } from "@funky/harness/port";
 import type { LlmPort } from "@funky/llm";
 import type { SandboxDriver, SandboxHandle } from "@funky/sandbox";
-import { SandboxUnavailableError } from "@funky/sandbox";
+import { SandboxGoneError, SandboxUnavailableError } from "@funky/sandbox";
 import { type EventPayload, type EventType, makeEvent } from "./events";
 import { makeExec } from "./exec";
 import { harnessStrategy } from "./harness-strategy";
@@ -150,16 +150,19 @@ function selectStrategy(runtime: RuntimeConfig | null): TurnStrategy {
  *  anything it defers on lands here. */
 function mapError(err: unknown, shell: TurnShell): TurnOutcome | Promise<TurnOutcome> {
   if (err instanceof ErrConflict) return "conflict"; // someone else owns this turn
-  // TODO(sessions): SANDBOX_FATAL ends the TURN and should not end the SESSION. Losing the
-  // sandbox mid-exec is unrecoverable for *this* turn — the in-flight command's fate is
-  // unknowable, so it can be neither replayed nor safely re-run — but a later turn starts
-  // with nothing in flight, so it could re-provision and continue (no idemKey in flight ⇒
-  // no side effect to duplicate). Two things block that today: terminalFail leaves
-  // sessions.status alone, so the session keeps accepting messages and burns maxAttempts on
-  // each; and this branch cannot tell "destroyed" from "unreachable N times" (computesdk.ts
-  // maps both to one error), so it must not be made session-terminal before that distinction
-  // exists. Design: turn-start loss → re-provision + a sandbox_replaced event; mid-exec loss
-  // → fail the turn only.
+  // GONE is permanent: the provider positively reported the sandbox does not exist, so
+  // every further delivery would fail identically — record the terminal turn_failed NOW
+  // instead of burning the remaining attempts against a corpse. This ends the TURN, not
+  // the SESSION: whether a later turn may re-provision and continue (a sandbox_replaced
+  // event — nothing is in flight at turn start, so there is no side effect to duplicate)
+  // is a deliberately separate decision; until then the session keeps its handle and each
+  // new message fails fast the same way.
+  if (err instanceof SandboxGoneError) {
+    return shell.terminalFail("SANDBOX_FATAL", err.message);
+  }
+  // Merely unreachable (or ambiguous): transient by classification, so the queue's
+  // backoff owns the retry. The last attempt still records a terminal event — a sandbox
+  // that stays unreachable forever must never hang the session silently.
   if (err instanceof SandboxUnavailableError) {
     return shell.lastAttempt ? shell.terminalFail("SANDBOX_FATAL", err.message) : "retry_later";
   }


### PR DESCRIPTION
Part 3 of 4, stacked on #83.

A `SandboxGoneError` escaping the turn now records `turn_failed(SANDBOX_FATAL)` on the **first** delivery instead of burning maxAttempts of exponential backoff against a sandbox the provider positively reported destroyed. This resolves the old `TODO(sessions)` in `turn.ts` — the blocker (the driver couldn't tell destroyed from unreachable) fell with #82.

Merely-unreachable (and ambiguous) unavailability keeps the existing policy: `retry_later` with the queue's backoff, and the last attempt still lands a terminal event so an unreachable sandbox never hangs the session silently.

This ends the **turn**, not the **session**. Whether a later turn may re-provision and continue (a `sandbox_replaced` event — nothing is in flight at turn start, so that path has no side effect to duplicate) is deliberately deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)