### PR TITLE
Add PostgreSQL adapter for durable agent store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,22 @@ jobs:
     # ubuntu runner provides via its preinstalled Docker.
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # The Store conformance suite runs on two bindings: PGlite (always) and a
+    # network postgres — the binding that exercises true concurrency (contended
+    # claims, lease races) that single-connection PGlite serializes away. This
+    # service is what un-skips packages/adapters/test/pg-postgres.test.ts.
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: pw
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
@@ -39,6 +55,8 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter '!chaos-tests' -r --if-present test
+        env:
+          STORE_TEST_DATABASE_URL: postgres://postgres:pw@localhost:5432/postgres
 
   chaos:
     # The product's warranty — durable agent execution proven at every crash point, under

--- a/packages/adapters/migrations/0000_init.sql
+++ b/packages/adapters/migrations/0000_init.sql
@@ -1,0 +1,60 @@
+-- Store schema, initial shape. Vanilla postgres only — transactions,
+-- SKIP LOCKED, partial unique indexes; no extensions (see the design
+-- doc's "Postgres targets": the same DDL must run on PGlite, compose,
+-- k8s, Cloud SQL, PlanetScale-for-Postgres).
+
+CREATE TABLE agent_configs (
+  id text PRIMARY KEY,
+  inference jsonb NOT NULL,
+  system_prompt text NOT NULL,
+  metadata jsonb,
+  created_at timestamptz NOT NULL
+);
+
+CREATE TABLE env_configs (
+  id text PRIMARY KEY,
+  network jsonb NOT NULL,
+  packages jsonb NOT NULL,
+  metadata jsonb,
+  created_at timestamptz NOT NULL
+);
+
+CREATE TABLE sessions (
+  id text PRIMARY KEY,
+  agent_config_id text NOT NULL REFERENCES agent_configs(id),
+  env_config_id text NOT NULL REFERENCES env_configs(id),
+  metadata jsonb,
+  created_at timestamptz NOT NULL
+);
+
+CREATE TABLE session_entries (
+  session_id text NOT NULL REFERENCES sessions(id),
+  seq integer NOT NULL,
+  entry jsonb NOT NULL,
+  PRIMARY KEY (session_id, seq)
+);
+
+CREATE TABLE work_items (
+  id text PRIMARY KEY,
+  session_id text NOT NULL REFERENCES sessions(id),
+  type text NOT NULL,
+  status text NOT NULL,
+  lease_token text,
+  lease_expires_at timestamptz,
+  lease_ms integer,
+  created_at timestamptz NOT NULL
+);
+
+-- The one-open-item invariant: at most one non-done item per session.
+CREATE UNIQUE INDEX work_items_one_open_per_session
+  ON work_items (session_id) WHERE status <> 'done';
+CREATE INDEX work_items_claim_scan ON work_items (status, created_at);
+
+CREATE TABLE pending_inputs (
+  session_id text NOT NULL REFERENCES sessions(id),
+  ord bigserial,
+  id text NOT NULL UNIQUE,
+  message jsonb NOT NULL,
+  arrived_at timestamptz NOT NULL,
+  PRIMARY KEY (session_id, ord)
+);

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@funky/adapters",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@funky/agent": "workspace:*",
+    "@funky/core": "workspace:*",
+    "drizzle-orm": "^1.0.0-beta.2",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@electric-sql/pglite": "^0.5.4",
+    "@types/pg": "^8.20.0",
+    "pg": "^8.22.0",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,0 +1,2 @@
+export { createPgStore } from "./store/pg";
+export type { PgStoreOptions, StoreDb } from "./store/pg";

--- a/packages/adapters/src/store/pg.ts
+++ b/packages/adapters/src/store/pg.ts
@@ -1,0 +1,407 @@
+// The Store port over vanilla postgres. One adapter, many runtimes: the
+// composition root binds `db` to PGlite (tests, local REPL) or a network
+// postgres (compose, k8s, managed) — there is no test/prod adapter split.
+//
+// Concurrency discipline:
+// - Per-session write serialization: every writing transaction locks the
+//   session row (SELECT … FOR UPDATE) before minting seq numbers, so the
+//   per-session log stays gapless and monotonic.
+// - Lock order is item → session everywhere an item is involved; no path
+//   takes session → item, so no cycle exists.
+// - claimItem uses FOR UPDATE SKIP LOCKED: contended claimers never
+//   queue behind each other, exactly one wins a given item.
+// - Fencing is token + live lease, symmetric across heartbeat and
+//   commitStep: a stale token or an expired lease rejects the write,
+//   even if nobody reclaimed the item (strict expiry, 2026-08-12).
+//   The token is minted here, fresh per claim, so credential
+//   uniqueness is structural — a re-claim always re-issues, and a
+//   previous holder's zombie can never present valid credentials.
+//   After expiry an item's fate always belongs to its next claimer —
+//   late work is discarded, never merged, and the P4 reaper can
+//   synthesize over an expired item without racing a slow worker.
+//
+// The clock is injected (`now`) so lease expiry is testable; all time
+// comparisons use it — never SQL now().
+
+import { randomUUID } from "node:crypto";
+import { and, asc, eq, gt, inArray, lte, ne, or, sql } from "drizzle-orm";
+import type { PgAsyncDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
+import {
+  AgentConfig,
+  AgentMessage,
+  CreateAgentConfigRequest,
+  CreateEnvConfigRequest,
+  CreateSessionRequest,
+  EnvConfig,
+  IntakeResult,
+  type JsonValue,
+  PendingInput,
+  Session,
+  SessionEntry,
+  UserMessage,
+  WorkItem,
+} from "@funky/core";
+import type { CommitStepRequest, Store } from "@funky/agent";
+import {
+  agentConfigs,
+  envConfigs,
+  pendingInputs,
+  sessionEntries,
+  sessions,
+  workItems,
+  type WrappedJson,
+} from "./schema";
+
+/** Any drizzle pg database — PGlite and node-postgres instances both fit. */
+export type StoreDb = PgAsyncDatabase<PgQueryResultHKT>;
+type Tx = Parameters<Parameters<StoreDb["transaction"]>[0]>[0];
+
+export interface PgStoreOptions {
+  /** Injected clock; defaults to wall time. All lease math uses it. */
+  now?: () => Date;
+}
+
+const iso = (d: Date) => d.toISOString();
+const wrap = (v: JsonValue | undefined): WrappedJson | null => (v === undefined ? null : { v });
+const unwrapped = (w: WrappedJson | null): { metadata?: JsonValue } =>
+  w === null ? {} : { metadata: w.v };
+
+export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
+  const now = opts.now ?? (() => new Date());
+
+  async function lockSession(tx: Tx, sessionId: string): Promise<void> {
+    const rows = await tx
+      .select({ id: sessions.id })
+      .from(sessions)
+      .where(eq(sessions.id, sessionId))
+      .for("update");
+    if (rows.length === 0) throw new Error(`unknown session: ${sessionId}`);
+  }
+
+  /** Mint envelopes and append; caller must hold the session lock. */
+  async function appendEntries(
+    tx: Tx,
+    sessionId: string,
+    payloads: Array<Record<string, unknown>>,
+  ): Promise<void> {
+    const [tail] = await tx
+      .select({ max: sql<number>`coalesce(max(${sessionEntries.seq}), -1)` })
+      .from(sessionEntries)
+      .where(eq(sessionEntries.sessionId, sessionId));
+    let seq = Number(tail?.max ?? -1);
+    for (const payload of payloads) {
+      seq += 1;
+      const entry = SessionEntry.parse({
+        id: randomUUID(),
+        seq,
+        timestamp: iso(now()),
+        ...payload,
+      });
+      await tx.insert(sessionEntries).values({ sessionId, seq, entry });
+    }
+  }
+
+  return {
+    async createAgentConfig(req) {
+      const parsed = CreateAgentConfigRequest.parse(req);
+      const id = randomUUID();
+      await db.insert(agentConfigs).values({
+        id,
+        inference: parsed.inference,
+        systemPrompt: parsed.systemPrompt,
+        metadata: wrap(parsed.metadata),
+        createdAt: now(),
+      });
+      return id;
+    },
+
+    async getAgentConfig(id) {
+      const [row] = await db.select().from(agentConfigs).where(eq(agentConfigs.id, id));
+      if (!row) return undefined;
+      return AgentConfig.parse({
+        id: row.id,
+        inference: row.inference,
+        systemPrompt: row.systemPrompt,
+        ...unwrapped(row.metadata),
+        createdAt: iso(row.createdAt),
+      });
+    },
+
+    async createEnvConfig(req) {
+      const parsed = CreateEnvConfigRequest.parse(req);
+      const id = randomUUID();
+      await db.insert(envConfigs).values({
+        id,
+        // Materialized at create — resolved decisions, not restatable defaults.
+        network: parsed.network ?? { type: "unrestricted" },
+        packages: parsed.packages ?? {},
+        metadata: wrap(parsed.metadata),
+        createdAt: now(),
+      });
+      return id;
+    },
+
+    async getEnvConfig(id) {
+      const [row] = await db.select().from(envConfigs).where(eq(envConfigs.id, id));
+      if (!row) return undefined;
+      return EnvConfig.parse({
+        id: row.id,
+        network: row.network,
+        packages: row.packages,
+        ...unwrapped(row.metadata),
+        createdAt: iso(row.createdAt),
+      });
+    },
+
+    async createSession(req) {
+      const parsed = CreateSessionRequest.parse(req);
+      // Configs are write-once and never deleted, so this pre-check cannot
+      // go stale; the FK constraints remain as the structural backstop.
+      const [agent] = await db
+        .select({ id: agentConfigs.id })
+        .from(agentConfigs)
+        .where(eq(agentConfigs.id, parsed.agentConfigId));
+      if (!agent) throw new Error(`unknown agent config: ${parsed.agentConfigId}`);
+      const [env] = await db
+        .select({ id: envConfigs.id })
+        .from(envConfigs)
+        .where(eq(envConfigs.id, parsed.envConfigId));
+      if (!env) throw new Error(`unknown env config: ${parsed.envConfigId}`);
+      const id = randomUUID();
+      await db.insert(sessions).values({
+        id,
+        agentConfigId: parsed.agentConfigId,
+        envConfigId: parsed.envConfigId,
+        metadata: wrap(parsed.metadata),
+        createdAt: now(),
+      });
+      return id;
+    },
+
+    async getSession(id) {
+      const [row] = await db.select().from(sessions).where(eq(sessions.id, id));
+      if (!row) return undefined;
+      return Session.parse({
+        id: row.id,
+        agentConfigId: row.agentConfigId,
+        envConfigId: row.envConfigId,
+        ...unwrapped(row.metadata),
+        createdAt: iso(row.createdAt),
+      });
+    },
+
+    async readEntries(sessionId, after) {
+      const rows = await db
+        .select({ entry: sessionEntries.entry })
+        .from(sessionEntries)
+        .where(
+          after === undefined
+            ? eq(sessionEntries.sessionId, sessionId)
+            : and(eq(sessionEntries.sessionId, sessionId), gt(sessionEntries.seq, after)),
+        )
+        .orderBy(asc(sessionEntries.seq));
+      return rows.map((r) => SessionEntry.parse(r.entry));
+    },
+
+    async listItems(sessionId) {
+      const rows = await db
+        .select()
+        .from(workItems)
+        .where(eq(workItems.sessionId, sessionId))
+        .orderBy(asc(workItems.createdAt));
+      return rows.map((r) =>
+        WorkItem.parse({ id: r.id, sessionId: r.sessionId, type: r.type, status: r.status }),
+      );
+    },
+
+    async pendingInputs(sessionId) {
+      const rows = await db
+        .select()
+        .from(pendingInputs)
+        .where(eq(pendingInputs.sessionId, sessionId))
+        .orderBy(asc(pendingInputs.ord));
+      return rows.map((r) =>
+        PendingInput.parse({
+          id: r.id,
+          sessionId: r.sessionId,
+          message: r.message,
+          arrivedAt: iso(r.arrivedAt),
+        }),
+      );
+    },
+
+    async claimItem(req) {
+      return db.transaction(async (tx) => {
+        const t = now();
+        // "Expired" has one spelling everywhere: live iff now < leaseExpiresAt.
+        // Equality is dead — heartbeat and commitStep agree, so the instant
+        // the old holder loses authority is the instant a claimer gains it.
+        const claimable = or(
+          eq(workItems.status, "ready"),
+          and(eq(workItems.status, "leased"), lte(workItems.leaseExpiresAt, t)),
+        );
+        const [candidate] = await tx
+          .select({ id: workItems.id, sessionId: workItems.sessionId, type: workItems.type })
+          .from(workItems)
+          .where(
+            req.sessionId === undefined
+              ? claimable
+              : and(claimable, eq(workItems.sessionId, req.sessionId)),
+          )
+          .orderBy(asc(workItems.createdAt))
+          .limit(1)
+          .for("update", { skipLocked: true });
+        if (!candidate) return undefined;
+        const token = randomUUID(); // fresh per claim — never re-issued
+        await tx
+          .update(workItems)
+          .set({
+            status: "leased",
+            leaseToken: token,
+            leaseMs: req.leaseMs,
+            leaseExpiresAt: new Date(t.getTime() + req.leaseMs),
+          })
+          .where(eq(workItems.id, candidate.id));
+        return {
+          item: WorkItem.parse({
+            id: candidate.id,
+            sessionId: candidate.sessionId,
+            type: candidate.type,
+            status: "leased",
+          }),
+          token,
+        };
+      });
+    },
+
+    async heartbeat(itemId, token) {
+      const t = now();
+      const rows = await db
+        .update(workItems)
+        .set({
+          leaseExpiresAt: sql`${iso(t)}::timestamptz + ${workItems.leaseMs} * interval '1 millisecond'`,
+        })
+        .where(
+          and(
+            eq(workItems.id, itemId),
+            eq(workItems.leaseToken, token),
+            eq(workItems.status, "leased"),
+            gt(workItems.leaseExpiresAt, t), // expired = lost, even if unclaimed
+          ),
+        )
+        .returning({ id: workItems.id });
+      return rows.length > 0;
+    },
+
+    async requestCancel(sessionId) {
+      await db.transaction(async (tx) => {
+        await lockSession(tx, sessionId);
+        await appendEntries(tx, sessionId, [{ type: "control", control: "cancel" }]);
+      });
+    },
+
+    async intake(sessionId, message) {
+      const msg = UserMessage.parse(message);
+      return db.transaction(async (tx) => {
+        await lockSession(tx, sessionId); // the race referee
+        const open = await tx
+          .select({ id: workItems.id })
+          .from(workItems)
+          .where(and(eq(workItems.sessionId, sessionId), ne(workItems.status, "done")))
+          .limit(1);
+        if (open.length > 0) {
+          const inputId = randomUUID();
+          await tx
+            .insert(pendingInputs)
+            .values({ id: inputId, sessionId, message: msg, arrivedAt: now() });
+          return IntakeResult.parse({ kind: "queued", inputId });
+        }
+        await appendEntries(tx, sessionId, [{ type: "message", message: msg }]);
+        const itemId = randomUUID();
+        await tx
+          .insert(workItems)
+          .values({ id: itemId, sessionId, type: "inference", status: "ready", createdAt: now() });
+        return IntakeResult.parse({ kind: "started", itemId });
+      });
+    },
+
+    async commitStep(req: CommitStepRequest) {
+      const messages = req.append.map((m) => AgentMessage.parse(m));
+      await db.transaction(async (tx) => {
+        const [item] = await tx
+          .select()
+          .from(workItems)
+          .where(eq(workItems.id, req.itemId))
+          .for("update");
+        if (!item) throw new Error(`commitStep: unknown item ${req.itemId}`);
+        if (item.status === "done") {
+          if (item.leaseToken !== req.token)
+            throw new Error(`commitStep: fenced — ${req.itemId} was finished under another claim`);
+          return; // idempotent re-commit (crash-after-commit recovery)
+        }
+        if (item.status !== "leased" || item.leaseToken !== req.token)
+          throw new Error(`commitStep: fenced — stale token for ${req.itemId}`);
+        if (item.leaseExpiresAt === null || item.leaseExpiresAt.getTime() <= now().getTime())
+          throw new Error(`commitStep: fenced — ${req.itemId}'s lease expired before commit`);
+        await lockSession(tx, item.sessionId);
+        await appendEntries(
+          tx,
+          item.sessionId,
+          messages.map((m) => ({ type: "message", message: m })),
+        );
+        if (req.consumeInputs !== undefined && req.consumeInputs.length > 0) {
+          const drained = await tx
+            .delete(pendingInputs)
+            .where(
+              and(
+                eq(pendingInputs.sessionId, item.sessionId),
+                inArray(pendingInputs.id, req.consumeInputs),
+              ),
+            )
+            .returning({ id: pendingInputs.id });
+          if (drained.length !== req.consumeInputs.length)
+            throw new Error("commitStep: consumeInputs names an unknown or already-consumed input");
+        }
+        await tx.update(workItems).set({ status: "done" }).where(eq(workItems.id, item.id));
+        if (req.next.kind !== "end_run") {
+          await tx.insert(workItems).values({
+            id: randomUUID(),
+            sessionId: item.sessionId,
+            type: req.next.kind,
+            status: "ready",
+            createdAt: now(),
+          });
+          return;
+        }
+        // end_run: the run's end is the atomic NON-creation of a next item.
+        // Pending inputs auto-chain a new run in this same transaction —
+        // except after a cancel, which parks them for the next intake.
+        if (req.next.status === "cancelled") return;
+        const parked = await tx
+          .select()
+          .from(pendingInputs)
+          .where(eq(pendingInputs.sessionId, item.sessionId))
+          .orderBy(asc(pendingInputs.ord));
+        if (parked.length === 0) return;
+        await appendEntries(
+          tx,
+          item.sessionId,
+          parked.map((p) => ({ type: "message", message: p.message })),
+        );
+        await tx.delete(pendingInputs).where(
+          inArray(
+            pendingInputs.ord,
+            parked.map((p) => p.ord),
+          ),
+        );
+        await tx.insert(workItems).values({
+          id: randomUUID(),
+          sessionId: item.sessionId,
+          type: "inference",
+          status: "ready",
+          createdAt: now(),
+        });
+      });
+    },
+  };
+}

--- a/packages/adapters/src/store/schema.ts
+++ b/packages/adapters/src/store/schema.ts
@@ -1,0 +1,122 @@
+// The pg adapter's physical shape. Drizzle types never leave this package:
+// `core` types are the only currency crossing the Store port.
+//
+// Two conventions the domain contract imposes on the SQL:
+// - Absence vs JSON null: `metadata` columns store the wrapped form
+//   `{ v: <JsonValue> }`; SQL NULL means the caller stored nothing. The
+//   wrapper exists because drivers parse jsonb 'null' and SQL NULL to the
+//   same JS null — without it, "no metadata" and "metadata: null" would
+//   collapse into one spelling on read.
+// - Envelope truth lives in the row's domain form: `session_entries.entry`
+//   is the full SessionEntry (id, seq, timestamp, payload); the bare `seq`
+//   column exists only for the primary key and ordered reads.
+
+import { sql } from "drizzle-orm";
+import {
+  bigserial,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import type {
+  InferenceConfig,
+  JsonValue,
+  NetworkPolicy,
+  Packages,
+  SessionEntry,
+  UserMessage,
+} from "@funky/core";
+
+/** SQL NULL = absent; `{ v }` = present (v may be JSON null). */
+export type WrappedJson = { v: JsonValue };
+
+export const agentConfigs = pgTable("agent_configs", {
+  id: text("id").primaryKey(),
+  inference: jsonb("inference").$type<InferenceConfig>().notNull(),
+  systemPrompt: text("system_prompt").notNull(),
+  metadata: jsonb("metadata").$type<WrappedJson>(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+});
+
+export const envConfigs = pgTable("env_configs", {
+  id: text("id").primaryKey(),
+  // Materialized at create — never SQL NULL (resolved decisions, not defaults).
+  network: jsonb("network").$type<NetworkPolicy>().notNull(),
+  packages: jsonb("packages").$type<Packages>().notNull(),
+  metadata: jsonb("metadata").$type<WrappedJson>(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+});
+
+export const sessions = pgTable("sessions", {
+  id: text("id").primaryKey(),
+  agentConfigId: text("agent_config_id")
+    .notNull()
+    .references(() => agentConfigs.id),
+  envConfigId: text("env_config_id")
+    .notNull()
+    .references(() => envConfigs.id),
+  metadata: jsonb("metadata").$type<WrappedJson>(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+});
+
+export const sessionEntries = pgTable(
+  "session_entries",
+  {
+    sessionId: text("session_id")
+      .notNull()
+      .references(() => sessions.id),
+    seq: integer("seq").notNull(),
+    entry: jsonb("entry").$type<SessionEntry>().notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.sessionId, t.seq] })],
+);
+
+export const workItems = pgTable(
+  "work_items",
+  {
+    id: text("id").primaryKey(),
+    sessionId: text("session_id")
+      .notNull()
+      .references(() => sessions.id),
+    type: text("type").notNull(), // ItemType
+    status: text("status").notNull(), // ItemStatus
+    // Lease bookkeeping — adapter internals, not port vocabulary.
+    leaseToken: text("lease_token"),
+    leaseExpiresAt: timestamp("lease_expires_at", { withTimezone: true }),
+    leaseMs: integer("lease_ms"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+  },
+  (t) => [
+    // The one-open-item invariant, enforced declaratively: at most one
+    // non-done item per session. This index IS "busy".
+    uniqueIndex("work_items_one_open_per_session")
+      .on(t.sessionId)
+      .where(sql`${t.status} <> 'done'`),
+    index("work_items_claim_scan").on(t.status, t.createdAt),
+  ],
+);
+
+export const pendingInputs = pgTable(
+  "pending_inputs",
+  {
+    sessionId: text("session_id")
+      .notNull()
+      .references(() => sessions.id),
+    // Drain order — arrival order even under equal timestamps. The key
+    // shape mimics session_entries, but ord is plumbing, not contract:
+    // a global bigserial, gappy and never per-session dense (seq is the
+    // hand-minted dense one). The composite PK is the access path for
+    // the session-scoped reads that are this table's only queries.
+    ord: bigserial("ord", { mode: "number" }),
+    // The port-level name — what consumeInputs targets.
+    id: text("id").notNull().unique(),
+    message: jsonb("message").$type<UserMessage>().notNull(),
+    arrivedAt: timestamp("arrived_at", { withTimezone: true }).notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.sessionId, t.ord] })],
+);

--- a/packages/adapters/test/pg-postgres.test.ts
+++ b/packages/adapters/test/pg-postgres.test.ts
@@ -1,0 +1,49 @@
+// The same conformance suite bound to a network postgres — the CI
+// binding that exercises true concurrency (contended claims, lease
+// races) that PGlite serializes away. Runs only when
+// STORE_TEST_DATABASE_URL is set; the database is wiped per run.
+
+import { readFileSync } from "node:fs";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, it } from "vitest";
+import { createPgStore, type StoreDb } from "../src";
+import { describeStoreConformance } from "./store-conformance";
+
+const url = process.env.STORE_TEST_DATABASE_URL;
+
+if (!url) {
+  describe.skip("Store conformance: pg over network postgres", () => {
+    it("skipped — set STORE_TEST_DATABASE_URL to run", () => {});
+  });
+} else {
+  const ddl = readFileSync(new URL("../migrations/0000_init.sql", import.meta.url), "utf8");
+  const pool = new Pool({ connectionString: url });
+
+  beforeAll(async () => {
+    await pool.query("DROP SCHEMA public CASCADE; CREATE SCHEMA public;");
+    await pool.query(ddl);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  describeStoreConformance("pg over network postgres", async () => {
+    await pool.query(
+      "TRUNCATE agent_configs, env_configs, sessions, session_entries, work_items, pending_inputs RESTART IDENTITY CASCADE",
+    );
+    let offsetMs = 0;
+    const store = createPgStore(drizzle({ client: pool }) as unknown as StoreDb, {
+      now: () => new Date(Date.now() + offsetMs),
+    });
+    return {
+      store,
+      clock: {
+        advance: (ms: number) => {
+          offsetMs += ms;
+        },
+      },
+    };
+  });
+}

--- a/packages/adapters/test/pg.test.ts
+++ b/packages/adapters/test/pg.test.ts
@@ -1,0 +1,43 @@
+// The pg adapter under the conformance suite, bound to PGlite — real
+// postgres in-process, zero setup. The CI binding against a network
+// postgres container lives in pg-postgres.test.ts; PGlite serializes
+// concurrent queries, so the contention cases only prove true parallelism
+// there.
+
+import { readFileSync } from "node:fs";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { afterAll, beforeAll } from "vitest";
+import { createPgStore, type StoreDb } from "../src";
+import { describeStoreConformance } from "./store-conformance";
+
+const ddl = readFileSync(new URL("../migrations/0000_init.sql", import.meta.url), "utf8");
+
+let client: PGlite;
+
+beforeAll(async () => {
+  client = new PGlite();
+  await client.exec(ddl);
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+describeStoreConformance("pg over PGlite", async () => {
+  await client.exec(
+    "TRUNCATE agent_configs, env_configs, sessions, session_entries, work_items, pending_inputs RESTART IDENTITY CASCADE",
+  );
+  let offsetMs = 0;
+  const store = createPgStore(drizzle({ client }) as unknown as StoreDb, {
+    now: () => new Date(Date.now() + offsetMs),
+  });
+  return {
+    store,
+    clock: {
+      advance: (ms: number) => {
+        offsetMs += ms;
+      },
+    },
+  };
+});

--- a/packages/adapters/test/store-conformance.ts
+++ b/packages/adapters/test/store-conformance.ts
@@ -1,0 +1,469 @@
+// The Store conformance suite — the port's jsdoc contract as executable
+// tests, written against the interface via a factory. Every adapter and
+// every binding runs this identical suite; what it pins is contract, what
+// it doesn't pin is implementation freedom.
+//
+// The harness provides a controllable clock so lease expiry is tested by
+// advancing time, never by sleeping.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import type { AssistantMessage, UserMessage } from "@funky/core";
+import type { CommitStepRequest, Store } from "@funky/agent";
+
+export interface StoreHarness {
+  store: Store;
+  clock: { advance(ms: number): void };
+}
+
+const user = (text: string): UserMessage => ({
+  role: "user",
+  content: [{ type: "text", text }],
+});
+
+const assistant = (text: string): AssistantMessage => ({
+  role: "assistant",
+  content: [{ type: "text", text }],
+  model: "test-model",
+  stopReason: "end_turn",
+});
+
+export function describeStoreConformance(
+  name: string,
+  makeHarness: () => Promise<StoreHarness>,
+): void {
+  describe(`Store conformance: ${name}`, () => {
+    let store: Store;
+    let clock: StoreHarness["clock"];
+
+    beforeEach(async () => {
+      ({ store, clock } = await makeHarness());
+    });
+
+    async function newSession(): Promise<string> {
+      const agentConfigId = await store.createAgentConfig({
+        inference: { provider: "fake", model: "scripted" },
+        systemPrompt: "s",
+      });
+      const envConfigId = await store.createEnvConfig({});
+      return store.createSession({ agentConfigId, envConfigId });
+    }
+
+    /** intake must have started a run; returns the claimed item + token. */
+    async function startAndClaim(sessionId: string): Promise<{ itemId: string; token: string }> {
+      const result = await store.intake(sessionId, user("go"));
+      expect(result.kind).toBe("started");
+      const claim = await store.claimItem({ leaseMs: 60_000, sessionId });
+      expect(claim).toBeDefined();
+      return { itemId: claim!.item.id, token: claim!.token };
+    }
+
+    describe("configs", () => {
+      it("round-trips an agent config through create and get", async () => {
+        const id = await store.createAgentConfig({
+          inference: { provider: "anthropic", model: "claude-sonnet-5", maxTokens: 8192 },
+          systemPrompt: "You are helpful.",
+          metadata: { team: "growth" },
+        });
+        const config = await store.getAgentConfig(id);
+        expect(config).toMatchObject({
+          id,
+          inference: { provider: "anthropic", model: "claude-sonnet-5", maxTokens: 8192 },
+          systemPrompt: "You are helpful.",
+          metadata: { team: "growth" },
+        });
+        expect(config?.createdAt).toMatch(/T.*Z$/);
+      });
+
+      it("stores absence as absence — no metadata or sampling keys materialize", async () => {
+        const id = await store.createAgentConfig({
+          inference: { provider: "fake", model: "m" },
+          systemPrompt: "s",
+        });
+        const config = await store.getAgentConfig(id);
+        expect(config).toBeDefined();
+        expect("metadata" in config!).toBe(false);
+        expect("maxTokens" in config!.inference).toBe(false);
+        expect("temperature" in config!.inference).toBe(false);
+      });
+
+      it("keeps JSON null metadata distinct from absent metadata", async () => {
+        const id = await store.createAgentConfig({
+          inference: { provider: "fake", model: "m" },
+          systemPrompt: "s",
+          metadata: null,
+        });
+        const config = await store.getAgentConfig(id);
+        expect(config).toBeDefined();
+        expect("metadata" in config!).toBe(true);
+        expect(config!.metadata).toBeNull();
+      });
+
+      it("rejects an invalid create request at the boundary", async () => {
+        await expect(
+          store.createAgentConfig({
+            // biome-ignore lint/suspicious/noExplicitAny: deliberately malformed
+            inference: "claude-sonnet-5" as any,
+            systemPrompt: "s",
+          }),
+        ).rejects.toThrow();
+      });
+
+      it("materializes network and packages at env config create", async () => {
+        const id = await store.createEnvConfig({});
+        const config = await store.getEnvConfig(id);
+        expect(config?.network).toEqual({ type: "unrestricted" });
+        expect(config?.packages).toEqual({});
+      });
+
+      it("preserves a provided recipe verbatim", async () => {
+        const id = await store.createEnvConfig({
+          network: { type: "allowlist", domains: ["pypi.org"] },
+          packages: { pip: ["pandas==2.2.0"] },
+        });
+        const config = await store.getEnvConfig(id);
+        expect(config?.network).toEqual({ type: "allowlist", domains: ["pypi.org"] });
+        expect(config?.packages).toEqual({ pip: ["pandas==2.2.0"] });
+      });
+
+      it("returns undefined for an unknown config id", async () => {
+        expect(await store.getAgentConfig("nope")).toBeUndefined();
+        expect(await store.getEnvConfig("nope")).toBeUndefined();
+      });
+    });
+
+    describe("sessions", () => {
+      it("round-trips a session", async () => {
+        const sessionId = await newSession();
+        const session = await store.getSession(sessionId);
+        expect(session?.id).toBe(sessionId);
+        expect(session?.agentConfigId).toBeDefined();
+        expect(session?.envConfigId).toBeDefined();
+      });
+
+      it("rejects a session naming an unknown agent config", async () => {
+        const envConfigId = await store.createEnvConfig({});
+        await expect(store.createSession({ agentConfigId: "nope", envConfigId })).rejects.toThrow();
+      });
+
+      it("rejects a session naming an unknown env config", async () => {
+        const agentConfigId = await store.createAgentConfig({
+          inference: { provider: "fake", model: "m" },
+          systemPrompt: "s",
+        });
+        await expect(store.createSession({ agentConfigId, envConfigId: "nope" })).rejects.toThrow();
+      });
+    });
+
+    describe("intake", () => {
+      it("starts a run on an idle session — one entry, one ready inference item", async () => {
+        const sessionId = await newSession();
+        const result = await store.intake(sessionId, user("hi"));
+        expect(result.kind).toBe("started");
+        const entries = await store.readEntries(sessionId);
+        expect(entries).toHaveLength(1);
+        expect(entries[0]).toMatchObject({ type: "message", seq: 0, message: user("hi") });
+        const items = await store.listItems(sessionId);
+        expect(items).toHaveLength(1);
+        expect(items[0]).toMatchObject({ type: "inference", status: "ready" });
+      });
+
+      it("queues on a busy session — a pending input, never a second item", async () => {
+        const sessionId = await newSession();
+        await store.intake(sessionId, user("first"));
+        const result = await store.intake(sessionId, user("second"));
+        expect(result.kind).toBe("queued");
+        expect(await store.listItems(sessionId)).toHaveLength(1);
+        const pending = await store.pendingInputs(sessionId);
+        expect(pending).toHaveLength(1);
+        expect(pending[0]?.message).toEqual(user("second"));
+        // The queued message is parked, not logged.
+        expect(await store.readEntries(sessionId)).toHaveLength(1);
+      });
+
+      it("rejects intake for an unknown session", async () => {
+        await expect(store.intake("nope", user("hi"))).rejects.toThrow();
+      });
+
+      it("admits exactly one starter under concurrent intake", async () => {
+        const sessionId = await newSession();
+        const results = await Promise.all(
+          Array.from({ length: 5 }, (_, i) => store.intake(sessionId, user(`m${i}`))),
+        );
+        expect(results.filter((r) => r.kind === "started")).toHaveLength(1);
+        expect(results.filter((r) => r.kind === "queued")).toHaveLength(4);
+        expect(await store.listItems(sessionId)).toHaveLength(1);
+      });
+    });
+
+    describe("claiming", () => {
+      it("leases the ready item to exactly one claimer", async () => {
+        const sessionId = await newSession();
+        await store.intake(sessionId, user("go"));
+        const claim = await store.claimItem({ leaseMs: 60_000 });
+        expect(claim?.item).toMatchObject({ sessionId, type: "inference", status: "leased" });
+        expect(claim?.token).toBeTruthy();
+        expect(await store.claimItem({ leaseMs: 60_000 })).toBeUndefined();
+      });
+
+      it("admits exactly one winner under contended claims", async () => {
+        const sessionId = await newSession();
+        await store.intake(sessionId, user("go"));
+        const claims = await Promise.all(
+          Array.from({ length: 8 }, () => store.claimItem({ leaseMs: 60_000 })),
+        );
+        expect(claims.filter((c) => c !== undefined)).toHaveLength(1);
+      });
+
+      it("scopes the claim scan when sessionId is given", async () => {
+        const s1 = await newSession();
+        const s2 = await newSession();
+        await store.intake(s1, user("a"));
+        await store.intake(s2, user("b"));
+        const claim = await store.claimItem({ leaseMs: 60_000, sessionId: s2 });
+        expect(claim?.item.sessionId).toBe(s2);
+      });
+
+      it("heartbeats only the live lease's token", async () => {
+        const sessionId = await newSession();
+        const { itemId, token } = await startAndClaim(sessionId);
+        expect(await store.heartbeat(itemId, token)).toBe(true);
+        expect(await store.heartbeat(itemId, "forged-token")).toBe(false);
+      });
+
+      it("reclaims an expired lease with a fresh token, fencing the old one", async () => {
+        const sessionId = await newSession();
+        const { itemId, token } = await startAndClaim(sessionId);
+        clock.advance(120_000);
+        expect(await store.heartbeat(itemId, token)).toBe(false); // lease lost
+        const reclaimed = await store.claimItem({ leaseMs: 60_000 });
+        expect(reclaimed?.item.id).toBe(itemId);
+        // A re-claim never re-issues the credential — the zombie stays fenced.
+        expect(reclaimed?.token).not.toBe(token);
+        await expect(
+          store.commitStep({
+            itemId,
+            token,
+            append: [assistant("stale work")],
+            next: { kind: "end_run", status: "completed" },
+          }),
+        ).rejects.toThrow(/fenced/);
+        await store.commitStep({
+          itemId,
+          token: reclaimed!.token,
+          append: [assistant("done")],
+          next: { kind: "end_run", status: "completed" },
+        });
+      });
+
+      it("transfers authority at the exact expiry instant — expired has one spelling", async () => {
+        const sessionId = await newSession();
+        const { itemId, token } = await startAndClaim(sessionId); // leaseMs 60_000
+        clock.advance(60_000); // now == leaseExpiresAt, exactly
+        expect(await store.heartbeat(itemId, token)).toBe(false); // holder is out…
+        await expect(
+          store.commitStep({
+            itemId,
+            token,
+            append: [assistant("at the wire")],
+            next: { kind: "end_run", status: "completed" },
+          }),
+        ).rejects.toThrow(/fenced/);
+        const reclaimed = await store.claimItem({ leaseMs: 60_000 }); // …and a claimer is in
+        expect(reclaimed?.item.id).toBe(itemId);
+      });
+
+      it("rejects a commit on an expired lease even before any reclaim", async () => {
+        const sessionId = await newSession();
+        const { itemId, token } = await startAndClaim(sessionId);
+        clock.advance(120_000);
+        await expect(
+          store.commitStep({
+            itemId,
+            token,
+            append: [assistant("late")],
+            next: { kind: "end_run", status: "completed" },
+          }),
+        ).rejects.toThrow(/fenced/);
+        // The rejected commit rolled back whole — nothing landed.
+        expect(await store.readEntries(sessionId)).toHaveLength(1);
+        // After expiry the item's fate belongs to its next claimer.
+        const reclaimed = await store.claimItem({ leaseMs: 60_000 });
+        expect(reclaimed?.item.id).toBe(itemId);
+      });
+    });
+
+    describe("cancel", () => {
+      it("appends a control entry in log order", async () => {
+        const sessionId = await newSession();
+        await store.intake(sessionId, user("go"));
+        await store.requestCancel(sessionId);
+        const entries = await store.readEntries(sessionId);
+        expect(entries).toHaveLength(2);
+        expect(entries[1]).toMatchObject({ type: "control", control: "cancel", seq: 1 });
+      });
+    });
+
+    describe("commitStep", () => {
+      it("appends output and chains the next item atomically", async () => {
+        const sessionId = await newSession();
+        const { itemId, token } = await startAndClaim(sessionId);
+        await store.commitStep({
+          itemId,
+          token,
+          append: [assistant("thinking…")],
+          next: { kind: "execute_tools" },
+        });
+        const entries = await store.readEntries(sessionId);
+        expect(entries.map((e) => e.seq)).toEqual([0, 1]);
+        const items = await store.listItems(sessionId);
+        expect(items).toHaveLength(2);
+        expect(items[0]).toMatchObject({ id: itemId, status: "done" });
+        expect(items[1]).toMatchObject({ type: "execute_tools", status: "ready" });
+      });
+
+      it("end_run with no pending inputs leaves the session idle", async () => {
+        const sessionId = await newSession();
+        const { itemId, token } = await startAndClaim(sessionId);
+        await store.commitStep({
+          itemId,
+          token,
+          append: [assistant("done")],
+          next: { kind: "end_run", status: "completed" },
+        });
+        const items = await store.listItems(sessionId);
+        expect(items).toHaveLength(1); // the run's end is the NON-creation of a next item
+        expect(items[0]?.status).toBe("done");
+        // Idle again: the next intake starts a run.
+        expect((await store.intake(sessionId, user("next"))).kind).toBe("started");
+      });
+
+      it("end_run auto-chains parked inputs into a new run, in arrival order", async () => {
+        const sessionId = await newSession();
+        const { itemId, token } = await startAndClaim(sessionId);
+        await store.intake(sessionId, user("follow-up 1"));
+        await store.intake(sessionId, user("follow-up 2"));
+        await store.commitStep({
+          itemId,
+          token,
+          append: [assistant("done")],
+          next: { kind: "end_run", status: "completed" },
+        });
+        const entries = await store.readEntries(sessionId);
+        expect(entries.map((e) => (e.type === "message" ? e.message : e.type))).toEqual([
+          user("go"),
+          assistant("done"),
+          user("follow-up 1"),
+          user("follow-up 2"),
+        ]);
+        expect(await store.pendingInputs(sessionId)).toHaveLength(0);
+        const items = await store.listItems(sessionId);
+        expect(items).toHaveLength(2);
+        expect(items[1]).toMatchObject({ type: "inference", status: "ready" });
+      });
+
+      it("end_run cancelled parks pending inputs instead of chaining", async () => {
+        const sessionId = await newSession();
+        const { itemId, token } = await startAndClaim(sessionId);
+        await store.intake(sessionId, user("queued during run"));
+        await store.commitStep({
+          itemId,
+          token,
+          append: [],
+          next: { kind: "end_run", status: "cancelled" },
+        });
+        expect(await store.listItems(sessionId)).toHaveLength(1); // no chain
+        expect(await store.pendingInputs(sessionId)).toHaveLength(1); // parked
+      });
+
+      it("drains consumed inputs atomically with the step", async () => {
+        const sessionId = await newSession();
+        const { itemId, token } = await startAndClaim(sessionId);
+        const queued = await store.intake(sessionId, user("steer!"));
+        expect(queued.kind).toBe("queued");
+        const inputId = queued.kind === "queued" ? queued.inputId : "";
+        await store.commitStep({
+          itemId,
+          token,
+          // Drained steering precedes step output.
+          append: [user("steer!"), assistant("adjusted")],
+          consumeInputs: [inputId],
+          next: { kind: "end_run", status: "completed" },
+        });
+        expect(await store.pendingInputs(sessionId)).toHaveLength(0);
+        expect((await store.readEntries(sessionId)).map((e) => e.seq)).toEqual([0, 1, 2]);
+      });
+
+      it("rejects consuming an unknown or already-consumed input", async () => {
+        const sessionId = await newSession();
+        const { itemId, token } = await startAndClaim(sessionId);
+        await expect(
+          store.commitStep({
+            itemId,
+            token,
+            append: [],
+            consumeInputs: ["nope"],
+            next: { kind: "inference" },
+          }),
+        ).rejects.toThrow();
+      });
+
+      it("resolves an idempotent re-commit of a done item without duplicating", async () => {
+        const sessionId = await newSession();
+        const { itemId, token } = await startAndClaim(sessionId);
+        const commit: CommitStepRequest = {
+          itemId,
+          token,
+          append: [assistant("done")],
+          next: { kind: "end_run", status: "completed" },
+        };
+        await store.commitStep(commit);
+        await store.commitStep(commit); // crash-after-commit recovery
+        expect(await store.readEntries(sessionId)).toHaveLength(2);
+        expect(await store.listItems(sessionId)).toHaveLength(1);
+      });
+
+      it("rejects a commit for an unknown item", async () => {
+        await expect(
+          store.commitStep({
+            itemId: "nope",
+            token: "any",
+            append: [],
+            next: { kind: "inference" },
+          }),
+        ).rejects.toThrow();
+      });
+    });
+
+    describe("the log", () => {
+      it("serves the seq cursor — only entries after the given seq", async () => {
+        const sessionId = await newSession();
+        const { itemId, token } = await startAndClaim(sessionId);
+        await store.commitStep({
+          itemId,
+          token,
+          append: [assistant("done")],
+          next: { kind: "end_run", status: "completed" },
+        });
+        const tail = await store.readEntries(sessionId, 0);
+        expect(tail).toHaveLength(1);
+        expect(tail[0]?.seq).toBe(1);
+        expect(await store.readEntries(sessionId, 1)).toHaveLength(0);
+      });
+
+      it("keeps seq gapless and monotonic across every write path", async () => {
+        const sessionId = await newSession();
+        const { itemId, token } = await startAndClaim(sessionId); // seq 0: user message
+        await store.requestCancel(sessionId); // seq 1: control
+        await store.commitStep({
+          itemId,
+          token,
+          append: [assistant("stopped")], // seq 2
+          next: { kind: "end_run", status: "cancelled" },
+        });
+        await store.intake(sessionId, user("again")); // seq 3
+        const entries = await store.readEntries(sessionId);
+        expect(entries.map((e) => e.seq)).toEqual([0, 1, 2, 3]);
+      });
+    });
+  });
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -12,4 +12,4 @@ export { nextAction } from "./engine/next-action";
 export type { Action, RunEndStatus } from "./engine/next-action";
 export type { Tool, ToolContext, ToolOutcome } from "./engine/tool";
 export type { InferenceProvider, StreamRequest } from "./ports/inference-provider";
-export type { CommitStepRequest, Store } from "./ports/store";
+export type { Claim, CommitStepRequest, LeaseToken, Store } from "./ports/store";

--- a/packages/agent/src/ports/store.ts
+++ b/packages/agent/src/ports/store.ts
@@ -73,19 +73,22 @@ export interface Store {
    * undefined = no work. No type filter — workers dispatch on the
    * claimed item's type. sessionId narrows the scan for the (deferred)
    * driver-per-sandbox topology.
+   *
+   * The returned token is the fencing credential, minted by the store
+   * fresh for every claim (2026-08-12) — uniqueness is structural, not
+   * caller discipline. A re-claim of the same item always issues a new
+   * token, so a previous holder's zombie is fenced by construction.
    */
-  claimItem(req: {
-    owner: string;
-    leaseMs: number;
-    sessionId?: SessionId;
-  }): Promise<WorkItem | undefined>;
+  claimItem(req: { leaseMs: number; sessionId?: SessionId }): Promise<Claim | undefined>;
 
   /**
-   * Extend the lease; false = lease lost, the driver must abort its
-   * step. outputTail is a coarse progress checkpoint (~2s), not the
-   * transcript — the transcript is written once, at commit.
+   * Extend the lease by the duration chosen at claim; false = lease
+   * lost, the driver must abort its step. itemId addresses the item;
+   * the token authorizes the write. (A progress-checkpoint payload was
+   * cut 2026-08-12 — it returns with its first reader, shaped by that
+   * reader's needs.)
    */
-  heartbeat(itemId: ItemId, owner: string, opts?: { outputTail?: string }): Promise<boolean>;
+  heartbeat(itemId: ItemId, token: LeaseToken): Promise<boolean>;
 
   /**
    * Appends a cancel ControlEntry to the log — nothing else. Workers
@@ -109,18 +112,32 @@ export interface Store {
   /**
    * The driver's write path: append the step's output, drain any
    * consumed inputs, and resolve the claimed item — cause and
-   * consequence in one transaction. Fenced like heartbeat: a stale
-   * owner throws. Re-committing a done item resolves idempotently
-   * (crash-after-commit recovery).
+   * consequence in one transaction. Fenced symmetrically with
+   * heartbeat: the commit must carry the claim's token within a live
+   * lease — a stale token OR an expired lease throws, even if no one
+   * has reclaimed the item (strict expiry, 2026-08-12). Late work
+   * is discarded, never merged: after expiry the item's fate belongs
+   * to its next claimer. Re-committing a done item resolves
+   * idempotently (crash-after-commit recovery).
    */
   commitStep(req: CommitStepRequest): Promise<void>;
 
   // P4 adds reaper operations (lease expiry, interrupted-result synthesis).
 }
 
+/** Minted by the store per claim; opaque to callers, checked by equality. */
+export type LeaseToken = string;
+
+/** claimItem's result: the leased item plus its fencing credential. */
+export interface Claim {
+  item: WorkItem;
+  token: LeaseToken;
+}
+
 export interface CommitStepRequest {
   itemId: ItemId;
-  owner: string;
+  /** The claim's credential — itemId addresses, the token authorizes. */
+  token: LeaseToken;
   /** Payloads — the store mints envelopes. Drained steering precedes step output. */
   append: AgentMessage[];
   /** Pending rows whose messages are in `append` — deleted in the same transaction. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,34 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
+  packages/adapters:
+    dependencies:
+      '@funky/agent':
+        specifier: workspace:*
+        version: link:../agent
+      '@funky/core':
+        specifier: workspace:*
+        version: link:../core
+      drizzle-orm:
+        specifier: ^1.0.0-beta.2
+        version: 1.0.0-rc.4-5d5b77c(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)(typebox@1.3.7)(zod@4.4.3)
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
+    devDependencies:
+      '@electric-sql/pglite':
+        specifier: ^0.5.4
+        version: 0.5.4
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
+      pg:
+        specifier: ^8.22.0
+        version: 8.22.0
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+
   packages/agent:
     dependencies:
       '@funky/core':


### PR DESCRIPTION
## Summary

- Add a PostgreSQL-backed implementation of the durable agent Store, including its schema and initial migration.
- Fence every claim with a store-minted token and consistently enforce lease expiry across claiming, heartbeats, and commits.
- Run a shared conformance suite against PGlite and network PostgreSQL, provisioning PostgreSQL in CI.

## Validation

- `pnpm format:check`
- `pnpm typecheck`
- `pnpm -F chaos-tests typecheck`
- Full non-chaos test suite with `STORE_TEST_DATABASE_URL` set