### PR TITLE
Expose derived session activity in the API read path

### DIFF
--- a/apps/api/test/sessions.integration.test.ts
+++ b/apps/api/test/sessions.integration.test.ts
@@ -102,6 +102,7 @@ describe("POST /v1/sessions", () => {
     expect(session).toMatchObject({
       type: "session",
       status: "provisioning",
+      activity: "idle", // derived: no turn job yet — the provision job is not activity
       agent: { id: agentId, version: 1 },
       environment_id: envId,
       title: null,
@@ -315,6 +316,73 @@ describe("GET /v1/sessions/:id/events", () => {
 });
 
 // ============================================================ namespace isolation
+
+// ==================================================================== activity
+
+// `activity` is derived at read time from sessions.status + the active turn job (see
+// deriveActivity's unit table in @funky/sessions). These drive the real read path over
+// HTTP and steer the queue rows directly, standing in for a worker's claims and nacks.
+describe("session activity (derived)", () => {
+  async function createSession(): Promise<string> {
+    const [agentId, envId] = await Promise.all([seedAgent(), seedEnv()]);
+    const res = await postJson("/v1/sessions", { agent: agentId, environment_id: envId });
+    return (await res.json()).id;
+  }
+
+  async function activityOf(id: string): Promise<string> {
+    const res = await app.request(`/v1/sessions/${id}`);
+    expect(res.status).toBe(200);
+    return (await res.json()).activity;
+  }
+
+  it("a fresh session is idle; a queued message flips it to running", async () => {
+    const id = await createSession();
+    expect(await activityOf(id)).toBe("idle");
+
+    const res = await postJson(`/v1/sessions/${id}/messages`, { content: "go" });
+    expect(res.status).toBe(202);
+    expect(await activityOf(id)).toBe("running"); // queued, attempts 0 — the dispatch sliver
+  });
+
+  it("a nacked delivery waiting out its backoff reads as rescheduling", async () => {
+    const id = await createSession();
+    await postJson(`/v1/sessions/${id}/messages`, { content: "go" });
+    await pg.pool.query(
+      "update turn_jobs set attempts = 1 where session_id = $1 and kind = 'turn'",
+      [id],
+    );
+    expect(await activityOf(id)).toBe("rescheduling");
+  });
+
+  it("a claimed job is running on a live lease, rescheduling once the lease expires", async () => {
+    const id = await createSession();
+    await postJson(`/v1/sessions/${id}/messages`, { content: "go" });
+    await pg.pool.query(
+      `update turn_jobs set state = 'running', attempts = 1,
+              lease_expires_at = now() + interval '60 seconds'
+       where session_id = $1 and kind = 'turn'`,
+      [id],
+    );
+    expect(await activityOf(id)).toBe("running");
+
+    await pg.pool.query(
+      "update turn_jobs set lease_expires_at = now() - interval '1 second' where session_id = $1 and kind = 'turn'",
+      [id],
+    );
+    expect(await activityOf(id)).toBe("rescheduling"); // dead worker; the queue will reclaim
+  });
+
+  it("an archived session is terminated, in get AND in list", async () => {
+    const id = await createSession();
+    const res = await app.request(`/v1/sessions/${id}/archive`, { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(await activityOf(id)).toBe("terminated");
+
+    const page = await (await app.request("/v1/sessions?include_archived=true")).json();
+    const row = page.data.find((s: { id: string }) => s.id === id);
+    expect(row.activity).toBe("terminated");
+  });
+});
 
 describe("namespace isolation", () => {
   it("a cross-namespace read is a 404, identical to a nonexistent session", async () => {

--- a/packages/sessions/src/activity.test.ts
+++ b/packages/sessions/src/activity.test.ts
@@ -1,0 +1,49 @@
+// packages/sessions/src/activity.test.ts — the activity derivation, as a pure table.
+//
+// deriveActivity is a pure function of (session status, active turn job); the queue read
+// feeding it is covered by the API integration suite. This is the whole state table.
+
+import { describe, expect, it } from "vitest";
+import type { ActiveTurnJob } from "./queue";
+import { deriveActivity } from "./service";
+
+const job = (over: Partial<ActiveTurnJob> = {}): ActiveTurnJob => ({
+  state: "queued",
+  attempts: 0,
+  leaseExpired: false,
+  ...over,
+});
+
+describe("deriveActivity", () => {
+  it("failed/archived → terminated, regardless of any job", () => {
+    expect(deriveActivity({ status: "failed" }, undefined)).toBe("terminated");
+    expect(deriveActivity({ status: "archived" }, job({ state: "running" }))).toBe("terminated");
+  });
+
+  it("no active turn job → idle (fresh sessions start here)", () => {
+    expect(deriveActivity({ status: "provisioning" }, undefined)).toBe("idle");
+    expect(deriveActivity({ status: "ready" }, undefined)).toBe("idle");
+  });
+
+  it("running with a live lease → running", () => {
+    expect(deriveActivity({ status: "ready" }, job({ state: "running" }))).toBe("running");
+  });
+
+  it("running with an expired lease → rescheduling (dead worker, queue will reclaim)", () => {
+    expect(
+      deriveActivity({ status: "ready" }, job({ state: "running", leaseExpired: true })),
+    ).toBe("rescheduling");
+  });
+
+  it("queued before any delivery → running (the dispatch sliver)", () => {
+    expect(deriveActivity({ status: "ready" }, job({ state: "queued", attempts: 0 }))).toBe(
+      "running",
+    );
+  });
+
+  it("queued after a failed delivery → rescheduling (backoff wait)", () => {
+    expect(deriveActivity({ status: "ready" }, job({ state: "queued", attempts: 2 }))).toBe(
+      "rescheduling",
+    );
+  });
+});

--- a/packages/sessions/src/index.ts
+++ b/packages/sessions/src/index.ts
@@ -7,16 +7,17 @@
 export * from "./events";
 export { EventStore, ErrConflict, type AppendHook } from "./store";
 export { JobQueue, onWake, LEASE_MS, HEARTBEAT_MS, POLL_INTERVAL_MS } from "./queue";
-export type { Job } from "./queue";
+export type { ActiveTurnJob, Job } from "./queue";
 export { nextAction, type Action } from "./reducer";
 export { buildContext, runTurn, type TurnDeps, type TurnOutcome } from "./turn";
 export { runProvision } from "./provision";
 // Phase F: the sessions resource (SessionsService) + the API/SSE event mapper.
-export { SessionsService, toApiEvent } from "./service";
+export { SessionsService, deriveActivity, toApiEvent } from "./service";
 export type {
   AgentRef,
   ApiSessionEvent,
   CreateSessionInput,
   Session,
+  SessionActivity,
   SessionPage,
 } from "./service";

--- a/packages/sessions/src/queue.ts
+++ b/packages/sessions/src/queue.ts
@@ -31,6 +31,14 @@ export type Job = {
   maxAttempts: number;
 };
 
+/** What the activity derivation (service.ts) needs to know about a session's active
+ *  turn job. Read-only queue introspection; never used to drive work. */
+export type ActiveTurnJob = {
+  state: "queued" | "running";
+  attempts: number;
+  leaseExpired: boolean;
+};
+
 export class JobQueue {
   constructor(private readonly db: Db) {}
 
@@ -116,6 +124,45 @@ export class JobQueue {
              lease_expires_at = null
       where  id = ${jobId}
     `);
+  }
+
+  /** The activity read (service.ts): each session's single active turn job (queued or
+   *  running — sendMessage's 409 guard keeps it to at most one), if any. leaseExpired
+   *  is computed against the DATABASE clock — the same clock pull() reclaims by — so
+   *  the API never disagrees with the queue about worker liveness. */
+  async activeTurnJobStates(
+    ns: string,
+    sessionIds: string[],
+    tx?: Tx,
+  ): Promise<Map<string, ActiveTurnJob>> {
+    if (sessionIds.length === 0) return new Map();
+    const q: Pick<Db, "select"> = tx ?? this.db;
+    const rows = await q
+      .select({
+        sessionId: turnJobs.sessionId,
+        state: turnJobs.state,
+        attempts: turnJobs.attempts,
+        leaseExpired: sql<boolean>`coalesce(${turnJobs.leaseExpiresAt} < now(), false)`,
+      })
+      .from(turnJobs)
+      .where(
+        and(
+          eq(turnJobs.namespace, ns),
+          inArray(turnJobs.sessionId, sessionIds),
+          eq(turnJobs.kind, "turn"),
+          inArray(turnJobs.state, ["queued", "running"]),
+        ),
+      );
+    const out = new Map<string, ActiveTurnJob>();
+    for (const r of rows) {
+      if (r.state !== "queued" && r.state !== "running") continue; // narrowed by the query
+      out.set(r.sessionId, {
+        state: r.state,
+        attempts: Number(r.attempts),
+        leaseExpired: r.leaseExpired,
+      });
+    }
+    return out;
   }
 
   /** The API's one-in-flight-turn-per-session guard (→ 409). Counts only turn jobs

--- a/packages/sessions/src/service.ts
+++ b/packages/sessions/src/service.ts
@@ -28,7 +28,7 @@ import {
   type SessionEvent,
   textContent,
 } from "./events";
-import type { JobQueue } from "./queue";
+import type { ActiveTurnJob, JobQueue } from "./queue";
 import { ErrConflict, type EventStore } from "./store";
 
 // ---------------------------------------------------------------- API shapes
@@ -39,6 +39,8 @@ export type Session = {
   type: "session";
   id: string;
   status: SessionStatus;
+  /** Derived at read time from the event log + job queue — never stored. */
+  activity: SessionActivity;
   agent: { id: string; version: number };
   environment_id: string;
   title: string | null;
@@ -47,6 +49,16 @@ export type Session = {
   updated_at: string;
   archived_at: string | null;
 };
+
+/** What the agent is doing right now, as a pure function of durable state:
+ *    idle         — waiting for input; nothing queued or running.
+ *    running      — a turn is queued for dispatch or actively executing on a worker.
+ *    rescheduling — a delivery failed transiently (or its worker died); the queue is
+ *                   backing off before retrying automatically.
+ *    terminated   — the session has ended (status failed/archived) and accepts nothing.
+ *  DERIVED, never stored: a worker-maintained copy would go stale the moment a worker
+ *  died mid-turn, and the log + queue already hold the truth (see worker.ts's header). */
+export type SessionActivity = "idle" | "running" | "rescheduling" | "terminated";
 
 /** An event as the API and SSE stream expose it (§3 of the handoff). */
 export type ApiSessionEvent = {
@@ -96,7 +108,7 @@ export class SessionsService {
         if (input.id) {
           const existing = await this.findRaw(tx, ctx, input.id);
           if (existing) {
-            return this.resolveIdempotentCreate(existing, input, agentConfigId, agentVersion, envConfigId);
+            return await this.resolveIdempotentCreate(ctx, existing, input, agentConfigId, agentVersion, envConfigId);
           }
         }
         await tx.insert(sessions).values({
@@ -117,27 +129,30 @@ export class SessionsService {
           kind: "provision",
         });
         const created = await this.findRaw(tx, ctx, id);
-        return { session: toSession(created!), created: true };
+        // A fresh session has no turn job by construction (only the provision job,
+        // which activity ignores) — no queue read needed: it is idle.
+        return { session: toSession(created!, deriveActivity(created!, undefined)), created: true };
       });
     } catch (err) {
       // Two same-id creates raced: loser hits the PK. Re-resolve via idempotency.
       if (isUniqueViolation(err) && input.id) {
         const existing = await this.findRaw(this.db, ctx, input.id);
         if (existing) {
-          return this.resolveIdempotentCreate(existing, input, agentConfigId, agentVersion, envConfigId);
+          return await this.resolveIdempotentCreate(ctx, existing, input, agentConfigId, agentVersion, envConfigId);
         }
       }
       throw err;
     }
   }
 
-  private resolveIdempotentCreate(
+  private async resolveIdempotentCreate(
+    ctx: AuthContext,
     existing: SessionRow,
     input: CreateSessionInput,
     agentConfigId: string,
     agentVersion: number,
     envConfigId: string,
-  ): { session: Session; created: boolean } {
+  ): Promise<{ session: Session; created: boolean }> {
     const same =
       existing.agentConfigId === agentConfigId &&
       existing.agentVersion === agentVersion &&
@@ -147,14 +162,14 @@ export class SessionsService {
     if (!same) {
       throw new ConflictError("a session with this id exists with a different configuration");
     }
-    return { session: toSession(existing), created: false };
+    return { session: toSession(existing, await this.activityOf(ctx, existing)), created: false };
   }
 
   // ------------------------------------------------------------------- get
   async get(ctx: AuthContext, id: string): Promise<Session> {
     const row = await this.findRaw(this.db, ctx, id);
     if (!row) throw new NotFoundError("session not found");
-    return toSession(row);
+    return toSession(row, await this.activityOf(ctx, row));
   }
 
   // ------------------------------------------------------------------ list
@@ -174,8 +189,13 @@ export class SessionsService {
       .limit(opts.limit + 1);
 
     const page = rows.slice(0, opts.limit);
+    // ONE queue read for the whole page, not one per row.
+    const jobs = await this.queue.activeTurnJobStates(
+      ctx.namespace,
+      page.map((r) => r.id),
+    );
     return {
-      data: page.map(toSession),
+      data: page.map((r) => toSession(r, deriveActivity(r, jobs.get(r.id)))),
       has_more: rows.length > opts.limit,
       last_id: page.at(-1)?.id,
     };
@@ -284,6 +304,11 @@ export class SessionsService {
     if (!row) throw new NotFoundError("session not found");
   }
 
+  private async activityOf(ctx: AuthContext, row: SessionRow): Promise<SessionActivity> {
+    const jobs = await this.queue.activeTurnJobStates(ctx.namespace, [row.id]);
+    return deriveActivity(row, jobs.get(row.id));
+  }
+
   private async resolveAgent(
     ctx: AuthContext,
     ref: AgentRef,
@@ -331,11 +356,30 @@ export class SessionsService {
 
 // ------------------------------------------------------------ pure helpers
 
-function toSession(row: SessionRow): Session {
+/** Session status + its active turn job (if any) → activity. Exported for tests; the
+ *  full state table lives on SessionActivity's doc comment. */
+export function deriveActivity(
+  row: Pick<SessionRow, "status">,
+  job: ActiveTurnJob | undefined,
+): SessionActivity {
+  if (row.status === "failed" || row.status === "archived") return "terminated";
+  if (!job) return "idle";
+  if (job.state === "running") {
+    // A live lease is a worker actively driving the turn. An expired one is a dead
+    // worker whose job the queue will hand out again — retrying, effectively.
+    return job.leaseExpired ? "rescheduling" : "running";
+  }
+  // queued: attempts=0 is the just-enqueued dispatch sliver (a worker is about to pick
+  // it up); attempts>0 means a delivery came back and the queue is backing off first.
+  return job.attempts > 0 ? "rescheduling" : "running";
+}
+
+function toSession(row: SessionRow, activity: SessionActivity): Session {
   return {
     type: "session",
     id: row.id,
     status: row.status,
+    activity,
     agent: { id: row.agentConfigId, version: row.agentVersion },
     environment_id: row.envConfigId,
     title: row.title,


### PR DESCRIPTION
Part 4 of 4, stacked on #84.

Sessions gain an `activity` field answering "what is the agent doing right now":

| activity | meaning |
|---|---|
| `idle` | waiting for input; no turn job queued or running |
| `running` | a turn is claimed with a live lease, or queued awaiting first pickup |
| `rescheduling` | a delivery failed transiently (backoff wait), or its worker died (expired lease; the queue will reclaim) |
| `terminated` | session ended — status `failed`/`archived` |

It is **derived at read time**, never stored: a worker-maintained state column would go stale the moment a worker died mid-turn, while `sessions.status` + the active turn job (state, attempts, lease liveness — computed against the *database* clock, the same clock the queue reclaims by) already hold the truth. Cost: one extra queue read per get, one per list page.

Covered by a pure unit table for `deriveActivity` and HTTP-level integration tests that steer `turn_jobs` directly to stand in for worker claims/nacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)