### PR TITLE
Implement the inference fold in @funky/agent

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -5,7 +5,14 @@
   "exports": {
     ".": "./src/index.ts"
   },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
   "dependencies": {
     "@funky/core": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/agent/src/fake-model-provider.ts
+++ b/packages/agent/src/fake-model-provider.ts
@@ -1,0 +1,37 @@
+import type { ProviderEvent } from "@funky/core";
+import type { ModelProvider, StreamRequest } from "./model-provider";
+
+/**
+ * A scripted ModelProvider for tests: yields the given steps in order.
+ * Beyond plain events, a step can throw (provider/network failure) or park
+ * until the caller aborts (for testing mid-stream cancellation, mimicking an
+ * SDK that raises AbortError when the signal fires).
+ *
+ * `requests` records every stream() call for assertions.
+ */
+export type FakeStep = ProviderEvent | { kind: "throw"; error: Error } | { kind: "untilAborted" };
+
+export interface FakeModelProvider extends ModelProvider {
+  requests: StreamRequest[];
+}
+
+export function createFakeModelProvider(script: FakeStep[]): FakeModelProvider {
+  const requests: StreamRequest[] = [];
+  return {
+    requests,
+    async *stream(req: StreamRequest, signal: AbortSignal): AsyncIterable<ProviderEvent> {
+      requests.push(req);
+      for (const step of script) {
+        if ("kind" in step) {
+          if (step.kind === "throw") throw step.error;
+          await new Promise<void>((resolve) => {
+            if (signal.aborted) return resolve();
+            signal.addEventListener("abort", () => resolve(), { once: true });
+          });
+          throw new DOMException("The operation was aborted.", "AbortError");
+        }
+        yield step;
+      }
+    },
+  };
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,2 +1,3 @@
 export { inference } from "./inference";
+export type { InferenceDeps, InferenceRequest } from "./inference";
 export type { ModelProvider, StreamRequest } from "./model-provider";

--- a/packages/agent/src/inference.ts
+++ b/packages/agent/src/inference.ts
@@ -1,18 +1,159 @@
-import type { AgentMessage, AssistantMessage, ProviderEvent, ToolSpec } from "@funky/core";
+import type {
+  AgentMessage,
+  AssistantMessage,
+  JsonValue,
+  ProviderEvent,
+  TextContent,
+  ThinkingContent,
+  ToolCall,
+  ToolSpec,
+  Usage,
+} from "@funky/core";
 import type { ModelProvider } from "./model-provider";
 
+export interface InferenceDeps {
+  provider: ModelProvider;
+  /** Sync fire-and-forget tap. Failures are swallowed: decoration never breaks the step. */
+  onDelta?: (e: ProviderEvent) => void;
+}
+
+/** Serializable data only — loggable, replayable. */
+export interface InferenceRequest {
+  model: string;
+  system: string;
+  context: AgentMessage[];
+  tools: ToolSpec[];
+}
+
+type DraftPart = TextContent | ThinkingContent | ToolCall;
+
+/**
+ * The fold: consume the provider's event stream, accumulate a draft
+ * AssistantMessage, return it.
+ *
+ * Contract: exactly one message per call; never throws for domain outcomes.
+ * `stopReason` discriminates — provider outcomes come from `done`; `aborted`
+ * (signal fired; partial content preserved) and `error` (provider threw, or
+ * the stream was malformed) are assigned here and only here. The driver
+ * decides what to do with an error message (commit vs. discard-and-retry);
+ * no retry policy lives in the engine.
+ */
 export async function inference(
-  deps: {
-    provider: ModelProvider;
-    onDelta?: (e: ProviderEvent) => void;  // sync fire-and-forget tap
-  },
-  req: {
-    model: string;
-    system: string;
-    context: AgentMessage[];
-    tools: ToolSpec[]
-  },
+  deps: InferenceDeps,
+  req: InferenceRequest,
   signal: AbortSignal,
 ): Promise<AssistantMessage> {
-  throw new Error("not implemented: the fold");
+  const parts: (DraftPart | undefined)[] = [];
+  const argBuffers = new Map<number, string>();
+  let done: { stopReason: AssistantMessage["stopReason"]; usage: Usage } | undefined;
+  let failure: string | undefined;
+
+  const tap = (event: ProviderEvent): void => {
+    if (!deps.onDelta) return;
+    try {
+      deps.onDelta(event);
+    } catch {
+      // Intentionally silent containment, not just "no logging yet": the
+      // engine has no ids to correlate a log line with (by design), and a
+      // throwing tap throws per-event at token frequency. Logging belongs
+      // in the caller's wrapper, which owns the sink, the ids, and the
+      // logger. Decoration never breaks the step.
+    }
+  };
+
+  const partAt = <T extends DraftPart["type"]>(
+    contentIndex: number,
+    type: T,
+  ): Extract<DraftPart, { type: T }> => {
+    const part = parts[contentIndex];
+    if (!part || part.type !== type) {
+      throw new Error(`malformed stream: expected open ${type} part at index ${contentIndex}`);
+    }
+    return part as Extract<DraftPart, { type: T }>;
+  };
+
+  try {
+    for await (const event of deps.provider.stream(req, signal)) {
+      tap(event);
+      switch (event.type) {
+        case "text_start":
+          parts[event.contentIndex] = { type: "text", text: "" };
+          break;
+        case "text_delta":
+          partAt(event.contentIndex, "text").text += event.delta;
+          break;
+        case "text_end":
+          break;
+        case "thinking_start":
+          parts[event.contentIndex] = { type: "thinking", thinking: "" };
+          break;
+        case "thinking_delta":
+          partAt(event.contentIndex, "thinking").thinking += event.delta;
+          break;
+        case "thinking_end": {
+          const part = partAt(event.contentIndex, "thinking");
+          if (event.signature !== undefined) part.thinkingSignature = event.signature;
+          if (event.redacted) {
+            // Redacted blocks carry no visible thinking; the opaque payload
+            // rides in the signature so replay reconstructs redacted_thinking.
+            part.redacted = true;
+            part.thinking = "";
+          }
+          break;
+        }
+        case "toolcall_start":
+          parts[event.contentIndex] = {
+            type: "toolCall",
+            id: event.toolCallId,
+            name: event.toolName,
+            arguments: {},
+          };
+          argBuffers.set(event.contentIndex, "");
+          break;
+        case "toolcall_delta": {
+          partAt(event.contentIndex, "toolCall");
+          const buffer = argBuffers.get(event.contentIndex) ?? "";
+          argBuffers.set(event.contentIndex, buffer + event.argsDelta);
+          break;
+        }
+        case "toolcall_end": {
+          const part = partAt(event.contentIndex, "toolCall");
+          part.arguments = parseArguments(argBuffers.get(event.contentIndex) ?? "");
+          break;
+        }
+        case "done":
+          done = { stopReason: event.stopReason, usage: event.usage };
+          break;
+      }
+    }
+    if (!done) failure = "malformed stream: ended without done";
+  } catch (err) {
+    failure = err instanceof Error ? err.message : String(err);
+  }
+
+  // Sparse slots (an adapter skipped an index) simply drop out of the message.
+  const content = parts.filter((part): part is DraftPart => part !== undefined);
+  const base = { role: "assistant", content, model: req.model } as const;
+
+  // A completed generation stands even if the signal fired during teardown.
+  if (done) return { ...base, stopReason: done.stopReason, usage: done.usage };
+  // An interrupted one is aborted regardless of how the interruption surfaced
+  // (SDK throw, clean stream end) — the partial draft is the message.
+  if (signal.aborted) return { ...base, stopReason: "aborted" };
+  return { ...base, stopReason: "error", errorMessage: failure ?? "unknown provider failure" };
+}
+
+/** Providers stream tool arguments as JSON text; an empty buffer means no arguments. */
+function parseArguments(buffer: string): Record<string, JsonValue> {
+  if (buffer.trim() === "") return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(buffer);
+  } catch {
+    throw new Error("malformed stream: tool-call arguments are not valid JSON");
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("malformed stream: tool-call arguments are not an object");
+  }
+  return parsed as Record<string, JsonValue>;
 }

--- a/packages/agent/test/inference.test.ts
+++ b/packages/agent/test/inference.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import type { ProviderEvent, Usage } from "@funky/core";
+import { createFakeModelProvider, type FakeStep } from "../src/fake-model-provider";
+import { inference, type InferenceRequest } from "../src/inference";
+
+const usage: Usage = { input: 10, output: 5, cacheRead: 0, cacheWrite: 0 };
+const req: InferenceRequest = { model: "test-model", system: "sys", context: [], tools: [] };
+const liveSignal = (): AbortSignal => new AbortController().signal;
+
+const run = (script: FakeStep[], onDelta?: (e: ProviderEvent) => void, signal?: AbortSignal) =>
+  inference({ provider: createFakeModelProvider(script), onDelta }, req, signal ?? liveSignal());
+
+const textScript: FakeStep[] = [
+  { type: "text_start", contentIndex: 0 },
+  { type: "text_delta", contentIndex: 0, delta: "Hello" },
+  { type: "text_delta", contentIndex: 0, delta: " world" },
+  { type: "text_end", contentIndex: 0 },
+  { type: "done", stopReason: "end_turn", usage },
+];
+
+describe("inference", () => {
+  it("folds streamed text into one assistant message", async () => {
+    const message = await run(textScript);
+    expect(message).toEqual({
+      role: "assistant",
+      content: [{ type: "text", text: "Hello world" }],
+      model: "test-model",
+      stopReason: "end_turn",
+      usage,
+    });
+  });
+
+  it("buffers tool-call argument JSON across deltas and parses at toolcall_end", async () => {
+    const message = await run([
+      { type: "toolcall_start", contentIndex: 0, toolCallId: "call_1", toolName: "bash" },
+      { type: "toolcall_delta", contentIndex: 0, argsDelta: '{"comm' },
+      { type: "toolcall_delta", contentIndex: 0, argsDelta: 'and":"ls"}' },
+      { type: "toolcall_end", contentIndex: 0 },
+      { type: "done", stopReason: "tool_use", usage },
+    ]);
+    expect(message.stopReason).toBe("tool_use");
+    expect(message.content).toEqual([
+      { type: "toolCall", id: "call_1", name: "bash", arguments: { command: "ls" } },
+    ]);
+  });
+
+  it("returns the partial draft with stopReason aborted when the signal fires mid-stream", async () => {
+    const controller = new AbortController();
+    const pending = run(
+      [
+        { type: "text_start", contentIndex: 0 },
+        { type: "text_delta", contentIndex: 0, delta: "Hel" },
+        { kind: "untilAborted" },
+      ],
+      undefined,
+      controller.signal,
+    );
+    controller.abort();
+    const message = await pending;
+    expect(message.stopReason).toBe("aborted");
+    expect(message.content).toEqual([{ type: "text", text: "Hel" }]);
+    expect(message.usage).toBeUndefined();
+  });
+
+  it("converts a provider throw into an error message, preserving the partial", async () => {
+    const message = await run([
+      { type: "text_start", contentIndex: 0 },
+      { type: "text_delta", contentIndex: 0, delta: "Hel" },
+      { kind: "throw", error: new Error("overloaded (529)") },
+    ]);
+    expect(message.stopReason).toBe("error");
+    expect(message.errorMessage).toBe("overloaded (529)");
+    expect(message.content).toEqual([{ type: "text", text: "Hel" }]);
+  });
+
+  it("treats a stream that ends without done as an error", async () => {
+    const message = await run([
+      { type: "text_start", contentIndex: 0 },
+      { type: "text_end", contentIndex: 0 },
+    ]);
+    expect(message.stopReason).toBe("error");
+    expect(message.errorMessage).toContain("ended without done");
+  });
+
+  it("treats unparseable tool-call arguments as an error", async () => {
+    const message = await run([
+      { type: "toolcall_start", contentIndex: 0, toolCallId: "call_1", toolName: "bash" },
+      { type: "toolcall_delta", contentIndex: 0, argsDelta: '{"command": tru' },
+      { type: "toolcall_end", contentIndex: 0 },
+    ]);
+    expect(message.stopReason).toBe("error");
+    expect(message.errorMessage).toContain("not valid JSON");
+  });
+
+  it("folds a redacted thinking block into an empty part carrying the opaque payload", async () => {
+    const message = await run([
+      { type: "thinking_start", contentIndex: 0 },
+      { type: "thinking_end", contentIndex: 0, signature: "opaque-payload", redacted: true },
+      { type: "text_start", contentIndex: 1 },
+      { type: "text_delta", contentIndex: 1, delta: "ok" },
+      { type: "text_end", contentIndex: 1 },
+      { type: "done", stopReason: "end_turn", usage },
+    ]);
+    expect(message.content).toEqual([
+      { type: "thinking", thinking: "", thinkingSignature: "opaque-payload", redacted: true },
+      { type: "text", text: "ok" },
+    ]);
+  });
+
+  it("taps every provider event, in order", async () => {
+    const seen: string[] = [];
+    await run(textScript, (e) => seen.push(e.type));
+    expect(seen).toEqual(["text_start", "text_delta", "text_delta", "text_end", "done"]);
+  });
+
+  it("is unaffected by a throwing tap", async () => {
+    const message = await run(textScript, () => {
+      throw new Error("broken renderer");
+    });
+    expect(message.stopReason).toBe("end_turn");
+    expect(message.content).toEqual([{ type: "text", text: "Hello world" }]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,10 @@ importers:
       '@funky/core':
         specifier: workspace:*
         version: link:../core
+    devDependencies:
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   packages/configs:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,10 @@
       "noUncheckedIndexedAccess": true,
       "types": ["node"]
     },
-    "include": ["apps/**/src/**/*.ts", "packages/**/src/**/*.ts", "packages/db/schema/**/*.ts"]
+    "include": [
+      "apps/**/src/**/*.ts",
+      "packages/**/src/**/*.ts",
+      "packages/**/test/**/*.ts",
+      "packages/db/schema/**/*.ts"
+    ]
 }


### PR DESCRIPTION
Fills in `inference()`, the fold that turns a provider's `ProviderEvent` stream into exactly one `AssistantMessage`.

## What it does

- **One message per call, never throws for domain outcomes.** Provider outcomes come from `done`; `aborted` (signal fired, partial content preserved) and `error` (provider threw, or the stream was malformed) are assigned in the fold and nowhere else. The driver decides commit vs. discard-and-retry — no retry policy lives in the engine.
- **Tool-call arguments** buffer as partial JSON across deltas and parse at `toolcall_end`; unparseable or non-object arguments surface as an `error`-stopped message rather than an exception.
- **Redacted thinking** folds into an empty part carrying the opaque payload in `thinkingSignature`, so replay can reconstruct a `redacted_thinking` block.
- **The `onDelta` tap is contained** — a throwing tap never breaks the step.

## Tests

Adds `createFakeModelProvider`, a scripted test double that yields plain events, throws, or parks until the caller aborts. Nine tests cover the text fold, tool-call buffering, mid-stream cancellation, provider failure, a stream that ends without `done`, malformed tool arguments, redacted thinking, tap ordering, and tap containment.

The root tsconfig `include` gains `packages/**/test/**` so the new suite is typechecked (mirroring the existing `apps/*/test/` layout).

## Stacked

A follow-up PR — Adopt Prettier and format the repo — is stacked on top of this branch. It needs no changes to `packages/agent`; these files are already Prettier-clean.

## Verification

`pnpm typecheck` and the full unit suite pass (414 passed, 3 skipped across all packages). The chaos suite needs Docker and was not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)