### PR TITLE
Define durable agent store contracts

### DIFF
--- a/packages/agent/src/build-context.ts
+++ b/packages/agent/src/build-context.ts
@@ -8,9 +8,9 @@ import { interruptedResult } from "./execute-tools";
  *
  * The log and the context deliberately diverge — the log keeps everything,
  * the context keeps what the model may see:
- * - custom entries are app payload, skipped; compaction is reserved and a
- *   no-op until its semantics land (then: drop seq <= upToSeq, inject the
- *   summary as user-role text)
+ * - custom entries (app payload) and control entries (harness signals)
+ *   are skipped; compaction is reserved and a no-op until its semantics
+ *   land (then: drop seq <= upToSeq, inject the summary as user-role text)
  *   TODO(compaction): upToSeq must land on a call/result group boundary —
  *   a cut between an assistant message and its results would orphan the
  *   results and this fold would silently drop them from context. This is

--- a/packages/agent/src/fake-inference-provider.ts
+++ b/packages/agent/src/fake-inference-provider.ts
@@ -1,8 +1,8 @@
 import type { ProviderEvent } from "@funky/core";
-import type { ModelProvider, StreamRequest } from "./model-provider";
+import type { InferenceProvider, StreamRequest } from "./inference-provider";
 
 /**
- * A scripted ModelProvider for tests: yields the given steps in order.
+ * A scripted InferenceProvider for tests: yields the given steps in order.
  * Beyond plain events, a step can throw (provider/network failure) or park
  * until the caller aborts (for testing mid-stream cancellation, mimicking an
  * SDK that raises AbortError when the signal fires).
@@ -11,11 +11,11 @@ import type { ModelProvider, StreamRequest } from "./model-provider";
  */
 export type FakeStep = ProviderEvent | { kind: "throw"; error: Error } | { kind: "untilAborted" };
 
-export interface FakeModelProvider extends ModelProvider {
+export interface FakeInferenceProvider extends InferenceProvider {
   requests: StreamRequest[];
 }
 
-export function createFakeModelProvider(script: FakeStep[]): FakeModelProvider {
+export function createFakeInferenceProvider(script: FakeStep[]): FakeInferenceProvider {
   const requests: StreamRequest[] = [];
   return {
     requests,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -9,6 +9,6 @@ export type {
   ToolUpdate,
 } from "./execute-tools";
 export { nextAction } from "./next-action";
-export type { Action, RunEndStatus, RunState } from "./next-action";
+export type { Action, RunEndStatus } from "./next-action";
 export type { Tool, ToolContext, ToolOutcome } from "./tool";
-export type { ModelProvider, StreamRequest } from "./model-provider";
+export type { InferenceProvider, StreamRequest } from "./inference-provider";

--- a/packages/agent/src/inference-provider.ts
+++ b/packages/agent/src/inference-provider.ts
@@ -16,7 +16,7 @@ import type { AgentMessage, ProviderEvent, ToolSpec } from "@funky/core";
  *   exceptions into `aborted`/`error`-stopped messages.
  * - Each `stream()` call is stateless and independent.
  */
-export interface ModelProvider {
+export interface InferenceProvider {
   stream(req: StreamRequest, signal: AbortSignal): AsyncIterable<ProviderEvent>;
 }
 

--- a/packages/agent/src/inference.ts
+++ b/packages/agent/src/inference.ts
@@ -9,10 +9,10 @@ import type {
   ToolSpec,
   Usage,
 } from "@funky/core";
-import type { ModelProvider } from "./model-provider";
+import type { InferenceProvider } from "./inference-provider";
 
 export interface InferenceDeps {
-  provider: ModelProvider;
+  provider: InferenceProvider;
   /** Sync fire-and-forget tap. Failures are swallowed: decoration never breaks the step. */
   onDelta?: (e: ProviderEvent) => void;
 }

--- a/packages/agent/src/next-action.ts
+++ b/packages/agent/src/next-action.ts
@@ -1,10 +1,5 @@
 import type { AgentMessage, ToolCall } from "@funky/core";
 
-export interface RunState {
-  /** Set by Store.requestCancel; checked here, at every boundary. */
-  cancelRequested: boolean;
-}
-
 export type RunEndStatus = "completed" | "max_tokens" | "cancelled";
 
 export type Action =
@@ -23,11 +18,13 @@ export type Action =
  * the message union itself; there is no separate "step result" vocabulary.
  *
  * Pure and memoryless. The caller invokes it at commit time and persists the
- * consequence — the next item, or the run's terminal status — in the same
- * transaction as the step's output, so statuses change through one write
- * path and a crash can never lose the decision. Decision order:
+ * consequence — the next item, or the run's end as the atomic NON-creation
+ * of one — in the same transaction as the step's output, so a crash can
+ * never separate a message from the decision it caused. Decision order:
  *
- *   1. cancelRequested ends the run "cancelled", whatever the step produced.
+ *   1. cancelRequested — true when a cancel control entry addresses the
+ *      current run; the driver computes it from the log at each boundary —
+ *      ends the run "cancelled", whatever the step produced.
  *   2. User messages and tool results feed into inference — error results
  *      too; recovery is the model's job.
  *   3. An assistant message dispatches on failure first (error → driver
@@ -43,8 +40,8 @@ export type Action =
  * (buildContext) and follow-ups chain new runs (intake); neither changes
  * which item comes next.
  */
-export function nextAction(message: AgentMessage, run: RunState): Action {
-  if (run.cancelRequested) return { kind: "end_run", status: "cancelled" };
+export function nextAction(message: AgentMessage, cancelRequested: boolean): Action {
+  if (cancelRequested) return { kind: "end_run", status: "cancelled" };
 
   switch (message.role) {
     case "user":

--- a/packages/agent/test/build-context.test.ts
+++ b/packages/agent/test/build-context.test.ts
@@ -50,7 +50,6 @@ const interrupted = (toolCallId: string): ToolResultMessage => ({
 const entry = (seq: number, message: AgentMessage): SessionEntry => ({
   id: `e${seq}`,
   seq,
-  runId: "r1",
   timestamp: "2026-08-10T12:00:00Z",
   type: "message",
   message,
@@ -83,7 +82,6 @@ describe("buildContext", () => {
     const custom: SessionEntry = {
       id: "e1",
       seq: 1,
-      runId: null,
       timestamp: "2026-08-10T12:00:00Z",
       type: "custom",
       namespace: "billing",
@@ -92,11 +90,21 @@ describe("buildContext", () => {
     expect(buildContext([entry(0, user("hi")), custom])).toEqual([user("hi")]);
   });
 
+  it("skips control entries — cancel never reaches the model", () => {
+    const control: SessionEntry = {
+      id: "e1",
+      seq: 1,
+      timestamp: "2026-08-10T12:00:00Z",
+      type: "control",
+      control: "cancel",
+    };
+    expect(buildContext([entry(0, user("hi")), control])).toEqual([user("hi")]);
+  });
+
   it("treats compaction entries as a no-op for now", () => {
     const compaction: SessionEntry = {
       id: "e1",
       seq: 1,
-      runId: null,
       timestamp: "2026-08-10T12:00:00Z",
       type: "compaction",
       summary: "earlier work…",

--- a/packages/agent/test/inference.test.ts
+++ b/packages/agent/test/inference.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ProviderEvent, Usage } from "@funky/core";
-import { createFakeModelProvider, type FakeStep } from "../src/fake-model-provider";
+import { createFakeInferenceProvider, type FakeStep } from "../src/fake-inference-provider";
 import { inference, type InferenceRequest } from "../src/inference";
 
 const usage: Usage = { input: 10, output: 5, cacheRead: 0, cacheWrite: 0 };
@@ -8,7 +8,11 @@ const req: InferenceRequest = { model: "test-model", system: "sys", context: [],
 const liveSignal = (): AbortSignal => new AbortController().signal;
 
 const run = (script: FakeStep[], onDelta?: (e: ProviderEvent) => void, signal?: AbortSignal) =>
-  inference({ provider: createFakeModelProvider(script), onDelta }, req, signal ?? liveSignal());
+  inference(
+    { provider: createFakeInferenceProvider(script), onDelta },
+    req,
+    signal ?? liveSignal(),
+  );
 
 const textScript: FakeStep[] = [
   { type: "text_start", contentIndex: 0 },

--- a/packages/agent/test/next-action.test.ts
+++ b/packages/agent/test/next-action.test.ts
@@ -38,8 +38,8 @@ const toolResult = (isError = false): ToolResultMessage => ({
   isError,
 });
 
-const live = { cancelRequested: false };
-const cancelled = { cancelRequested: true };
+const live = false;
+const cancelled = true;
 
 describe("nextAction", () => {
   describe("after a user message", () => {

--- a/packages/core/src/entries.ts
+++ b/packages/core/src/entries.ts
@@ -19,9 +19,6 @@ const EntryBase = {
   id: z.string(),
   // Per-session ordering; assigned by the store, gapless within a session.
   seq: z.number().int().nonnegative(),
-  // Attribution, not ownership: entries belong to the session; null for
-  // entries written outside any run.
-  runId: z.string().nullable(),
   timestamp: z.iso.datetime(),
 };
 
@@ -53,9 +50,23 @@ export const CompactionEntry = z.object({
 });
 export type CompactionEntry = z.infer<typeof CompactionEntry>;
 
+// The harness control plane riding in the log. requestCancel appends one;
+// workers check for it behind the tail at boundaries. Seq order scopes it
+// precisely: a cancel landing before the run's terminal message addresses
+// that run; landing after it, the cancel addresses a run that no longer
+// exists and is ignored — the log's total order, not flag timing, decides.
+// Never model context: buildContext skips it.
+export const ControlEntry = z.object({
+  ...EntryBase,
+  type: z.literal("control"),
+  control: z.literal("cancel"),
+});
+export type ControlEntry = z.infer<typeof ControlEntry>;
+
 export const SessionEntry = z.discriminatedUnion("type", [
   MessageEntry,
   CustomEntry,
   CompactionEntry,
+  ControlEntry,
 ]);
 export type SessionEntry = z.infer<typeof SessionEntry>;

--- a/packages/core/src/environment.ts
+++ b/packages/core/src/environment.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+/**
+ * The environment vocabulary — the declarative description of the world a
+ * session runs in. Described here, instantiated elsewhere: the
+ * SandboxProvider port (deferred) turns descriptions into running
+ * sandboxes, and its adapters are the interpreters. Only converged intent
+ * belongs in this file, and it arrives one promoted field at a time —
+ * there is deliberately no opaque options bag: a capability enters the
+ * recipe together with the adapter contract that interprets it.
+ */
+
+// Intent, not mechanism: adapters translate to whatever their provider
+// enforces and MUST reject create() when they cannot enforce it — never
+// silently run more open than asked.
+export const NetworkPolicy = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("unrestricted") }),
+  z.object({ type: z.literal("none") }),
+  z.object({ type: z.literal("allowlist"), domains: z.array(z.string()) }),
+]);
+export type NetworkPolicy = z.infer<typeof NetworkPolicy>;
+
+// Keyed by package manager ("pip", "npm", "apt", "cargo", …) — open like
+// InferenceConfig.provider: core doesn't enumerate managers, and an
+// adapter that cannot guarantee one MUST reject create(). Spec strings
+// keep each ecosystem's native syntax ("pandas==2.2.0", "express@4.18.0",
+// "rails:7.1.0") — the map names the interpreter; the string stays native
+// to it, so no invented cross-ecosystem version grammar to translate.
+export const Packages = z.record(z.string(), z.array(z.string()));
+export type Packages = z.infer<typeof Packages>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,7 @@
 export * from "./entries";
+export * from "./environment";
+export * from "./inference";
 export * from "./messages";
 export * from "./provider-events";
+export * from "./store";
 export * from "./tools";

--- a/packages/core/src/inference.ts
+++ b/packages/core/src/inference.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+/**
+ * The inference vocabulary — the declarative description of how a
+ * session's inference runs: which model serves it and how to sample. The
+ * InferenceProvider adapter is the interpreter: `provider` routes within
+ * it ("anthropic", "openai", …) the way env recipes route within the
+ * SandboxProvider — core does not enumerate vendors.
+ */
+export const InferenceConfig = z.object({
+  provider: z.string(),
+  model: z.string(),
+  // Absent = the provider's own default — there is no harness value to
+  // materialize, so absence is the stored truth too (never null).
+  maxTokens: z.number().int().positive().optional(),
+  temperature: z.number().optional(),
+});
+export type InferenceConfig = z.infer<typeof InferenceConfig>;

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1,0 +1,142 @@
+import { z } from "zod";
+import { NetworkPolicy, Packages } from "./environment";
+import { JsonValue, UserMessage } from "./messages";
+import { InferenceConfig } from "./inference";
+
+/**
+ * The Store port's vocabulary — the rows and results both sides of the
+ * port speak. The api consumes the intake half (configs, sessions,
+ * IntakeResult); the driver consumes the claim half (WorkItem,
+ * PendingInput); store adapters implement all of it.
+ *
+ * The engine imports none of this: it speaks messages and entries only.
+ * nextAction's cancelRequested input is computed by the driver at each
+ * boundary from the log's control entries — no import edge.
+ *
+ * Request shapes (Create*Request, after InferenceRequest and
+ * StreamRequest) become stored rows verbatim, plus the store-minted
+ * envelope (id, createdAt). Two rules keep every row one-shaped:
+ * - Rows store decisions, not rules: a default that is RESOLVED at
+ *   creation time is materialized into the write-once row (network →
+ *   unrestricted), so a later change of the platform default can never
+ *   reinterpret an old row. Where absence itself is the fact (no
+ *   sampling override, no metadata), absence is stored as absence.
+ * - null never appears in structured vocabulary. Absence has one
+ *   spelling — the TS-native one that composes with `?.`, `??`, and
+ *   spread defaults. (Opaque JsonValue payloads are the caller's
+ *   business and may contain anything JSON can.)
+ *
+ * Ids are opaque strings minted by the store. The aliases document which
+ * id space a signature means; upgrading them to branded types later is a
+ * change on this file only.
+ */
+
+export type ConfigId = string;
+export type SessionId = string;
+export type ItemId = string;
+export type InputId = string;
+
+// --- configs ---
+
+// Config rows are write-once: the port exposes no update or delete, so
+// immutability is an API impossibility, not a discipline. Sessions
+// reference config ids — the resolved config is always read through the
+// id, never copied forward.
+
+export const CreateAgentConfigRequest = z.object({
+  inference: InferenceConfig,
+  systemPrompt: z.string(),
+  metadata: JsonValue.optional(),
+});
+export type CreateAgentConfigRequest = z.infer<typeof CreateAgentConfigRequest>;
+
+export const AgentConfig = CreateAgentConfigRequest.extend({
+  id: z.string(),
+  createdAt: z.iso.datetime(),
+});
+export type AgentConfig = z.infer<typeof AgentConfig>;
+
+// The env config is the sandbox recipe — the immutable description of
+// the world a session runs in.
+export const CreateEnvConfigRequest = z.object({
+  network: NetworkPolicy.optional(),
+  // Presence is guaranteed at create() or creation fails — missing deps
+  // surface at provision, not mid-session.
+  packages: Packages.optional(),
+  metadata: JsonValue.optional(),
+});
+export type CreateEnvConfigRequest = z.infer<typeof CreateEnvConfigRequest>;
+
+export const EnvConfig = CreateEnvConfigRequest.extend({
+  id: z.string(),
+  // Materialized at create — resolved decisions, not restatable defaults:
+  network: NetworkPolicy, // absence resolved to { type: "unrestricted" }
+  packages: Packages, // absence resolved to {}
+  createdAt: z.iso.datetime(),
+});
+export type EnvConfig = z.infer<typeof EnvConfig>;
+
+// --- sessions ---
+
+export const CreateSessionRequest = z.object({
+  agentConfigId: z.string(),
+  envConfigId: z.string(),
+  metadata: JsonValue.optional(),
+});
+export type CreateSessionRequest = z.infer<typeof CreateSessionRequest>;
+
+export const Session = CreateSessionRequest.extend({
+  id: z.string(),
+  createdAt: z.iso.datetime(),
+});
+export type Session = z.infer<typeof Session>;
+
+// --- work items ---
+
+export const ItemType = z.enum(["inference", "execute_tools"]);
+export type ItemType = z.infer<typeof ItemType>;
+
+export const ItemStatus = z.enum(["ready", "leased", "done"]);
+export type ItemStatus = z.infer<typeof ItemStatus>;
+
+export const WorkItem = z.object({
+  id: z.string(),
+  sessionId: z.string(),
+  type: ItemType,
+  status: ItemStatus,
+});
+export type WorkItem = z.infer<typeof WorkItem>;
+
+// --- pending inputs ---
+
+// What is a run? It starts from a ueser query to the completion of
+// the agent.
+
+// A user message that arrived while a run was active (or parked by a
+// cancelled run's terminal commit). Whether it steers or follows up is
+// decided by which boundary drains it — inference prep vs terminal
+// commit — never by the message itself.
+export const PendingInput = z.object({
+  id: z.string(),
+  sessionId: z.string(),
+  message: UserMessage,
+  arrivedAt: z.iso.datetime(),
+});
+export type PendingInput = z.infer<typeof PendingInput>;
+
+// --- intake ---
+
+// intake()'s in-transaction branch: no open item → a new run starts, the
+// message its input and an inference item its first step; open item → the
+// message queues as a pending input.
+export const IntakeResult = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("started"),
+    itemId: z.string(),
+  }),
+  z.object({
+    kind: z.literal("queued"),
+    inputId: z.string(),
+  }),
+]);
+export type IntakeResult = z.infer<typeof IntakeResult>;

--- a/packages/core/test/entries.test.ts
+++ b/packages/core/test/entries.test.ts
@@ -4,7 +4,6 @@ import { SessionEntry } from "../src/entries";
 const envelope = {
   id: "e1",
   seq: 0,
-  runId: "r1",
   timestamp: "2026-08-10T12:00:00Z",
 };
 
@@ -42,15 +41,14 @@ describe("SessionEntry", () => {
     expect(SessionEntry.parse(JSON.parse(JSON.stringify(entry)))).toEqual(entry);
   });
 
-  it("accepts a null runId — entries written outside any run", () => {
-    const entry = {
-      ...envelope,
-      runId: null,
-      type: "custom",
-      namespace: "billing",
-      data: {},
-    };
-    expect(SessionEntry.parse(entry).runId).toBeNull();
+  it("round-trips a control entry — cancel rides the log, not a flag", () => {
+    const entry = { ...envelope, type: "control", control: "cancel" };
+    expect(SessionEntry.parse(JSON.parse(JSON.stringify(entry)))).toEqual(entry);
+  });
+
+  it("rejects an unknown control kind", () => {
+    const result = SessionEntry.safeParse({ ...envelope, type: "control", control: "pause" });
+    expect(result.success).toBe(false);
   });
 
   it("rejects an unknown entry type", () => {

--- a/packages/core/test/store.test.ts
+++ b/packages/core/test/store.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import {
+  AgentConfig,
+  CreateAgentConfigRequest,
+  CreateEnvConfigRequest,
+  CreateSessionRequest,
+  EnvConfig,
+  IntakeResult,
+  PendingInput,
+  Session,
+  WorkItem,
+} from "../src/store";
+
+const roundTrip = <T>(schema: { parse: (v: unknown) => T }, value: unknown): T =>
+  schema.parse(JSON.parse(JSON.stringify(value)));
+
+describe("configs", () => {
+  it("round-trips a stored agent config", () => {
+    const config = {
+      id: "ac1",
+      inference: {
+        provider: "anthropic",
+        model: "claude-sonnet-5",
+        maxTokens: 8192,
+        temperature: 0.7,
+      },
+      systemPrompt: "You are helpful.",
+      metadata: { team: "growth" },
+      createdAt: "2026-08-11T12:00:00Z",
+    };
+    expect(roundTrip(AgentConfig, config)).toEqual(config);
+  });
+
+  it("accepts a create request without metadata or sampling params — absence needs no placeholder", () => {
+    const result = CreateAgentConfigRequest.safeParse({
+      inference: { provider: "fake", model: "scripted" },
+      systemPrompt: "s",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("round-trips a stored agent config with no sampling overrides — absence is the stored form", () => {
+    const config = {
+      id: "ac1",
+      inference: { provider: "fake", model: "scripted" },
+      systemPrompt: "s",
+      createdAt: "2026-08-11T12:00:00Z",
+    };
+    expect(roundTrip(AgentConfig, config)).toEqual(config);
+  });
+
+  it("rejects null sampling params — absence has exactly one spelling", () => {
+    const result = AgentConfig.safeParse({
+      id: "ac1",
+      inference: { provider: "anthropic", model: "m", maxTokens: null, temperature: null },
+      systemPrompt: "s",
+      createdAt: "2026-08-11T12:00:00Z",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a bare-string inference config — it must say which provider serves the model", () => {
+    const result = CreateAgentConfigRequest.safeParse({
+      inference: "claude-sonnet-5",
+      systemPrompt: "s",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("env configs", () => {
+  it("round-trips a stored env config with the full recipe spine", () => {
+    const config = {
+      id: "ec1",
+      network: { type: "allowlist", domains: ["api.anthropic.com", "pypi.org"] },
+      packages: { pip: ["pandas==2.2.0", "numpy"], npm: ["express@4.18.0"] },
+      metadata: { envId: "env_014588" },
+      createdAt: "2026-08-11T12:00:00Z",
+    };
+    expect(roundTrip(EnvConfig, config)).toEqual(config);
+  });
+
+  it("rejects a flat package list — specs are keyed by their package manager", () => {
+    const result = CreateEnvConfigRequest.safeParse({ packages: ["numpy", "pandas"] });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts an empty create request — network and packages resolve at create", () => {
+    const result = CreateEnvConfigRequest.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an unknown network policy type", () => {
+    const result = CreateEnvConfigRequest.safeParse({ network: { type: "vpn" } });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a stored env config missing network — materialized decisions must be present", () => {
+    const result = EnvConfig.safeParse({
+      id: "ec1",
+      packages: {},
+      createdAt: "2026-08-11T12:00:00Z",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("sessions", () => {
+  it("round-trips a stored session — no metadata means no metadata key", () => {
+    const session = {
+      id: "s1",
+      agentConfigId: "ac1",
+      envConfigId: "ec1",
+      createdAt: "2026-08-11T12:00:00Z",
+    };
+    expect(roundTrip(Session, session)).toEqual(session);
+  });
+
+  it("rejects a create request without an agent config id", () => {
+    const result = CreateSessionRequest.safeParse({ envConfigId: "ec1" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a create request without an env config id — every session names its world", () => {
+    const result = CreateSessionRequest.safeParse({ agentConfigId: "ac1" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("work items", () => {
+  it("round-trips a work item", () => {
+    const item = { id: "i1", sessionId: "s1", type: "inference", status: "ready" };
+    expect(roundTrip(WorkItem, item)).toEqual(item);
+  });
+
+  it("rejects an unknown item type", () => {
+    const result = WorkItem.safeParse({
+      id: "i1",
+      sessionId: "s1",
+      type: "provision",
+      status: "ready",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("pending inputs", () => {
+  it("round-trips a pending input wrapping a user message", () => {
+    const input = {
+      id: "p1",
+      sessionId: "s1",
+      message: { role: "user", content: [{ type: "text", text: "also check the tests" }] },
+      arrivedAt: "2026-08-11T12:00:00Z",
+    };
+    expect(roundTrip(PendingInput, input)).toEqual(input);
+  });
+
+  it("rejects a pending input carrying a non-user message", () => {
+    const result = PendingInput.safeParse({
+      id: "p1",
+      sessionId: "s1",
+      message: { role: "assistant", content: [], model: "m", stopReason: "end_turn" },
+      arrivedAt: "2026-08-11T12:00:00Z",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("intake results", () => {
+  it("round-trips both branches", () => {
+    const started = { kind: "started", itemId: "i1" };
+    const queued = { kind: "queued", inputId: "p1" };
+    expect(roundTrip(IntakeResult, started)).toEqual(started);
+    expect(roundTrip(IntakeResult, queued)).toEqual(queued);
+  });
+
+  it("rejects an unknown kind", () => {
+    const result = IntakeResult.safeParse({ kind: "rejected", reason: "quota" });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds core Zod contracts for inference and environment configs, sessions, work items, pending inputs, and intake results. Moves cancellation into ordered session control entries, removes per-entry run attribution, and keeps control entries out of model context. Renames the agent-side model provider abstraction to InferenceProvider and updates exports and tests. Validation: pnpm format:check, pnpm typecheck, and pnpm test.