### PR TITLE
Document the pi harness; console runtime picker gains Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,17 @@ Now every session provisions an isolated [E2B](https://e2b.dev) sandbox, through
 [ComputeSDK](https://computesdk.com) so further providers can slot in behind the same
 driver.
 
-### Running an agent on the Claude Code harness
+### Running an agent on a harness (Claude Code or Pi)
 
-Agents can run their turns inside [Claude Code](https://code.claude.com/docs/en/agent-sdk)
-(the Agent SDK) instead of Funky's native loop — same sessions, same sandboxes, same
-durable event log. This is a self-contained walkthrough; no need to run the Quickstart first.
+Agents can run their turns inside a vendor coding agent instead of Funky's native loop —
+same sessions, same sandboxes, same durable event log. Two harnesses are supported:
+
+- **Claude Code** ([the Agent SDK](https://code.claude.com/docs/en/agent-sdk)) — requires
+  an Anthropic model and `ANTHROPIC_API_KEY` on the worker.
+- **Pi** ([pi.dev](https://pi.dev), the pi coding agent) — runs on Anthropic, OpenAI, or
+  Together AI models; the worker needs the matching provider key.
+
+This is a self-contained walkthrough; no need to run the Quickstart first.
 
 **1. Add your key to `.env`** (independent of `FUNKY_LLM`) and bring up the stack:
 
@@ -147,6 +153,9 @@ AID=$(curl -s -X POST localhost:3000/v1/agents -H "$H" -H "$J" -d '{
   "runtime": { "type": "claude-code" }
 }' | jq -r .id)
 
+# — or the same agent on the Pi harness ("runtime": {"type": "pi"}), which also
+#   accepts openai and togetherai models
+
 # an environment, then a session on it
 EID=$(curl -s -X POST localhost:3000/v1/environments -H "$H" -H "$J" \
   -d '{"name":"basic","network":{"type":"unrestricted"}}' | jq -r .id)
@@ -161,13 +170,14 @@ curl -s -X POST localhost:3000/v1/sessions/$SID/messages -H "$H" -H "$J" \
 
 You'll see a `harness_attempt_started` event, then the agent run commands in its sandbox
 (`assistant_message` → `tool_result`) and answer — the same event stream as a native turn.
-
-> The **Console** at http://localhost:5173 can *view* a harness session, but can't yet
-> *create* one — use the `curl` above to create the agent with `runtime`.
+(The **Console** at http://localhost:5173 can create harness agents too — pick the runtime
+in the agent form.)
 
 The harness's commands execute in the session's Funky sandbox (exactly-once, crash-safe),
-and the Claude Code transcript is stored in Funky's Postgres — so a session survives worker
-crashes and can be resumed by any worker, keeping turns fully stateless. Design and
+and the vendor transcript is stored in Funky's Postgres — so a session survives worker
+crashes and can be resumed by any worker, keeping turns fully stateless. Claude Code gets
+a single `exec` tool bridged into the sandbox; Pi keeps its native four-tool surface
+(`read`, `bash`, `edit`, `write`), each backed by the same sandbox bridge. Design and
 guarantees: [`packages/ports/harness/DESIGN.md`](packages/ports/harness/DESIGN.md).
 
 ### Worker metrics (Prometheus scrape or OpenTelemetry push)

--- a/apps/web/src/console/Agents.tsx
+++ b/apps/web/src/console/Agents.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Cpu } from 'lucide-react'
 import { agents as agentsApi } from '../lib/api'
-import type { Agent } from '../lib/types'
+import type { Agent, RuntimeKind } from '../lib/types'
 import { DEFAULT_MODEL_LABEL, modelConfigFor, modelLabel } from '../lib/models'
 import { errMsg, initials } from '../lib/format'
 import { Avatar, Badge, Button, Checkbox, Modal, Textarea, Input } from '../ui/ui'
@@ -21,13 +21,16 @@ export function Agents({
   const [open, setOpen] = useState(false)
   const [name, setName] = useState('')
   const [model, setModel] = useState(DEFAULT_MODEL_LABEL)
-  const [runtime, setRuntime] = useState<'native' | 'claude-code'>('native')
+  const [runtime, setRuntime] = useState<RuntimeKind>('native')
   const [prompt, setPrompt] = useState('')
   const [saving, setSaving] = useState(false)
 
   function chooseModel(next: string) {
     setModel(next)
-    if (modelConfigFor(next).provider !== 'anthropic') setRuntime('native')
+    // claude-code is anthropic-only; pi and native follow the model anywhere.
+    if (modelConfigFor(next).provider !== 'anthropic') {
+      setRuntime((r) => (r === 'claude-code' ? 'native' : r))
+    }
   }
 
   async function create() {
@@ -96,7 +99,11 @@ export function Agents({
                   <div className="row__sub">{modelLabel(a.model)}</div>
                 </div>
                 <div className="row__excerpt">{a.system_prompt}</div>
-                {a.runtime?.type === 'claude-code' ? <Badge tone="neutral">Claude Code</Badge> : null}
+                {a.runtime?.type === 'claude-code' ? (
+                  <Badge tone="neutral">Claude Code</Badge>
+                ) : a.runtime?.type === 'pi' ? (
+                  <Badge tone="neutral">Pi</Badge>
+                ) : null}
                 <Badge tone="green" dot>
                   Ready
                 </Badge>

--- a/apps/web/src/console/QuickStart.tsx
+++ b/apps/web/src/console/QuickStart.tsx
@@ -3,6 +3,7 @@ import { Check } from 'lucide-react'
 import { agents as agentsApi, environments as envsApi, sessions as sessApi } from '../lib/api'
 import { DEFAULT_MODEL_LABEL, modelConfigFor } from '../lib/models'
 import { networkPolicy, networkSummary, type NetworkMode } from '../lib/network'
+import type { RuntimeKind } from '../lib/types'
 import { errMsg, initials } from '../lib/format'
 import { Avatar, Badge, Button, CodeBlock, Input, Textarea } from '../ui/ui'
 import { ModelField, NetworkFields, RuntimeField } from './parts'
@@ -16,7 +17,7 @@ export function QuickStart({ onLaunch }: { onLaunch: (sessionId: string) => Prom
   const [step, setStep] = useState(1)
   const [agentName, setAgentName] = useState('Funky Assistant')
   const [model, setModel] = useState(DEFAULT_MODEL_LABEL)
-  const [runtime, setRuntime] = useState<'native' | 'claude-code'>('native')
+  const [runtime, setRuntime] = useState<RuntimeKind>('native')
   const [systemPrompt, setSystemPrompt] = useState(DEFAULT_PROMPT)
   const [envName, setEnvName] = useState('basic')
   const [envDesc, setEnvDesc] = useState('default dev box')
@@ -31,7 +32,10 @@ export function QuickStart({ onLaunch }: { onLaunch: (sessionId: string) => Prom
 
   function chooseModel(nextModel: string) {
     setModel(nextModel)
-    if (modelConfigFor(nextModel).provider !== 'anthropic') setRuntime('native')
+    // claude-code is anthropic-only; pi and native follow the model anywhere.
+    if (modelConfigFor(nextModel).provider !== 'anthropic') {
+      setRuntime((r) => (r === 'claude-code' ? 'native' : r))
+    }
   }
 
   function guardStep1() {
@@ -155,7 +159,10 @@ export function QuickStart({ onLaunch }: { onLaunch: (sessionId: string) => Prom
               <div className="review">
                 <ReviewRow label="Agent" value={agentName} strong />
                 <ReviewRow label="Model" value={model} mono />
-                <ReviewRow label="Runtime" value={runtime === 'claude-code' ? 'Claude Code' : 'Native'} />
+                <ReviewRow
+                  label="Runtime"
+                  value={{ native: 'Native', 'claude-code': 'Claude Code', pi: 'Pi' }[runtime]}
+                />
                 <ReviewRow label="Environment" value={envName} mono />
                 <ReviewRow label="Network" value={networkSummary(network)} />
                 <ReviewRow label="System prompt" value={systemPrompt} />

--- a/apps/web/src/console/Sessions.tsx
+++ b/apps/web/src/console/Sessions.tsx
@@ -195,7 +195,12 @@ function CreateSessionModal({
           value={agentId}
           options={agents.map((a) => ({
             value: a.id,
-            label: a.runtime?.type === 'claude-code' ? `${a.name} · Claude Code` : a.name,
+            label:
+              a.runtime?.type === 'claude-code'
+                ? `${a.name} · Claude Code`
+                : a.runtime?.type === 'pi'
+                  ? `${a.name} · Pi`
+                  : a.name,
           }))}
           onChange={setAgentId}
         />

--- a/apps/web/src/console/curl.ts
+++ b/apps/web/src/console/curl.ts
@@ -1,5 +1,5 @@
 import { modelConfigFor } from '../lib/models'
-import type { NetworkPolicy } from '../lib/types'
+import type { NetworkPolicy, RuntimeKind } from '../lib/types'
 
 // The Quick Start's right-hand code panel. Unlike the prototype's illustrative sample, this
 // mirrors the *real* requests the console makes (and the README quickstart), so a developer
@@ -8,7 +8,7 @@ export type CurlState = {
   step: number
   agentName: string
   model: string
-  runtime: 'native' | 'claude-code'
+  runtime: RuntimeKind
   systemPrompt: string
   envName: string
   envDesc: string
@@ -27,9 +27,9 @@ export function buildCurl(st: CurlState): string {
   ].join('\n')
 
   if (st.step >= 1) {
-    // claude-code runs turns inside the Claude Agent SDK (the harness); native omits the field.
+    // A harness runtime (claude-code, pi) rides the create body; native omits the field.
     const runtimeLine =
-      st.runtime === 'claude-code' ? `,\n  "runtime": { "type": "claude-code" }` : ''
+      st.runtime !== 'native' ? `,\n  "runtime": { "type": "${st.runtime}" }` : ''
     code += `\n\n# 1. an agent: who it is and what model it uses
 AID=$(curl -s -X POST localhost:3000/v1/agents -H "$H" -H "$J" -d '{
   "name": ${j(st.agentName || 'my agent')},

--- a/apps/web/src/console/parts.tsx
+++ b/apps/web/src/console/parts.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { AlertTriangle, Archive, Cpu, Layers, MessageSquare, MoreVertical, X, Zap } from 'lucide-react'
 import { Button, Select, Textarea } from '../ui/ui'
 import { MODEL_OPTIONS } from '../lib/models'
-import type { Provider } from '../lib/types'
+import type { Provider, RuntimeKind } from '../lib/types'
 import type { NetworkMode } from '../lib/network'
 import { useClickOutside } from './data'
 
@@ -110,15 +110,15 @@ export function ModelField({ value, onChange }: { value: string; onChange: (v: s
   )
 }
 
-// How the agent runs its turns. Claude Code is only valid for Anthropic models; Together
-// models use Funky's provider-neutral native loop.
+// How the agent runs its turns. Claude Code is only valid for Anthropic models; pi
+// supports every provider the console offers models for.
 export function RuntimeField({
   value,
   onChange,
   modelProvider,
 }: {
-  value: 'native' | 'claude-code'
-  onChange: (v: 'native' | 'claude-code') => void
+  value: RuntimeKind
+  onChange: (v: RuntimeKind) => void
   modelProvider: Provider
 }) {
   const claudeCodeAvailable = modelProvider === 'anthropic'
@@ -134,15 +134,21 @@ export function RuntimeField({
             label: 'Claude Code — run turns inside the Claude Agent SDK',
             disabled: !claudeCodeAvailable,
           },
+          { value: 'pi', label: 'Pi — run turns inside the pi coding agent' },
         ]}
-        onChange={(v) => onChange(v as 'native' | 'claude-code')}
+        onChange={(v) => onChange(v as RuntimeKind)}
       />
       {value === 'claude-code' ? (
         <p className="model-hint">
           Runs each turn inside Claude Code; needs <code>ANTHROPIC_API_KEY</code> on the worker.
         </p>
+      ) : value === 'pi' ? (
+        <p className="model-hint">
+          Runs each turn inside the pi coding agent; needs the model provider’s API key on the
+          worker.
+        </p>
       ) : !claudeCodeAvailable ? (
-        <p className="model-hint">Together AI models run with the Native runtime.</p>
+        <p className="model-hint">Claude Code is only available for Anthropic models.</p>
       ) : null}
     </div>
   )

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -18,9 +18,11 @@ export type ModelConfig = {
   temperature?: number
 }
 
-// How an agent runs its turns: 'native' = Funky's built-in loop; 'claude-code' = inside
-// the Claude Agent SDK (the harness). claude-code requires an anthropic model.
-export type RuntimeConfig = { type: 'native' } | { type: 'claude-code' }
+// How an agent runs its turns: 'native' = Funky's built-in loop; anything else names a
+// vendor harness. claude-code requires an anthropic model; pi supports anthropic,
+// openai, and togetherai models.
+export type RuntimeKind = 'native' | 'claude-code' | 'pi'
+export type RuntimeConfig = { type: RuntimeKind }
 
 export type Agent = {
   type: 'agent'

--- a/apps/worker/src/config.ts
+++ b/apps/worker/src/config.ts
@@ -40,17 +40,19 @@ const EnvSchema = z
     // e2b: an isolated remote sandbox per session. (The in-process subprocess driver still
     // exists for the offline test suites, but is not a production sandbox option.)
     FUNKY_SANDBOX: z.enum(["docker", "e2b"]).default("docker"),
-    // Used by the direct Anthropic provider and by agents with runtime=claude-code (the
-    // harness driver is only constructed when this key is present).
+    // Used by the direct Anthropic provider and by the harnesses (runtime=claude-code
+    // needs this key; runtime=pi accepts it among others). A harness driver is only
+    // constructed when a key it can use is present.
     ANTHROPIC_API_KEY: optionalSecret,
-    // Direct AI SDK provider credentials. At least one supported provider key is required
-    // when the real driver is enabled; each agent still selects its own provider/model.
+    // Direct AI SDK provider credentials, also accepted by the pi harness. At least one
+    // supported provider key is required when the real driver is enabled; each agent
+    // still selects its own provider/model.
     OPENAI_API_KEY: optionalSecret,
     TOGETHER_API_KEY: optionalSecret,
-    // Harness (claude-code) knobs. CWD_ROOT must be identical across the worker
-    // fleet — the harness derives the transcript store's projectKey from it.
-    // SCRATCH_ROOT holds the disposable per-attempt local session copy; point it at
-    // RAM-backed storage (tmpfs) in production.
+    // Harness knobs. CWD_ROOT is claude-code-only and must be identical across the
+    // worker fleet — that harness derives the transcript store's projectKey from it.
+    // SCRATCH_ROOT holds every harness's disposable per-attempt local session copy;
+    // point it at RAM-backed storage (tmpfs) in production.
     FUNKY_HARNESS_CWD_ROOT: z.string().min(1).default("/tmp/funky-harness-cwd"),
     FUNKY_HARNESS_SCRATCH_ROOT: z.string().min(1).default("/tmp/funky-harness-scratch"),
     // Required ONLY when FUNKY_SANDBOX=e2b (docker needs no account).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,9 +85,10 @@ services:
     # workloads prefer FUNKY_SANDBOX=e2b (remote) or run the containers under gVisor/Kata.
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    # RAM-backed scratch for the claude-code harness: each in-flight harness turn keeps
-    # its DISPOSABLE local session copy here (the durable transcript is in Postgres).
-    # tmpfs means a dead worker leaves nothing behind — statelessness by construction.
+    # RAM-backed scratch for the harnesses (claude-code, pi): each in-flight harness
+    # turn keeps its DISPOSABLE local session copy here (the durable transcript is in
+    # Postgres). tmpfs means a dead worker leaves nothing behind — statelessness by
+    # construction.
     tmpfs:
       - /dev/shm/funky-harness
     environment:
@@ -109,8 +110,9 @@ services:
       OTEL_METRIC_EXPORT_INTERVAL: ${OTEL_METRIC_EXPORT_INTERVAL:-}
       OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-}
       OTEL_RESOURCE_ATTRIBUTES: ${OTEL_RESOURCE_ATTRIBUTES:-}
-      # Harness (agents with runtime=claude-code). CWD_ROOT must be identical across
-      # every worker replica — the transcript store's key derives from it.
+      # Harnesses (agents with runtime=claude-code or runtime=pi). CWD_ROOT is
+      # claude-code-only and must be identical across every worker replica — the
+      # transcript store's key derives from it.
       FUNKY_HARNESS_SCRATCH_ROOT: /dev/shm/funky-harness
       FUNKY_HARNESS_CWD_ROOT: /tmp/funky-harness-cwd
     depends_on:

--- a/packages/ports/harness/DESIGN.md
+++ b/packages/ports/harness/DESIGN.md
@@ -1,13 +1,17 @@
 # The Harness Port — running managed agent SDKs on Funky's stateless runtime
 
-Status: **implemented** (v1). First driver: **Claude Code**
-(`@anthropic-ai/claude-agent-sdk`). See §11 for the map from this document to the code
-and the tests that pin each guarantee.
+Status: **implemented** (v1). Drivers: **Claude Code**
+(`@anthropic-ai/claude-agent-sdk`) and **pi** (`@earendil-works/pi-coding-agent`,
+[pi.dev](https://pi.dev)). See §11 for the map from this document to the code and the
+tests that pin each guarantee.
 
-This document explains what the harness port is, how the Claude Code driver keeps
-Funky's core promise — **stateless, crash-resumable turn execution with exactly-once
-command execution** — while the agentic loop runs inside a closed binary, and which
-alternatives were considered and rejected.
+This document explains what the harness port is, how the drivers keep Funky's core
+promise — **stateless, crash-resumable turn execution with exactly-once command
+execution** — while the agentic loop runs inside a vendor harness, and which
+alternatives were considered and rejected. §§2–9 walk the design through the first
+driver (Claude Code, a closed binary the SDK drives over a subprocess); §9b describes
+where the pi driver — an open TypeScript loop that runs in-process — lands differently
+while preserving every invariant in §10.
 
 ---
 
@@ -112,9 +116,12 @@ Division of labor (mirrors the llm/sandbox ports):
 ### Selection
 
 Agent behavior is versioned, so the switch lives on `agent_config_versions.runtime`
-(jsonb): `null` / `{"type":"native"}` → the existing loop; `{"type":"claude-code"}` →
-the harness. Sessions pin the agent version, so a session's runtime never changes
-mid-life.
+(jsonb): `null` / `{"type":"native"}` → the existing loop; any other type names a
+harness driver (`{"type":"claude-code"}`, `{"type":"pi"}`). The worker holds a
+**registry** (`HarnessRegistry`) keyed by runtime type — one strategy serves every
+harness; only the driver differs. A session whose runtime names a driver the worker
+doesn't serve fails the turn with a terminal HARNESS error. Sessions pin the agent
+version, so a session's runtime never changes mid-life.
 
 ## 4. Exactly-once command execution
 
@@ -304,8 +311,18 @@ harness_transcript_entries
 sessions               + harness_attempt text?   — current fence token
                        + harness_state   jsonb?  — committed { driver, sdk_session_id } (cache/audit; tip query is authoritative)
 
-agent_config_versions  + runtime jsonb?          — null/native | {"type":"claude-code"}
+agent_config_versions  + runtime jsonb?          — null/native | {"type":"claude-code"} | {"type":"pi"}
 ```
+
+The table is driver-neutral; per-driver row shapes:
+
+| | claude-code | pi |
+|---|---|---|
+| `project_key` | SDK-derived from the sanitized cwd | the constant `"pi"` |
+| `sdk_session_id` | new id per resume (lineage via tip) | stable for the session's life |
+| `entry_uuid` | the SDK entry's `uuid` (nullable) | the pi entry's `id` (always set; the header row uses the session id) |
+| `entry` | SDK `SessionStoreEntry`, verbatim | pi `FileEntry` (header or session entry), verbatim |
+| `subpath` | `''` main, `subagents/…` | always `''` |
 
 Event model additions (`packages/sessions/src/events.ts`):
 
@@ -348,6 +365,64 @@ not projected in v1 (additive `ContentBlock` kind later).
   default `FUNKY_WORKER_CONCURRENCY=50` is sized for the native loop; deployments
   running mostly harness sessions should size it down.
 
+## 9b. Driver specifics (pi)
+
+pi's loop is open TypeScript embedded in-process (`createAgentSession`) — no
+subprocess, no closed binary. Two structural differences from Claude Code, one
+guarantee-preserving consequence each:
+
+**Tool surface: replacement, not denial.** pi's four default tools (`read`, `bash`,
+`edit`, `write`) are re-created over the SDK's own `*Operations` remote-execution seam
+and passed as `customTools`, shadowing the built-ins by name — the model keeps pi's
+native tool surface, but every primitive (a bash command, a file read, a write, an
+edit's read-modify-write) compiles to a POSIX shell command that funnels through the
+same journaled exec bridge as claude-code's MCP tool: append the decision (seq →
+idemKey) → `Executor.exec` → append the result. File content crosses the exec channel
+base64-encoded (the channel is a combined text stream; base64 keeps bytes intact — a
+truncated read refuses to return corrupt bytes rather than decode a partial stream).
+Nothing the model does can reach the worker host; §4's case analysis applies verbatim
+because the bridge is the same.
+
+**Transcript: driver-owned mirror, not an SDK adapter.** pi's `SessionManager` owns a
+local JSONL session file (header line + tree-structured entries) and has no pluggable
+store, so the driver owns the mirror instead of adapting one: the file lives on
+per-attempt scratch; every `FileEntry` — the header included, so the file is
+byte-reconstructible — is flushed to `harness_transcript_entries` behind the same
+guarded INSERT as §5.1 (fence check fused into the write, dedupe on the pi entry id).
+Resume materializes the file from Postgres and `SessionManager.open()`s it; pi keeps
+its session id across resumes, so the §5.2 tip query works unchanged. Because flushes
+are driver-driven and awaited — before the model is prompted, on every appended entry,
+and once more before the turn returns — a fence loss surfaces synchronously (no
+`mirror_error` indirection) and a committed turn never sits on a holed transcript
+(§10.4).
+
+Driver-level details:
+
+- **cwd is a fiction.** pi resolves tool paths against its cwd, but commands run in
+  the sandbox's own workdir. The driver pins pi's cwd to the constant `/workspace`;
+  the operations layer translates paths under it back to relative form, which the
+  sandbox resolves against its real workdir. Absolute paths outside the fiction pass
+  through untouched. Deterministic across the fleet by construction — pi needs no
+  `FUNKY_HARNESS_CWD_ROOT`.
+- **Isolation.** Per-attempt `agentDir` on scratch; `DefaultResourceLoader` with
+  extensions/skills/prompt-templates/themes/context-files disabled and the pinned
+  agent version's prompt as the base system prompt (pi appends its tool docs); an
+  isolated `ModelRuntime` whose only credential is the key injected for this turn
+  (`setRuntimeApiKey` — no host auth.json, no env fallback, no network refresh).
+- **Providers.** anthropic, openai, and togetherai (mapped to pi-ai's `together`) —
+  the providers a worker can hold keys for. Anything else, a missing key, or a model
+  id absent from pi-ai's catalog is a `HarnessPermanentError`. The API edge enforces
+  the same set on `runtime: {"type":"pi"}`.
+- **maxTurns.** pi's loop has no cap, so the driver counts assistant turns and aborts
+  a turn that would START past `tool_policy.max_iterations` — a run that finishes
+  exactly on budget is a success; the abort maps to `turn_failed(BUDGET)` with the
+  transcript tip committed, like claude-code's `error_max_turns`.
+- **Failures.** After the run, `AgentState.errorMessage` (pi's own retry budget
+  already exhausted) classifies as auth-looking → permanent, else transient — same
+  taxonomy, same worker outcomes (§6).
+- Concurrency note: pi runs in-process (no subprocess per turn), so it is lighter
+  than claude-code under the same `FUNKY_WORKER_CONCURRENCY`.
+
 ## 10. Invariants (the contract, in one place)
 
 1. Every exec decision is in the log **before** the sandbox sees it; its idemKey is
@@ -374,13 +449,18 @@ Where each piece of this document lives, and the test that pins it:
 | Fence acquisition + recovery + commit (§4.3, §5) | `harnessStrategy` in `packages/sessions/src/harness-strategy.ts` | `packages/sessions/src/harness-turn.test.ts` — the two ★ crash-resume tests are the exactly-once proof |
 | Shared turn shell + strategy seam (§3) | `runTurn` / `selectStrategy` in `packages/sessions/src/turn.ts`; `TurnShell` / `TurnStrategy` in `packages/sessions/src/strategy.ts`; `nativeStrategy` in `native-strategy.ts` | driven through `runTurn` by `turn.test.ts` + `harness-turn.test.ts` |
 | Shared exec/reboot policy (§4.1) | `packages/sessions/src/exec.ts` (extracted from `turn.ts`, used by both strategies) | native `turn.test.ts` + chaos suite (unchanged) |
+| pi driver: in-process session, sandbox ops, maxTurns, projection (§9b) | `PiHarness` + `makeSandboxOps` in `src/drivers/pi.ts` | `src/pi.test.ts` (fake `createSessionFn` seam; real SessionManager/ModelRuntime) |
+| pi fenced transcript mirror + materialization (§9b) | `PiTranscriptStore` / `loadPiTranscript` in `src/drivers/pi-store.ts` | `src/pi-store.test.ts` ("★ the write fence") |
+| Driver registry keyed by runtime (§3) | `HarnessRegistry` in `src/port.ts`; lookup in `packages/sessions/src/harness-strategy.ts` | harness-turn test "the registry keys by runtime type" |
 | Schema (§8) | `packages/db/schema/harness.ts`, `sessions.ts`, `configs.ts`; migration `20260718201401_harness_port` | `packages/db/src/schema.test.ts` |
 | Event model additions (§8) | `harness_attempt_started` + `HARNESS` error class in `packages/sessions/src/events.ts` | `events.test.ts` round-trip |
 | API edge (`runtime` on agents) (§3, §9) | `apps/api/src/routes/agents.ts`, `packages/configs/{types,service}.ts` | `apps/api/test/agents.test.ts` |
 | Worker wiring + env knobs (§9) | `apps/worker/src/{index,config,worker}.ts`; compose tmpfs in `docker-compose.yml` | `apps/worker/test/config.test.ts` |
 
-Not covered offline: a live end-to-end run against the real Claude Code subprocess
-(needs `ANTHROPIC_API_KEY`). The driver's SDK-facing behavior is exercised through the
-`queryFn` test seam; the real subprocess's message cadence and resume-id behavior
-should be smoke-tested once per SDK upgrade (`resume` id changes are tolerated by
-design — the tip query accepts whatever id entries land under).
+Not covered offline: a live end-to-end run against a real model (needs a provider API
+key). Each driver's SDK-facing behavior is exercised through its test seam
+(claude-code: `queryFn`; pi: `createSessionFn` — though pi's SessionManager,
+ModelRuntime, and resource plumbing are real even in tests). The real message cadence
+and resume behavior should be smoke-tested once per SDK upgrade (claude-code `resume`
+id changes are tolerated by design — the tip query accepts whatever id entries land
+under; pi keeps one id, so its tip is trivially stable).


### PR DESCRIPTION
**Stack 3/3** — on top of #87. Docs and console surface for the pi harness:

- **DESIGN.md**: multi-driver registry framing in §3; new §9b "Driver specifics (pi)" (in-process loop, tool replacement over `*Operations`, driver-owned fenced mirror, the `/workspace` cwd fiction, driver-enforced maxTurns, provider set); per-driver row shapes in §8; implementation-map rows for the new code and tests.
- **README**: the harness walkthrough covers both drivers, and drops the stale note claiming the console cannot create harness agents (it has a runtime picker).
- **Console**: `RuntimeKind` gains `'pi'` — picker option (with worker-key hint), agent badge, session labels, and the Quick Start curl panel. claude-code stays anthropic-only; switching to a non-anthropic model now only resets the runtime when it was claude-code, leaving pi selected.
- **docker-compose / worker config**: comments updated for the second harness (`FUNKY_HARNESS_CWD_ROOT` is claude-code-only; the tmpfs scratch serves both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)