### PR TITLE
Add session entry schemas to core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,14 @@
   "exports": {
     ".": "./src/index.ts"
   },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
   "dependencies": {
     "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/core/src/entries.ts
+++ b/packages/core/src/entries.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import { AgentMessage, JsonValue } from "./messages";
+
+/**
+ * The session log's row type — the envelope around the payloads.
+ *
+ * Messages are what the model sees; entries are what the store owns. The
+ * store mints the envelope (id, seq, timestamp) inside its transaction —
+ * callers hand it payloads, never entries. sessionId is not repeated per
+ * row: every read and every wire stream is already session-scoped.
+ *
+ * Evolution rules match messages.ts: this is persistence format. Adding an
+ * entry type is backward compatible (old sessions parse fine); removing or
+ * renaming one is a migration. App extensibility lives in `custom` entries
+ * — the message union stays closed.
+ */
+
+const EntryBase = {
+  id: z.string(),
+  // Per-session ordering; assigned by the store, gapless within a session.
+  seq: z.number().int().nonnegative(),
+  // Attribution, not ownership: entries belong to the session; null for
+  // entries written outside any run.
+  runId: z.string().nullable(),
+  timestamp: z.iso.datetime(),
+};
+
+export const MessageEntry = z.object({
+  ...EntryBase,
+  type: z.literal("message"),
+  message: AgentMessage,
+});
+export type MessageEntry = z.infer<typeof MessageEntry>;
+
+// App-defined payload riding in the log; invisible to the model. UIs and
+// services filter by namespace; buildContext skips these entirely.
+export const CustomEntry = z.object({
+  ...EntryBase,
+  type: z.literal("custom"),
+  namespace: z.string(),
+  data: JsonValue,
+});
+export type CustomEntry = z.infer<typeof CustomEntry>;
+
+// Reserved: schema now, semantics later. Will mark entries with
+// seq <= upToSeq as superseded, with `summary` rendered into context as
+// user-role text. buildContext treats it as a no-op until then.
+export const CompactionEntry = z.object({
+  ...EntryBase,
+  type: z.literal("compaction"),
+  summary: z.string(),
+  upToSeq: z.number().int().nonnegative(),
+});
+export type CompactionEntry = z.infer<typeof CompactionEntry>;
+
+export const SessionEntry = z.discriminatedUnion("type", [
+  MessageEntry,
+  CustomEntry,
+  CompactionEntry,
+]);
+export type SessionEntry = z.infer<typeof SessionEntry>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./entries";
 export * from "./messages";
 export * from "./provider-events";
 export * from "./tools";

--- a/packages/core/test/entries.test.ts
+++ b/packages/core/test/entries.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { SessionEntry } from "../src/entries";
+
+const envelope = {
+  id: "e1",
+  seq: 0,
+  runId: "r1",
+  timestamp: "2026-08-10T12:00:00Z",
+};
+
+describe("SessionEntry", () => {
+  it("round-trips a message entry wrapping an assistant message with a tool call", () => {
+    const entry = {
+      ...envelope,
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "checking" },
+          { type: "toolCall", id: "c1", name: "read", arguments: { path: "a.ts" } },
+        ],
+        model: "claude-sonnet-5",
+        stopReason: "tool_use",
+        usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0 },
+      },
+    };
+    expect(SessionEntry.parse(JSON.parse(JSON.stringify(entry)))).toEqual(entry);
+  });
+
+  it("round-trips a custom entry with a nested payload", () => {
+    const entry = {
+      ...envelope,
+      type: "custom",
+      namespace: "review",
+      data: { verdict: "approved", scores: [1, 2, 3], nested: { deep: null } },
+    };
+    expect(SessionEntry.parse(JSON.parse(JSON.stringify(entry)))).toEqual(entry);
+  });
+
+  it("round-trips a compaction entry", () => {
+    const entry = { ...envelope, type: "compaction", summary: "earlier work…", upToSeq: 41 };
+    expect(SessionEntry.parse(JSON.parse(JSON.stringify(entry)))).toEqual(entry);
+  });
+
+  it("accepts a null runId — entries written outside any run", () => {
+    const entry = {
+      ...envelope,
+      runId: null,
+      type: "custom",
+      namespace: "billing",
+      data: {},
+    };
+    expect(SessionEntry.parse(entry).runId).toBeNull();
+  });
+
+  it("rejects an unknown entry type", () => {
+    const result = SessionEntry.safeParse({ ...envelope, type: "model_change", model: "x" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a message entry whose payload is not a known message role", () => {
+    const result = SessionEntry.safeParse({
+      ...envelope,
+      type: "message",
+      message: { role: "system", content: [] },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a missing envelope field", () => {
+    const { seq: _seq, ...withoutSeq } = envelope;
+    const result = SessionEntry.safeParse({
+      ...withoutSeq,
+      type: "compaction",
+      summary: "s",
+      upToSeq: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a non-ISO timestamp", () => {
+    const result = SessionEntry.safeParse({
+      ...envelope,
+      timestamp: "yesterday",
+      type: "custom",
+      namespace: "n",
+      data: {},
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,10 @@ importers:
       zod:
         specifier: ^4.0.0
         version: 4.4.3
+    devDependencies:
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   packages/db:
     dependencies:


### PR DESCRIPTION
Adds persistent session entry schemas for messages, custom app data, and reserved compaction records, with a shared validated envelope for ordering, run attribution, and timestamps. Exports the schemas from the core package and adds its Vitest scripts and dependency. Tests cover valid round trips, nullable run attribution, unknown entry types, malformed messages, missing envelope fields, and invalid timestamps. Validation: `pnpm test`, `pnpm typecheck`, and Prettier checks pass.