### PR TITLE
Build model context from session entries

### DIFF
--- a/packages/agent/src/build-context.ts
+++ b/packages/agent/src/build-context.ts
@@ -1,0 +1,78 @@
+import type { AgentMessage, SessionEntry, ToolCall, UserMessage } from "@funky/core";
+import { interruptedResult } from "./execute-tools";
+
+/**
+ * Fold the session log into the model context. Pure: the driver reads the
+ * entries and drains pending inputs; this function only decides what the
+ * transcript looks like.
+ *
+ * The log and the context deliberately diverge — the log keeps everything,
+ * the context keeps what the model may see:
+ * - custom entries are app payload, skipped; compaction is reserved and a
+ *   no-op until its semantics land (then: drop seq <= upToSeq, inject the
+ *   summary as user-role text)
+ *   TODO(compaction): upToSeq must land on a call/result group boundary —
+ *   a cut between an assistant message and its results would orphan the
+ *   results and this fold would silently drop them from context. This is
+ *   a constraint on the future compactor; nothing enforces it yet.
+ *   TODO(compaction): with multiple compaction entries (recompaction),
+ *   the highest upToSeq governs; earlier ones are themselves superseded.
+ * - assistant messages with stopReason aborted/error stay in the log but
+ *   are dropped here
+ * - tool calls and results must pair up, repaired in both directions: a
+ *   kept assistant message whose calls have no committed results gets
+ *   synthesized interrupted results (the cancel-before-execute path), and
+ *   a result whose parent assistant message was dropped is dropped with it
+ *   — dangling calls and orphaned results are equally malformed
+ *
+ * steeringMessages append at the tail: they are steering by construction
+ * (the driver drains only at inference prep; follow-ups become ordinary
+ * user entries when the terminal commit chains a new run).
+ *
+ * Provider API shape (role alternation, results as user-role blocks) is
+ * the adapter's translation, not context semantics.
+ */
+export function buildContext(
+  entries: SessionEntry[],
+  steeringMessages: UserMessage[] = [],
+): AgentMessage[] {
+  const context: AgentMessage[] = [];
+  // Calls from the most recent kept assistant message still awaiting results.
+  let openCalls = new Map<string, ToolCall>();
+
+  const closeOpenCalls = () => {
+    for (const call of openCalls.values()) context.push(interruptedResult(call));
+    openCalls = new Map();
+  };
+
+  for (const entry of [...entries].sort((a, b) => a.seq - b.seq)) {
+    if (entry.type !== "message") continue;
+    const message = entry.message;
+    // Results are only valid immediately after their assistant message, so
+    // any other message arriving is proof the still-open calls will never
+    // be answered — and the last valid position to synthesize their results.
+    if (message.role !== "toolResult") closeOpenCalls();
+    switch (message.role) {
+      case "user":
+        context.push(message);
+        break;
+      case "assistant": {
+        if (message.stopReason === "aborted" || message.stopReason === "error") break;
+        context.push(message);
+        for (const part of message.content) {
+          if (part.type === "toolCall") openCalls.set(part.id, part);
+        }
+        break;
+      }
+      case "toolResult":
+        // No matching open call means the parent assistant message was
+        // dropped (or the result is a duplicate) — drop the result too.
+        if (openCalls.delete(message.toolCallId)) context.push(message);
+        break;
+    }
+  }
+  closeOpenCalls();
+
+  context.push(...steeringMessages);
+  return context;
+}

--- a/packages/agent/src/execute-tools.ts
+++ b/packages/agent/src/execute-tools.ts
@@ -107,6 +107,8 @@ function errorResult(call: ToolCall, message: string): ToolResultMessage {
   };
 }
 
-function interruptedResult(call: ToolCall): ToolResultMessage {
+/** Also used by buildContext to close dangling calls — one definition of the
+ *  interruption text, so the model sees the same signal either way. */
+export function interruptedResult(call: ToolCall): ToolResultMessage {
   return errorResult(call, "Tool execution was interrupted.");
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,3 +1,4 @@
+export { buildContext } from "./build-context";
 export { inference } from "./inference";
 export type { InferenceDeps, InferenceRequest } from "./inference";
 export { executeTools } from "./execute-tools";

--- a/packages/agent/test/build-context.test.ts
+++ b/packages/agent/test/build-context.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AgentMessage,
+  AssistantMessage,
+  SessionEntry,
+  StopReason,
+  ToolResultMessage,
+  UserMessage,
+} from "@funky/core";
+import { buildContext } from "../src/build-context";
+
+const user = (text: string): UserMessage => ({
+  role: "user",
+  content: [{ type: "text", text }],
+});
+
+const assistant = (
+  stopReason: StopReason,
+  content: AssistantMessage["content"] = [{ type: "text", text: "ok" }],
+): AssistantMessage => ({
+  role: "assistant",
+  content,
+  model: "test-model",
+  stopReason,
+});
+
+const toolCall = (id: string) => ({
+  type: "toolCall" as const,
+  id,
+  name: "echo",
+  arguments: {},
+});
+
+const toolResult = (toolCallId: string): ToolResultMessage => ({
+  role: "toolResult",
+  toolCallId,
+  toolName: "echo",
+  content: [{ type: "text", text: "done" }],
+  isError: false,
+});
+
+const interrupted = (toolCallId: string): ToolResultMessage => ({
+  role: "toolResult",
+  toolCallId,
+  toolName: "echo",
+  content: [{ type: "text", text: "Tool execution was interrupted." }],
+  isError: true,
+});
+
+const entry = (seq: number, message: AgentMessage): SessionEntry => ({
+  id: `e${seq}`,
+  seq,
+  runId: "r1",
+  timestamp: "2026-08-10T12:00:00Z",
+  type: "message",
+  message,
+});
+
+describe("buildContext", () => {
+  it("folds message entries in seq order", () => {
+    const a = assistant("end_turn");
+    expect(buildContext([entry(0, user("hi")), entry(1, a)])).toEqual([user("hi"), a]);
+  });
+
+  it("sorts by seq, not array order", () => {
+    const a = assistant("end_turn");
+    expect(buildContext([entry(1, a), entry(0, user("hi"))])).toEqual([user("hi"), a]);
+  });
+
+  it("keeps a complete tool round-trip intact", () => {
+    const asking = assistant("tool_use", [toolCall("c1")]);
+    const done = assistant("end_turn");
+    const context = buildContext([
+      entry(0, user("go")),
+      entry(1, asking),
+      entry(2, toolResult("c1")),
+      entry(3, done),
+    ]);
+    expect(context).toEqual([user("go"), asking, toolResult("c1"), done]);
+  });
+
+  it("skips custom entries", () => {
+    const custom: SessionEntry = {
+      id: "e1",
+      seq: 1,
+      runId: null,
+      timestamp: "2026-08-10T12:00:00Z",
+      type: "custom",
+      namespace: "billing",
+      data: { plan: "pro" },
+    };
+    expect(buildContext([entry(0, user("hi")), custom])).toEqual([user("hi")]);
+  });
+
+  it("treats compaction entries as a no-op for now", () => {
+    const compaction: SessionEntry = {
+      id: "e1",
+      seq: 1,
+      runId: null,
+      timestamp: "2026-08-10T12:00:00Z",
+      type: "compaction",
+      summary: "earlier work…",
+      upToSeq: 0,
+    };
+    expect(buildContext([entry(0, user("hi")), compaction])).toEqual([user("hi")]);
+  });
+
+  it("drops aborted and error assistant messages from context", () => {
+    const good = assistant("end_turn");
+    const context = buildContext([
+      entry(0, user("hi")),
+      entry(1, assistant("aborted")),
+      entry(2, user("again")),
+      entry(3, assistant("error")),
+      entry(4, user("once more")),
+      entry(5, good),
+    ]);
+    expect(context).toEqual([user("hi"), user("again"), user("once more"), good]);
+  });
+
+  it("drops results orphaned by a dropped assistant message", () => {
+    const context = buildContext([
+      entry(0, user("hi")),
+      entry(1, assistant("aborted", [toolCall("c1")])),
+      entry(2, toolResult("c1")),
+    ]);
+    expect(context).toEqual([user("hi")]);
+  });
+
+  it("synthesizes interrupted results for calls with no committed results", () => {
+    const asking = assistant("tool_use", [toolCall("c1"), toolCall("c2")]);
+    const context = buildContext([entry(0, user("go")), entry(1, asking)]);
+    expect(context).toEqual([user("go"), asking, interrupted("c1"), interrupted("c2")]);
+  });
+
+  it("synthesizes only the missing results, after the committed ones", () => {
+    const asking = assistant("tool_use", [toolCall("c1"), toolCall("c2")]);
+    const context = buildContext([entry(0, asking), entry(1, toolResult("c1"))]);
+    expect(context).toEqual([asking, toolResult("c1"), interrupted("c2")]);
+  });
+
+  it("closes dangling calls before the next message, not at the end", () => {
+    const asking = assistant("tool_use", [toolCall("c1")]);
+    const followUp = user("follow-up");
+    const answer = assistant("end_turn");
+    const context = buildContext([entry(0, asking), entry(1, followUp), entry(2, answer)]);
+    expect(context).toEqual([asking, interrupted("c1"), followUp, answer]);
+  });
+
+  it("appends steering messages at the tail, in order", () => {
+    const a = assistant("end_turn");
+    const context = buildContext(
+      [entry(0, user("hi")), entry(1, a)],
+      [user("steer one"), user("steer two")],
+    );
+    expect(context).toEqual([user("hi"), a, user("steer one"), user("steer two")]);
+  });
+
+  it("closes dangling calls before appending steering messages", () => {
+    const asking = assistant("tool_use", [toolCall("c1")]);
+    const context = buildContext([entry(0, asking)], [user("steer")]);
+    expect(context).toEqual([asking, interrupted("c1"), user("steer")]);
+  });
+
+  it("builds from steering alone when the log is empty", () => {
+    expect(buildContext([], [user("first")])).toEqual([user("first")]);
+  });
+
+  it("returns an empty context for an empty log", () => {
+    expect(buildContext([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Fold ordered session entries into model context while filtering non-model and failed assistant entries.
- Repair dangling tool calls and orphaned results, then append pending steering messages.
- Export the context builder and cover ordering, filtering, repair, and steering behavior with tests.

## Testing

- `pnpm test`
- `pnpm typecheck`
- `pnpm format:check`
- `git diff --check`