### PR TITLE
Add agent next-action policy

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -7,5 +7,7 @@ export type {
   ToolExecutionMode,
   ToolUpdate,
 } from "./execute-tools";
+export { nextAction } from "./next-action";
+export type { Action, RunEndStatus, RunState } from "./next-action";
 export type { Tool, ToolContext, ToolOutcome } from "./tool";
 export type { ModelProvider, StreamRequest } from "./model-provider";

--- a/packages/agent/src/next-action.ts
+++ b/packages/agent/src/next-action.ts
@@ -1,0 +1,70 @@
+import type { AgentMessage, ToolCall } from "@funky/core";
+
+export interface RunState {
+  /** Set by Store.requestCancel; checked here, at every boundary. */
+  cancelRequested: boolean;
+}
+
+export type RunEndStatus = "completed" | "max_tokens" | "cancelled";
+
+export type Action =
+  | { kind: "inference" }
+  | { kind: "execute_tools"; calls: ToolCall[] }
+  | { kind: "end_run"; status: RunEndStatus }
+  /** Provider failure. Carries nothing: the message is on the AssistantMessage,
+   *  and retry-vs-commit is the driver's call — policy is memoryless. */
+  | { kind: "error" };
+
+/**
+ * The policy: given the last message a step committed, decide what the run
+ * does next. The role already names the step that produced it — inference
+ * commits an assistant message, execute_tools commits tool results, intake
+ * commits the user message that starts a run — so the policy dispatches on
+ * the message union itself; there is no separate "step result" vocabulary.
+ *
+ * Pure and memoryless. The caller invokes it at commit time and persists the
+ * consequence — the next item, or the run's terminal status — in the same
+ * transaction as the step's output, so statuses change through one write
+ * path and a crash can never lose the decision. Decision order:
+ *
+ *   1. cancelRequested ends the run "cancelled", whatever the step produced.
+ *   2. User messages and tool results feed into inference — error results
+ *      too; recovery is the model's job.
+ *   3. An assistant message dispatches on failure first (error → driver
+ *      decides retry vs commit; aborted → cancelled; max_tokens → truncated),
+ *      then on the presence of tool calls rather than stopReason: a committed
+ *      toolCall with no result is a malformed context for every later request.
+ *
+ * There is deliberately no turn cap. The runaway breaker will be a token
+ * budget accumulated from persisted usage — guarding the inference branch
+ * here — once the ledger lands; turn counts are a poor proxy for spend.
+ *
+ * Not here by design: pending-input drain. Steering shapes the next context
+ * (buildContext) and follow-ups chain new runs (intake); neither changes
+ * which item comes next.
+ */
+export function nextAction(message: AgentMessage, run: RunState): Action {
+  if (run.cancelRequested) return { kind: "end_run", status: "cancelled" };
+
+  switch (message.role) {
+    case "user":
+    case "toolResult":
+      return { kind: "inference" };
+    case "assistant":
+      switch (message.stopReason) {
+        case "error":
+          return { kind: "error" };
+        case "aborted":
+          return { kind: "end_run", status: "cancelled" };
+        case "max_tokens":
+          // Truncated output — any tool calls in it are suspect, never executed.
+          return { kind: "end_run", status: "max_tokens" };
+        case "end_turn":
+        case "tool_use": {
+          const calls = message.content.filter((part) => part.type === "toolCall");
+          if (calls.length > 0) return { kind: "execute_tools", calls };
+          return { kind: "end_run", status: "completed" };
+        }
+      }
+  }
+}

--- a/packages/agent/test/next-action.test.ts
+++ b/packages/agent/test/next-action.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AssistantMessage,
+  StopReason,
+  ToolCall,
+  ToolResultMessage,
+  UserMessage,
+} from "@funky/core";
+import { nextAction } from "../src/next-action";
+
+const user = (): UserMessage => ({
+  role: "user",
+  content: [{ type: "text", text: "hi" }],
+});
+
+const assistant = (
+  stopReason: StopReason,
+  content: AssistantMessage["content"] = [],
+): AssistantMessage => ({
+  role: "assistant",
+  content,
+  model: "test-model",
+  stopReason,
+});
+
+const toolCall = (id: string): ToolCall => ({
+  type: "toolCall",
+  id,
+  name: "echo",
+  arguments: {},
+});
+
+const toolResult = (isError = false): ToolResultMessage => ({
+  role: "toolResult",
+  toolCallId: "c1",
+  toolName: "echo",
+  content: [{ type: "text", text: "ok" }],
+  isError,
+});
+
+const live = { cancelRequested: false };
+const cancelled = { cancelRequested: true };
+
+describe("nextAction", () => {
+  describe("after a user message", () => {
+    it("starts the run with inference", () => {
+      expect(nextAction(user(), live)).toEqual({ kind: "inference" });
+    });
+  });
+
+  describe("after inference", () => {
+    it("ends the run completed on end_turn without tool calls", () => {
+      const action = nextAction(assistant("end_turn", [{ type: "text", text: "hi" }]), live);
+      expect(action).toEqual({ kind: "end_run", status: "completed" });
+    });
+
+    it("schedules tool execution with the message's calls, in order", () => {
+      const calls = [toolCall("c1"), toolCall("c2")];
+      expect(nextAction(assistant("tool_use", calls), live)).toEqual({
+        kind: "execute_tools",
+        calls,
+      });
+    });
+
+    it("executes on tool calls even when stopReason says end_turn", () => {
+      expect(nextAction(assistant("end_turn", [toolCall("c1")]), live)).toEqual({
+        kind: "execute_tools",
+        calls: [toolCall("c1")],
+      });
+    });
+
+    it("ends the run completed on tool_use with no calls in the content", () => {
+      expect(nextAction(assistant("tool_use"), live)).toEqual({
+        kind: "end_run",
+        status: "completed",
+      });
+    });
+
+    it("ends the run on max_tokens without executing the truncated calls", () => {
+      expect(nextAction(assistant("max_tokens", [toolCall("c1")]), live)).toEqual({
+        kind: "end_run",
+        status: "max_tokens",
+      });
+    });
+
+    it("ends the run cancelled on an aborted message", () => {
+      expect(nextAction(assistant("aborted"), live)).toEqual({
+        kind: "end_run",
+        status: "cancelled",
+      });
+    });
+
+    it("surfaces a provider error for the driver to decide", () => {
+      expect(nextAction(assistant("error"), live)).toEqual({ kind: "error" });
+    });
+  });
+
+  describe("after tool execution", () => {
+    it("feeds tool results back into inference", () => {
+      expect(nextAction(toolResult(), live)).toEqual({ kind: "inference" });
+    });
+
+    it("feeds error results back into inference too", () => {
+      expect(nextAction(toolResult(true), live)).toEqual({ kind: "inference" });
+    });
+  });
+
+  describe("cancel overlay", () => {
+    it("outranks pending tool calls", () => {
+      expect(nextAction(assistant("tool_use", [toolCall("c1")]), cancelled)).toEqual({
+        kind: "end_run",
+        status: "cancelled",
+      });
+    });
+
+    it("outranks the tool-results-to-inference row", () => {
+      expect(nextAction(toolResult(), cancelled)).toEqual({
+        kind: "end_run",
+        status: "cancelled",
+      });
+    });
+
+    it("outranks a run start — cancel can race intake", () => {
+      expect(nextAction(user(), cancelled)).toEqual({ kind: "end_run", status: "cancelled" });
+    });
+
+    it("outranks a provider error — a cancelled run is never retried", () => {
+      expect(nextAction(assistant("error"), cancelled)).toEqual({
+        kind: "end_run",
+        status: "cancelled",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a pure next-action policy that maps committed agent messages and cancellation state to inference, tool execution, terminal statuses, or provider-error handling. Exports the policy and its action/run types from `@funky/agent`. Adds transition tests covering normal completion, tool calls, truncation, provider errors, aborted runs, tool results, and cancellation precedence.

## Validation

- `pnpm format:check`
- `pnpm typecheck`
- `pnpm --filter @funky/agent test`