### PR TITLE
Generalize the harness layer to multiple drivers

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -5,7 +5,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Client, Pool } from "pg";
 import { createDb } from "@funky/db";
-import { type HarnessPort, makeHarness } from "@funky/harness";
+import { type HarnessRegistry, makeHarness } from "@funky/harness";
 import { FakeLlm, type LlmConfig, makeLlm } from "@funky/llm";
 import { makeSandbox, type SandboxConfig } from "@funky/sandbox";
 import { EventStore, JobQueue } from "@funky/sessions";
@@ -30,17 +30,22 @@ const metrics = createMetrics();
 const listenClient = new Client({ connectionString: cfg.databaseUrl });
 await listenClient.connect();
 
-// The claude-code harness needs an Anthropic key regardless of FUNKY_LLM; without
-// one, harness sessions fail their turns with a terminal HARNESS error instead.
-const harness: HarnessPort | undefined = cfg.anthropicApiKey
-  ? makeHarness({
-      driver: "claude-code",
-      db,
-      apiKey: cfg.anthropicApiKey,
-      cwdRoot: cfg.harnessCwdRoot,
-      scratchRoot: cfg.harnessScratchRoot,
-    })
-  : undefined;
+// One registry entry per harness this worker can serve. The claude-code harness needs
+// an Anthropic key regardless of FUNKY_LLM; without one, claude-code sessions fail
+// their turns with a terminal HARNESS error instead.
+const harnesses: HarnessRegistry = {
+  ...(cfg.anthropicApiKey
+    ? {
+        "claude-code": makeHarness({
+          driver: "claude-code",
+          db,
+          apiKey: cfg.anthropicApiKey,
+          cwdRoot: cfg.harnessCwdRoot,
+          scratchRoot: cfg.harnessScratchRoot,
+        }),
+      }
+    : {}),
+};
 
 // OTel bridge over the shared metrics object; exporters per FUNKY_METRICS. The standard
 // OTEL_* env vars (endpoint, headers, interval, resource attributes) are read here and
@@ -57,7 +62,7 @@ const worker = startWorker({
   store,
   llm: makeLlm(llmConfig(cfg)), // fake by default — no API key needed
   sandbox: makeSandbox(sandboxConfig(cfg)), // docker by default — isolated, no account needed
-  ...(harness ? { harness } : {}),
+  harnesses,
   db,
   listenClient,
   concurrency: cfg.concurrency,

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -12,7 +12,7 @@
 
 import type { Client } from "pg";
 import type { Db } from "@funky/db";
-import type { HarnessPort } from "@funky/harness/port";
+import type { HarnessRegistry } from "@funky/harness/port";
 import type { LlmPort } from "@funky/llm";
 import type { SandboxDriver } from "@funky/sandbox";
 import {
@@ -32,8 +32,9 @@ export type WorkerDeps = {
   store: EventStore;
   llm: LlmPort;
   sandbox: SandboxDriver;
-  /** Optional — required only for agents whose runtime is a vendor harness. */
-  harness?: HarnessPort;
+  /** Optional — required only for agents whose runtime is a vendor harness; keyed by
+   *  the runtime type the entry serves. */
+  harnesses?: HarnessRegistry;
   db: Db;
   listenClient: Client; // DEDICATED client for LISTEN (never from the pool)
   concurrency: number; // FUNKY_WORKER_CONCURRENCY
@@ -83,7 +84,7 @@ export function startWorker(deps: WorkerDeps): WorkerHandle {
     llm: deps.llm,
     sandbox: deps.sandbox,
     db: deps.db,
-    ...(deps.harness ? { harness: deps.harness } : {}),
+    ...(deps.harnesses ? { harnesses: deps.harnesses } : {}),
   };
 
   let inFlight = 0;

--- a/packages/db/schema/configs.ts
+++ b/packages/db/schema/configs.ts
@@ -31,6 +31,10 @@ import {
  *  session — a session's runtime never changes mid-life. */
 export type RuntimeConfig = { type: "native" } | { type: "claude-code" };
 
+/** The harness driver names — every runtime except the native loop. Keyed on by the
+ *  worker's driver registry and recorded in sessions.harness_state.driver. */
+export type HarnessDriver = Exclude<RuntimeConfig["type"], "native">;
+
 export type ModelConfig = {
   provider:
     | "anthropic"

--- a/packages/ports/harness/src/port.ts
+++ b/packages/ports/harness/src/port.ts
@@ -11,10 +11,15 @@
 // conditional-append conflict semantics, the write fence, and the commit — so the
 // crash-safety story lives in exactly one place. See DESIGN.md.
 
-import type { HarnessState, ModelConfig } from "@funky/db/schema";
+import type { HarnessDriver, HarnessState, ModelConfig } from "@funky/db/schema";
 import type { ContentBlock, ToolCall } from "@funky/sessions/events";
 
-export type { HarnessState };
+export type { HarnessDriver, HarnessState };
+
+/** The worker's driver registry: one port per harness runtime it can serve. A harness
+ *  session on a worker whose registry lacks its driver fails the turn with a terminal
+ *  HARNESS error (harness-strategy.ts). */
+export type HarnessRegistry = Partial<Record<HarnessDriver, HarnessPort>>;
 
 /** What one exec produced. Non-zero exit / timeout(124) / OOM(137) are RESULTS, not
  *  errors — same rule as the sandbox port. */

--- a/packages/sessions/src/harness-strategy.ts
+++ b/packages/sessions/src/harness-strategy.ts
@@ -25,6 +25,7 @@ import { randomUUID } from "node:crypto";
 import { and, desc, eq } from "drizzle-orm";
 import { harnessTranscriptEntries, sessions } from "@funky/db/schema";
 import {
+  type HarnessDriver,
   HarnessFencedError,
   HarnessPermanentError,
   type HarnessProjectedEvent,
@@ -43,6 +44,12 @@ import { ErrConflict } from "./store";
 import type { TurnShell, TurnStrategy } from "./strategy";
 import { type TurnDeps, readMaxIterations } from "./turn";
 
+/** Operator hint for the "no driver on this worker" failure — what to configure so
+ *  this worker can serve the driver. */
+const DRIVER_HINTS: Partial<Record<HarnessDriver, string>> = {
+  "claude-code": " (is ANTHROPIC_API_KEY set?)",
+};
+
 export const harnessStrategy: TurnStrategy = {
   async run(shell: TurnShell) {
     const { ns, sessionId, session, version, events, append, terminalFail, exec, deps } = shell;
@@ -54,10 +61,15 @@ export const harnessStrategy: TurnStrategy = {
     const lastUser = findLastIndex(events, (e) => e.type === "user_message");
     if (lastUser < 0) return "completed"; // nothing to answer
 
-    if (!deps.harness) {
+    // The pinned runtime names the driver; the worker's registry may or may not serve
+    // it. Either gap is an honest terminal failure, not a crash or a silent retry.
+    const driver = version.runtime?.type !== "native" ? version.runtime?.type : undefined;
+    const harness = driver ? deps.harnesses?.[driver] : undefined;
+    if (!driver || !harness) {
+      const hint = driver ? (DRIVER_HINTS[driver] ?? "") : "";
       return terminalFail(
         "HARNESS",
-        "agent runtime is claude-code but this worker has no harness driver (is ANTHROPIC_API_KEY set?)",
+        `agent runtime is ${driver ?? "unknown"} but this worker has no ${driver ?? "matching"} harness driver${hint}`,
       );
     }
 
@@ -147,7 +159,7 @@ export const harnessStrategy: TurnStrategy = {
       return next;
     };
 
-    const result: HarnessTurnResult = await deps.harness.runTurn({
+    const result: HarnessTurnResult = await harness.runTurn({
       namespace: ns,
       sessionId,
       attempt,
@@ -175,7 +187,7 @@ export const harnessStrategy: TurnStrategy = {
       await tx
         .update(sessions)
         .set({
-          harnessState: { driver: "claude-code", sdk_session_id: result.sdkSessionId },
+          harnessState: { driver, sdk_session_id: result.sdkSessionId },
           updatedAt: new Date(),
         })
         .where(and(eq(sessions.namespace, ns), eq(sessions.id, sessionId)));

--- a/packages/sessions/src/harness-turn.test.ts
+++ b/packages/sessions/src/harness-turn.test.ts
@@ -147,7 +147,13 @@ const untouchableLlm: LlmPort = {
 };
 
 function deps(harness?: HarnessPort) {
-  return { store, llm: untouchableLlm, sandbox, db, ...(harness ? { harness } : {}) };
+  return {
+    store,
+    llm: untouchableLlm,
+    sandbox,
+    db,
+    ...(harness ? { harnesses: { "claude-code": harness } } : {}),
+  };
 }
 
 async function log() {

--- a/packages/sessions/src/turn.ts
+++ b/packages/sessions/src/turn.ts
@@ -18,7 +18,7 @@
 import { and, eq } from "drizzle-orm";
 import type { Db } from "@funky/db";
 import { type RuntimeConfig, agentConfigVersions, sessions } from "@funky/db/schema";
-import type { HarnessPort } from "@funky/harness/port";
+import type { HarnessRegistry } from "@funky/harness/port";
 import type { LlmPort } from "@funky/llm";
 import type { SandboxDriver, SandboxHandle } from "@funky/sandbox";
 import { SandboxUnavailableError } from "@funky/sandbox";
@@ -42,10 +42,11 @@ export type TurnDeps = {
   llm: LlmPort;
   sandbox: SandboxDriver;
   db: Db; // for reading session + agent version rows
-  /** Optional: agent versions with runtime {type:"claude-code"} dispatch to this
-   *  port (harness-strategy.ts). A harness session on a worker without a driver fails
-   *  the turn with a terminal HARNESS error. */
-  harness?: HarnessPort;
+  /** Optional: agent versions with a harness runtime (e.g. {type:"claude-code"})
+   *  dispatch to the registry entry named by their runtime type (harness-strategy.ts).
+   *  A harness session on a worker whose registry lacks its driver fails the turn
+   *  with a terminal HARNESS error. */
+  harnesses?: HarnessRegistry;
 };
 
 export type TurnOutcome =
@@ -132,19 +133,17 @@ export async function runTurn(job: Job, deps: TurnDeps): Promise<TurnOutcome> {
   }
 }
 
-/** Pinned runtime → strategy. null / {type:"native"} → the native loop; {type:"claude-code"}
- *  → the harness loop. Replaces the former inline dispatch branch. */
+/** Pinned runtime → strategy. null / {type:"native"} → the native loop; every other
+ *  runtime → the harness loop (one strategy for all vendors; only the DRIVER differs,
+ *  and harness-strategy resolves it from the registry — an unknown or unserved runtime
+ *  fails the turn with a terminal HARNESS error there, never a crash here). */
 function selectStrategy(runtime: RuntimeConfig | null): TurnStrategy {
   switch (runtime?.type) {
-    case "claude-code":
-      return harnessStrategy;
     case "native":
     case undefined: // null runtime column → native (the historical default)
       return nativeStrategy;
-    default: {
-      const never: never = runtime;
-      throw new Error(`unknown runtime: ${JSON.stringify(never)}`);
-    }
+    default:
+      return harnessStrategy;
   }
 }
 


### PR DESCRIPTION
**Stack 1/3** (base for #→pi driver→docs). No behavior change.

A single `TurnDeps.harness` port hardwired the worker to one vendor harness. This PR replaces it with a registry keyed by the pinned runtime type, so a second driver can slot in without touching the strategy:

- `HarnessDriver` (`packages/db/schema/configs.ts`): every `RuntimeConfig` type except `native`.
- `HarnessRegistry` (`packages/ports/harness/src/port.ts`): `Partial<Record<HarnessDriver, HarnessPort>>`; the worker builds one entry per harness it can serve.
- `harness-strategy` resolves its driver from the registry by `version.runtime.type`. A missing driver is the same honest terminal `HARNESS` failure as before, now naming the runtime (with a per-driver operator hint).
- `sessions.harness_state.driver` records the pinned runtime type instead of a hardcoded `"claude-code"`.
- `selectStrategy`: any non-native runtime dispatches to `harnessStrategy`; an unknown runtime value fails the turn there (terminal `HARNESS`) instead of throwing in the shell.

Existing claude-code sessions behave identically; all suites pass unchanged (only the test helper wiring moved to the registry shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)