### PR TITLE
Add @funky/core and @funky/agent: the message and provider contracts

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@funky/agent",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@funky/core": "workspace:*"
+  }
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,0 +1,2 @@
+export { inference } from "./inference";
+export type { ModelProvider, StreamRequest } from "./model-provider";

--- a/packages/agent/src/inference.ts
+++ b/packages/agent/src/inference.ts
@@ -1,0 +1,18 @@
+import type { AgentMessage, AssistantMessage, ProviderEvent, ToolSpec } from "@funky/core";
+import type { ModelProvider } from "./model-provider";
+
+export async function inference(
+  deps: {
+    provider: ModelProvider;
+    onDelta?: (e: ProviderEvent) => void;  // sync fire-and-forget tap
+  },
+  req: {
+    model: string;
+    system: string;
+    context: AgentMessage[];
+    tools: ToolSpec[]
+  },
+  signal: AbortSignal,
+): Promise<AssistantMessage> {
+  throw new Error("not implemented: the fold");
+}

--- a/packages/agent/src/model-provider.ts
+++ b/packages/agent/src/model-provider.ts
@@ -1,0 +1,29 @@
+import type { AgentMessage, ProviderEvent, ToolSpec } from "@funky/core";
+
+/**
+ * The harness's entire knowledge of "there is an AI model somewhere":
+ * one request in, one live stream of increments out.
+ *
+ * Contract for implementations:
+ * - Translate `req` to the vendor wire format and the vendor's stream events
+ *   to `ProviderEvent`s, one by one, as they arrive. Nothing else: no fold
+ *   (the engine assembles the message), no retries (driver policy), no
+ *   persistence, no knowledge of sessions/runs/items.
+ * - End the stream with exactly one `done` event on provider-reported
+ *   completion.
+ * - Pass `signal` into the vendor SDK so cancellation severs the HTTP stream
+ *   mid-generation; on abort or any failure, just throw — the engine converts
+ *   exceptions into `aborted`/`error`-stopped messages.
+ * - Each `stream()` call is stateless and independent.
+ */
+export interface ModelProvider {
+  stream(req: StreamRequest, signal: AbortSignal): AsyncIterable<ProviderEvent>;
+}
+
+/** Serializable data only — the (req, signal) split mirrors the engine's. */
+export interface StreamRequest {
+  model: string;
+  system: string;
+  context: AgentMessage[];
+  tools: ToolSpec[];
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@funky/core",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "zod": "^4.0.0"
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./messages";
+export * from "./provider-events";
+export * from "./tools";

--- a/packages/core/src/messages.ts
+++ b/packages/core/src/messages.ts
@@ -1,0 +1,130 @@
+import { z } from "zod";
+
+/**
+ * The message vocabulary of the harness — the provider-facing payload types.
+ *
+ * These schemas are the persistence format: entries wrap these messages and
+ * stored sessions must parse forever. Evolution rules:
+ * - adding an optional field is backward compatible; removing or renaming
+ *   one is a migration — fields must earn their way in
+ * - the union stays closed (user | assistant | toolResult); app
+ *   extensibility lives in entries, never here
+ */
+
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export const JsonValue: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(JsonValue),
+    z.record(z.string(), JsonValue),
+  ]),
+);
+
+// --- content parts ---
+
+export const TextContent = z.object({
+  type: z.literal("text"),
+  text: z.string(),
+});
+export type TextContent = z.infer<typeof TextContent>;
+
+export const ImageContent = z.object({
+  type: z.literal("image"),
+  data: z.string(), // base64
+  mimeType: z.string(), // e.g. "image/png"
+});
+export type ImageContent = z.infer<typeof ImageContent>;
+
+export const ThinkingContent = z.object({
+  type: z.literal("thinking"),
+  thinking: z.string(),
+  // Anthropic extended thinking: the signature must round-trip to the API
+  // for multi-turn continuity. When `redacted` is true, `thinking` is empty
+  // and the opaque encrypted payload rides in `thinkingSignature`.
+  thinkingSignature: z.string().optional(),
+  redacted: z.boolean().optional(),
+});
+export type ThinkingContent = z.infer<typeof ThinkingContent>;
+
+export const ToolCall = z.object({
+  type: z.literal("toolCall"),
+  id: z.string(),
+  name: z.string(),
+  arguments: z.record(z.string(), JsonValue),
+});
+export type ToolCall = z.infer<typeof ToolCall>;
+
+// --- usage and stop reasons ---
+
+// Token counts only. Cost is computed at metering/display time from pricing
+// tables — never persisted, so price changes don't invalidate stored sessions.
+export const Usage = z.object({
+  input: z.number(),
+  output: z.number(),
+  cacheRead: z.number(),
+  cacheWrite: z.number(),
+  // Subset of `output`; present only when the provider reports a breakdown.
+  reasoning: z.number().optional(),
+});
+export type Usage = z.infer<typeof Usage>;
+
+export const StopReason = z.enum([
+  // provider outcomes
+  "end_turn",
+  "tool_use",
+  "max_tokens",
+  // harness outcomes — such messages are kept in the log but filtered from
+  // model context by buildContext
+  "aborted",
+  "error",
+]);
+export type StopReason = z.infer<typeof StopReason>;
+
+// --- messages ---
+
+export const UserMessage = z.object({
+  role: z.literal("user"),
+  // Always an array; plain strings are normalized at intake.
+  content: z.array(z.discriminatedUnion("type", [TextContent, ImageContent])),
+});
+export type UserMessage = z.infer<typeof UserMessage>;
+
+export const AssistantMessage = z.object({
+  role: z.literal("assistant"),
+  content: z.array(z.discriminatedUnion("type", [TextContent, ThinkingContent, ToolCall])),
+  model: z.string(),
+  stopReason: StopReason,
+  // Absent when the stream died before the provider reported usage.
+  usage: Usage.optional(),
+  // Set when stopReason === "error".
+  errorMessage: z.string().optional(),
+});
+export type AssistantMessage = z.infer<typeof AssistantMessage>;
+
+export const ToolResultMessage = z.object({
+  role: z.literal("toolResult"),
+  toolCallId: z.string(),
+  toolName: z.string(),
+  content: z.array(z.discriminatedUnion("type", [TextContent, ImageContent])),
+  // Tool-specific structured payload for UI rendering; never sent to the model.
+  details: JsonValue.optional(),
+  isError: z.boolean(),
+});
+export type ToolResultMessage = z.infer<typeof ToolResultMessage>;
+
+export const AgentMessage = z.discriminatedUnion("role", [
+  UserMessage,
+  AssistantMessage,
+  ToolResultMessage,
+]);
+export type AgentMessage = z.infer<typeof AgentMessage>;

--- a/packages/core/src/provider-events.ts
+++ b/packages/core/src/provider-events.ts
@@ -1,0 +1,40 @@
+import type { StopReason, Usage } from "./messages";
+
+/**
+ * Streaming increments from a model provider.
+ *
+ * The taxonomy follows pi's `AssistantMessageEvent` (per-kind start/delta/end
+ * tags, `contentIndex` addressing the part being generated) — but events are
+ * pure increments: nothing ever carries an assembled or partial
+ * `AssistantMessage`. The engine owns the fold — accumulating parts, parsing
+ * tool-call arguments at `toolcall_end`, synthesizing aborted/error outcomes —
+ * so the "exactly one message per inference" invariant lives in one place
+ * instead of in every provider adapter. Adapters are dumb translators: vendor
+ * SDK event in, `ProviderEvent` out, exceptions propagate (there is no error
+ * event).
+ *
+ * Ephemeral (never persisted, never parsed from untrusted input), so plain
+ * types rather than zod schemas.
+ */
+
+/** Outcomes a provider can report. `aborted`/`error` are assigned by the engine, never by a provider. */
+export type ProviderStopReason = Extract<StopReason, "end_turn" | "tool_use" | "max_tokens">;
+
+export type ProviderEvent =
+  | { type: "text_start"; contentIndex: number }
+  | { type: "text_delta"; contentIndex: number; delta: string }
+  | { type: "text_end"; contentIndex: number }
+  | { type: "thinking_start"; contentIndex: number }
+  | { type: "thinking_delta"; contentIndex: number; delta: string }
+  /** Anthropic delivers the signature at block end; the fold attaches it to the part.
+   *  Redacted blocks never stream deltas: adapters emit an empty start/end pair with
+   *  `redacted: true` and the opaque encrypted payload in `signature`; the fold sets
+   *  the part's `redacted` flag so replay reconstructs a `redacted_thinking` block. */
+  | { type: "thinking_end"; contentIndex: number; signature?: string; redacted?: boolean }
+  /** Tool identity is known before arguments stream — required here, so UIs can show the call early. */
+  | { type: "toolcall_start"; contentIndex: number; toolCallId: string; toolName: string }
+  /** Arguments stream as partial JSON text; the fold buffers and parses at `toolcall_end`. */
+  | { type: "toolcall_delta"; contentIndex: number; argsDelta: string }
+  | { type: "toolcall_end"; contentIndex: number }
+  /** Terminal marker. Carries the provider outcome and usage — never a message. */
+  | { type: "done"; stopReason: ProviderStopReason; usage: Usage };

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+import { JsonValue } from "./messages";
+
+/**
+ * The serializable declaration of a tool: what the model needs to decide to
+ * call it — never how to run it. Executables (the `Tool` interface with an
+ * `execute()` body) live in the agent package, executor-side only; specs are
+ * what travel in inference requests and to model providers.
+ */
+export const ToolSpec = z.object({
+  name: z.string(),
+  description: z.string(),
+  // JSON Schema for the tool's arguments. Kept as plain JSON (not zod) so it
+  // serializes; executables declare zod schemas and project to this at the edge.
+  inputSchema: z.record(z.string(), JsonValue),
+});
+export type ToolSpec = z.infer<typeof ToolSpec>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,12 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
+  packages/agent:
+    dependencies:
+      '@funky/core':
+        specifier: workspace:*
+        version: link:../core
+
   packages/configs:
     dependencies:
       '@funky/db':
@@ -189,6 +195,12 @@ importers:
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+
+  packages/core:
+    dependencies:
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
 
   packages/db:
     dependencies:


### PR DESCRIPTION
Adds two new workspace packages that define the harness's message vocabulary and its model-provider seam, ahead of the engine that will use them. `@funky/core` holds the closed `user | assistant | toolResult` message union as zod schemas (the persistence format), the `ProviderEvent` streaming taxonomy, and `ToolSpec`; `@funky/agent` holds the `ModelProvider.stream(req, signal)` interface and the `inference()` entry point.

This is contracts only — `inference()` is a stub that throws, and nothing outside `@funky/agent` imports `@funky/core`, so no existing behavior changes. It lands separately because the message schemas are what stored sessions must parse forever, and they're much cheaper to review now than to migrate later.

Notable design choices: events are pure increments that never carry an assembled message, so the engine owns the fold and the "exactly one message per inference" invariant lives in one place rather than in every adapter; `Usage` records tokens only, with cost computed at display time so pricing changes don't invalidate stored sessions.

This supersedes `@funky/llm`'s `LlmPort`, which is non-streaming, flattens content to strings, and caps a turn at one tool call — but the two coexist for now and nothing is migrated here. The fold and the first provider adapter, with tests, follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)