### PR TITLE
Add durable agent driver loop

### DIFF
--- a/packages/adapters/src/store/pg.ts
+++ b/packages/adapters/src/store/pg.ts
@@ -1,6 +1,6 @@
 // The Store port over vanilla postgres. One adapter, many runtimes: the
-// composition root binds `db` to PGlite (tests, local REPL) or a network
-// postgres (compose, k8s, managed) — there is no test/prod adapter split.
+// composition root binds `db` to PGlite (tests) or a network postgres
+// (compose, k8s, managed) — there is no test/prod adapter split.
 //
 // Concurrency discipline:
 // - Per-session write serialization: every writing transaction locks the
@@ -41,7 +41,7 @@ import {
   UserMessage,
   WorkItem,
 } from "@funky/core";
-import type { CommitStepRequest, Store } from "@funky/agent";
+import { type CommitStepRequest, FencedError, type Store } from "@funky/agent";
 import {
   agentConfigs,
   envConfigs,
@@ -233,9 +233,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
     async claimItem(req) {
       return db.transaction(async (tx) => {
         const t = now();
-        // "Expired" has one spelling everywhere: live iff now < leaseExpiresAt.
-        // Equality is dead — heartbeat and commitStep agree, so the instant
-        // the old holder loses authority is the instant a claimer gains it.
+        // "Expired" iff leaseExpiresAt <= now.
         const claimable = or(
           eq(workItems.status, "ready"),
           and(eq(workItems.status, "leased"), lte(workItems.leaseExpiresAt, t)),
@@ -336,13 +334,15 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         if (!item) throw new Error(`commitStep: unknown item ${req.itemId}`);
         if (item.status === "done") {
           if (item.leaseToken !== req.token)
-            throw new Error(`commitStep: fenced — ${req.itemId} was finished under another claim`);
+            throw new FencedError(
+              `commitStep: fenced — ${req.itemId} was finished under another claim`,
+            );
           return; // idempotent re-commit (crash-after-commit recovery)
         }
         if (item.status !== "leased" || item.leaseToken !== req.token)
-          throw new Error(`commitStep: fenced — stale token for ${req.itemId}`);
+          throw new FencedError(`commitStep: fenced — stale token for ${req.itemId}`);
         if (item.leaseExpiresAt === null || item.leaseExpiresAt.getTime() <= now().getTime())
-          throw new Error(`commitStep: fenced — ${req.itemId}'s lease expired before commit`);
+          throw new FencedError(`commitStep: fenced — ${req.itemId}'s lease expired before commit`);
         await lockSession(tx, item.sessionId);
         await appendEntries(
           tx,

--- a/packages/adapters/test/driver.test.ts
+++ b/packages/adapters/test/driver.test.ts
@@ -1,0 +1,345 @@
+// The driver against the real pg store over PGlite — the two halves of
+// the Store port's "two callers" story exercised together: intake on
+// one side, claim → runStep on the other. runStep is the tested unit;
+// runDriver is a trivial policy shell around it, covered for real by
+// the crash-resume suite at the process level. Scripted inference, a
+// real echo tool, and the store's injected clock stand in for the
+// world; tests drive steps one at a time, so almost nothing here waits.
+
+import { readFileSync } from "node:fs";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import type { ProviderEvent, SessionEntry, Usage, UserMessage } from "@funky/core";
+import {
+  type Claim,
+  type DriverDeps,
+  FencedError,
+  type InferenceProvider,
+  runStep,
+  type Store,
+  type StreamRequest,
+  type Tool,
+} from "@funky/agent";
+import { createPgStore, type StoreDb } from "../src";
+
+const ddl = readFileSync(new URL("../migrations/0000_init.sql", import.meta.url), "utf8");
+
+let client: PGlite;
+let store: Store;
+let clock: { advance: (ms: number) => void };
+
+beforeAll(async () => {
+  client = new PGlite();
+  await client.exec(ddl);
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+beforeEach(async () => {
+  await client.exec(
+    "TRUNCATE agent_configs, env_configs, sessions, session_entries, work_items, pending_inputs RESTART IDENTITY CASCADE",
+  );
+  let offsetMs = 0;
+  store = createPgStore(drizzle({ client }) as unknown as StoreDb, {
+    now: () => new Date(Date.now() + offsetMs),
+  });
+  clock = {
+    advance: (ms) => {
+      offsetMs += ms;
+    },
+  };
+});
+
+// --- scripted provider: one script per stream() call, in call order ---
+
+type Step = ProviderEvent | { wait: Promise<void> } | { throw: Error } | "untilAborted";
+
+interface ScriptedProvider extends InferenceProvider {
+  requests: StreamRequest[];
+}
+
+function scriptedProvider(scripts: Step[][]): ScriptedProvider {
+  const requests: StreamRequest[] = [];
+  return {
+    requests,
+    async *stream(req: StreamRequest, signal: AbortSignal): AsyncIterable<ProviderEvent> {
+      const script = scripts[requests.length] ?? [];
+      requests.push(req);
+      for (const step of script) {
+        if (step === "untilAborted") {
+          await new Promise<void>((resolve) => {
+            if (signal.aborted) return resolve();
+            signal.addEventListener("abort", () => resolve(), { once: true });
+          });
+          throw new DOMException("The operation was aborted.", "AbortError");
+        }
+        if ("wait" in step) {
+          await step.wait;
+          continue;
+        }
+        if ("throw" in step) throw step.throw;
+        yield step;
+      }
+    },
+  };
+}
+
+const usage: Usage = { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 };
+
+const sayText = (text: string): Step[] => [
+  { type: "text_start", contentIndex: 0 },
+  { type: "text_delta", contentIndex: 0, delta: text },
+  { type: "text_end", contentIndex: 0 },
+  { type: "done", stopReason: "end_turn", usage },
+];
+
+const callEcho = (text: string): Step[] => [
+  { type: "toolcall_start", contentIndex: 0, toolCallId: "call_1", toolName: "echo" },
+  { type: "toolcall_delta", contentIndex: 0, argsDelta: JSON.stringify({ text }) },
+  { type: "toolcall_end", contentIndex: 0 },
+  { type: "done", stopReason: "tool_use", usage },
+];
+
+// --- fixtures ---
+
+const echo: Tool = {
+  name: "echo",
+  description: "echoes its input",
+  input: z.object({ text: z.string() }),
+  execute: async (args) => ({
+    content: [{ type: "text", text: (args as { text: string }).text }],
+  }),
+};
+
+const echoOnly = new Map([[echo.name, echo]]);
+const noTools = new Map<string, Tool>();
+
+const user = (text: string): UserMessage => ({ role: "user", content: [{ type: "text", text }] });
+
+const inferenceConfig = {
+  provider: "scripted",
+  model: "scripted-1",
+  maxTokens: 512,
+  temperature: 0.2,
+};
+
+async function newSession(): Promise<string> {
+  const agentConfigId = await store.createAgentConfig({
+    inference: inferenceConfig,
+    systemPrompt: "be brief",
+  });
+  const envConfigId = await store.createEnvConfig({});
+  return store.createSession({ agentConfigId, envConfigId });
+}
+
+/** Claim the session's ready item — the tests' stand-in for the loop shell. */
+async function claim(sessionId: string, leaseMs = 60_000): Promise<Claim> {
+  const claimed = await store.claimItem({ leaseMs, sessionId });
+  if (!claimed) throw new Error("expected a claimable item");
+  return claimed;
+}
+
+async function until(cond: () => Promise<boolean> | boolean): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (await cond()) return;
+    await new Promise((resolve) => setTimeout(resolve, 15));
+  }
+  throw new Error("until: condition not reached within 10s");
+}
+
+const messages = (entries: SessionEntry[]) =>
+  entries.filter((entry) => entry.type === "message").map((entry) => entry.message);
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+// --- the scenarios ---
+
+describe("driver steps over the pg store", () => {
+  it("runs a full turn: inference → tools → inference → completion", async () => {
+    const sessionId = await newSession();
+    const provider = scriptedProvider([callEcho("hi"), sayText("done!")]);
+    const deps: DriverDeps = { store, provider, tools: echoOnly };
+
+    await store.intake(sessionId, user("go"));
+    await runStep(deps, await claim(sessionId), 60_000); // inference → tool call
+    await runStep(deps, await claim(sessionId), 60_000); // execute_tools
+    await runStep(deps, await claim(sessionId), 60_000); // inference → end_turn
+    // The run ended: its end is the non-creation of a fourth item.
+    expect(await store.claimItem({ leaseMs: 60_000, sessionId })).toBeUndefined();
+
+    const log = messages(await store.readEntries(sessionId));
+    expect(log.map((m) => m.role)).toEqual(["user", "assistant", "toolResult", "assistant"]);
+    expect(log[2]).toMatchObject({ toolName: "echo", content: [{ type: "text", text: "hi" }] });
+    expect(log[3]).toMatchObject({ stopReason: "end_turn" });
+
+    // The driver assembled the request from the session's config and tools:
+    // model + sampling ride through; provider picked the adapter and stops.
+    expect(provider.requests[0]).toMatchObject({
+      model: "scripted-1",
+      maxTokens: 512,
+      temperature: 0.2,
+    });
+    expect(provider.requests[0]).not.toHaveProperty("provider");
+    expect(provider.requests[0]?.system).toBe("be brief");
+    expect(provider.requests[0]?.tools.map((t) => t.name)).toEqual(["echo"]);
+    expect(provider.requests[1]?.context.map((m) => m.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+    ]);
+  });
+
+  it("drains an input queued before the step as steering, not a follow-up", async () => {
+    const sessionId = await newSession();
+    await store.intake(sessionId, user("go"));
+    const queued = await store.intake(sessionId, user("steer"));
+    expect(queued.kind).toBe("queued");
+
+    const provider = scriptedProvider([sayText("ok")]);
+    await runStep({ store, provider, tools: noTools }, await claim(sessionId), 60_000);
+
+    // Steering shaped the context (appended at the tail)…
+    expect(provider.requests[0]?.context.map((m) => m.role)).toEqual(["user", "user"]);
+    // …rode in the commit before the step's output, and was consumed.
+    const log = messages(await store.readEntries(sessionId));
+    expect(log.map((m) => m.role)).toEqual(["user", "user", "assistant"]);
+    expect(await store.pendingInputs(sessionId)).toHaveLength(0);
+    // One run, one item: steering never chains a new run.
+    expect(await store.listItems(sessionId)).toHaveLength(1);
+  });
+
+  it("auto-chains an input that arrives mid-step into a follow-up run", async () => {
+    const sessionId = await newSession();
+    await store.intake(sessionId, user("go"));
+
+    const gate = deferred();
+    const provider = scriptedProvider([
+      [...sayText("first").slice(0, 3), { wait: gate.promise }, sayText("first")[3] as Step],
+      sayText("second"),
+    ]);
+    const deps: DriverDeps = { store, provider, tools: noTools };
+
+    const inFlight = runStep(deps, await claim(sessionId), 60_000);
+    // Arrive after run 1's inference prep: too late to steer this step.
+    await until(() => provider.requests.length === 1);
+    const queued = await store.intake(sessionId, user("follow-up"));
+    expect(queued.kind).toBe("queued");
+    gate.resolve();
+    await inFlight;
+
+    // The terminal commit chained a second run…
+    await runStep(deps, await claim(sessionId), 60_000);
+
+    // …with the follow-up as an ordinary user entry after run 1's terminal message.
+    const log = messages(await store.readEntries(sessionId));
+    expect(log.map((m) => m.role)).toEqual(["user", "assistant", "user", "assistant"]);
+    expect(provider.requests[1]?.context.map((m) => m.role)).toEqual(["user", "assistant", "user"]);
+    expect(await store.listItems(sessionId)).toHaveLength(2);
+  });
+
+  it("ends a cancelled run at the claim boundary and parks queued inputs", async () => {
+    const sessionId = await newSession();
+    await store.intake(sessionId, user("go"));
+    await store.requestCancel(sessionId);
+    const queued = await store.intake(sessionId, user("while cancelled"));
+    expect(queued.kind).toBe("queued");
+
+    const provider = scriptedProvider([sayText("fresh")]);
+    const deps: DriverDeps = { store, provider, tools: noTools };
+    await runStep(deps, await claim(sessionId), 60_000);
+
+    // The run ended without inference, appending nothing; the queued
+    // input is parked, not chained.
+    expect(provider.requests).toHaveLength(0);
+    expect(await store.readEntries(sessionId)).toHaveLength(2); // user + control
+    expect(await store.pendingInputs(sessionId)).toHaveLength(1);
+
+    // The consumed cancel does not re-fire: the next intake starts a run
+    // that completes normally, draining the parked input as steering.
+    const next = await store.intake(sessionId, user("again"));
+    expect(next.kind).toBe("started");
+    await runStep(deps, await claim(sessionId), 60_000);
+
+    const log = messages(await store.readEntries(sessionId));
+    expect(log[log.length - 1]).toMatchObject({ role: "assistant", stopReason: "end_turn" });
+    expect(provider.requests[0]?.context.map((m) => m.role)).toEqual(["user", "user", "user"]);
+  });
+
+  it("commits a provider failure and ends the run as error — no retry", async () => {
+    const sessionId = await newSession();
+    await store.intake(sessionId, user("go"));
+    const provider = scriptedProvider([[{ throw: new Error("provider exploded") }]]);
+    await runStep({ store, provider, tools: noTools }, await claim(sessionId), 60_000);
+
+    const log = messages(await store.readEntries(sessionId));
+    expect(log).toHaveLength(2);
+    expect(log[1]).toMatchObject({ role: "assistant", stopReason: "error" });
+    expect(provider.requests).toHaveLength(1);
+    expect(await store.claimItem({ leaseMs: 60_000, sessionId })).toBeUndefined();
+  });
+
+  it("drops an interrupted step on lease loss; the next claim re-executes", async () => {
+    const sessionId = await newSession();
+    await store.intake(sessionId, user("go"));
+    const provider = scriptedProvider([["untilAborted"], sayText("recovered")]);
+    const deps: DriverDeps = { store, provider, tools: noTools };
+
+    const inFlight = runStep(deps, await claim(sessionId, 500), 500);
+    await until(() => provider.requests.length === 1);
+    clock.advance(10_000); // the next heartbeat reports the lease lost
+    await inFlight;
+
+    // The aborted attempt left no trace…
+    expect(messages(await store.readEntries(sessionId))).toHaveLength(1);
+    // …and the re-claim (fresh token, expired lease) re-executes cleanly.
+    await runStep(deps, await claim(sessionId), 60_000);
+    const log = messages(await store.readEntries(sessionId));
+    expect(log.map((m) => m.role)).toEqual(["user", "assistant"]);
+    expect(log[1]).toMatchObject({ stopReason: "end_turn" });
+    expect(provider.requests).toHaveLength(2);
+  });
+
+  it("drops the step when the commit is fenced, and the re-claim redoes it", async () => {
+    const sessionId = await newSession();
+    await store.intake(sessionId, user("go"));
+
+    let fencedOnce = false;
+    const fencingStore: Store = {
+      ...store,
+      commitStep: async (req) => {
+        if (!fencedOnce) {
+          fencedOnce = true;
+          throw new FencedError("injected: reclaimed elsewhere");
+        }
+        return store.commitStep(req);
+      },
+    };
+
+    const provider = scriptedProvider([sayText("a"), sayText("b")]);
+    const deps: DriverDeps = { store: fencingStore, provider, tools: noTools };
+
+    // First step's commit is fenced: runStep swallows it and drops the work.
+    await runStep(deps, await claim(sessionId, 300), 300);
+    expect(fencedOnce).toBe(true);
+    expect(messages(await store.readEntries(sessionId))).toHaveLength(1);
+
+    // Expire the dropped claim; the re-claim's step commits for real.
+    clock.advance(1_000);
+    await runStep(deps, await claim(sessionId), 60_000);
+    const log = messages(await store.readEntries(sessionId));
+    expect(log.map((m) => m.role)).toEqual(["user", "assistant"]);
+    expect(log[1]).toMatchObject({ content: [{ type: "text", text: "b" }] });
+    expect(provider.requests).toHaveLength(2);
+  });
+});

--- a/packages/adapters/test/store-conformance.ts
+++ b/packages/adapters/test/store-conformance.ts
@@ -8,7 +8,7 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import type { AssistantMessage, UserMessage } from "@funky/core";
-import type { CommitStepRequest, Store } from "@funky/agent";
+import { type CommitStepRequest, FencedError, type Store } from "@funky/agent";
 
 export interface StoreHarness {
   store: Store;
@@ -246,7 +246,7 @@ export function describeStoreConformance(
             append: [assistant("stale work")],
             next: { kind: "end_run", status: "completed" },
           }),
-        ).rejects.toThrow(/fenced/);
+        ).rejects.toThrow(FencedError);
         await store.commitStep({
           itemId,
           token: reclaimed!.token,
@@ -267,7 +267,7 @@ export function describeStoreConformance(
             append: [assistant("at the wire")],
             next: { kind: "end_run", status: "completed" },
           }),
-        ).rejects.toThrow(/fenced/);
+        ).rejects.toThrow(FencedError);
         const reclaimed = await store.claimItem({ leaseMs: 60_000 }); // …and a claimer is in
         expect(reclaimed?.item.id).toBe(itemId);
       });
@@ -283,7 +283,7 @@ export function describeStoreConformance(
             append: [assistant("late")],
             next: { kind: "end_run", status: "completed" },
           }),
-        ).rejects.toThrow(/fenced/);
+        ).rejects.toThrow(FencedError);
         // The rejected commit rolled back whole — nothing landed.
         expect(await store.readEntries(sessionId)).toHaveLength(1);
         // After expiry the item's fate belongs to its next claimer.

--- a/packages/agent/src/driver/README.md
+++ b/packages/agent/src/driver/README.md
@@ -1,0 +1,41 @@
+# driver/
+
+The claim → step → commit loop — the impure half of the harness, and
+the Store port's second caller (`intake` is the api's write path;
+`commitStep` is ours). Two exports, mechanism and policy:
+
+- **`runStep(deps, claim, leaseMs)`** — one claim → at most one commit.
+  The tested unit: the driver integration suite (in
+  `packages/adapters`) drives it step by step against the real pg store.
+- **`runDriver(deps, opts)`** — the production shell `apps/worker`
+  hosts: claim, step, repeat, sleep on miss. It takes no stop signal and
+  never returns — funky is cloud-only (2026-08-09), scale-down is
+  removing the container, and the crash rule makes that safe. The shell
+  is covered at the process level by the crash-resume suite.
+
+What lives here is what neither the engine nor a host may own:
+
+- **Leases.** The heartbeat keeper extends the claim every `leaseMs / 3`;
+  a lost — or merely unreachable — lease aborts the step. This is the
+  only mid-step abort in the system, and it is internal: it bounds a
+  zombie's side effects and spend, never correctness.
+- **The crash rule.** An interrupted step is never committed. A dying
+  worker commits nothing mid-step; the lease expires and the next
+  claimer re-executes from the unchanged log — shutdown IS a crash, so
+  crash-safety is exercised on every shutdown and no drain logic exists.
+  `FencedError` on commit is the same rule from the other side — the
+  item's fate belongs to another claim; drop the work, claim again.
+- **Boundary cancel checks.** `cancelRequested` reads the log's tail:
+  while an item is open, only cancels (and decoration entries) can
+  trail the last message entry — a theorem of the one-open-item
+  invariant — so a trailing cancel addresses the current run and
+  anything behind the last message entry is already answered. Checked
+  at the claim boundary (skip the step) and the commit boundary (end
+  the run whatever the step produced). Valid only while holding the
+  open item; a consumer with no claim needs the run-liveness derivation
+  this deliberately isn't.
+- **v1 policies, explicit and small.** Provider errors commit and end
+  the run as `"error"` (no retry yet); idle claiming polls
+  (`idlePollMs`) until a Notifier port exists.
+
+The engine decides, the store persists, the driver survives.

--- a/packages/agent/src/driver/loop.ts
+++ b/packages/agent/src/driver/loop.ts
@@ -1,0 +1,294 @@
+// The driver — the claim → step → commit loop, and the Store port's
+// second caller (intake is the api's write path; commitStep is ours).
+// Two exports, mechanism and policy: runStep is one claim → at most one
+// commit, the unit the driver tests exercise directly; runDriver is the
+// production shell a worker process hosts — claim, step, repeat — and
+// it ends only with the process. Funky is cloud-only: scale-down is
+// removing the container, and the crash rule makes that safe, so there
+// is deliberately no stop signal and no graceful-drain path.
+//
+// The rule the durability story rests on: an interrupted step is never
+// committed. A dying worker — SIGKILL, OOM, node loss — commits nothing
+// mid-step; the lease expires and the next claimer re-executes from the
+// unchanged log. Shutdown IS a crash, so crash-safety is exercised on
+// every shutdown. FencedError on commit is the same rule from the other
+// side: the item's fate belongs to another claim now — drop the work,
+// claim again. The only mid-step abort is internal: the heartbeat
+// losing (or failing to reach) the lease aborts the in-flight provider
+// stream and tool calls, bounding a zombie's side effects and spend.
+//
+// Cancellation is checked at step boundaries, never mid-step:
+// requestCancel appends a control entry and the log's order scopes
+// which run it addresses (see cancelRequested). At the claim boundary a
+// pending cancel skips the step entirely; at the commit boundary it
+// ends the run whatever the step produced. v1 cancel latency is
+// therefore one step.
+
+import type {
+  AgentMessage,
+  ItemId,
+  ProviderEvent,
+  SessionEntry,
+  SessionId,
+  ToolCall,
+} from "@funky/core";
+import { buildContext } from "../engine/build-context";
+import { executeTools, type ToolUpdate } from "../engine/execute-tools";
+import { inference } from "../engine/inference";
+import { type Action, nextAction } from "../engine/next-action";
+import { type Tool, toToolSpec } from "../engine/tool";
+import type { InferenceProvider } from "../ports/inference-provider";
+import {
+  type Claim,
+  type CommitStepRequest,
+  FencedError,
+  type LeaseToken,
+  type Store,
+} from "../ports/store";
+
+export interface DriverDeps {
+  store: Store;
+  provider: InferenceProvider;
+  /** Executables by name; projected to specs at the inference edge. */
+  tools: Map<string, Tool>;
+  /** Decoration taps forwarded to the engine steps. Fire-and-forget. */
+  onDelta?: (event: ProviderEvent) => void;
+  onUpdate?: (update: ToolUpdate) => void;
+}
+
+export interface DriverOptions {
+  /** Lease duration per claim; each heartbeat extends by this. Default 60s. */
+  leaseMs?: number;
+  /** Delay between empty claim attempts. Default 1s. Poll-only until a
+   *  Notifier port exists. */
+  idlePollMs?: number;
+  /** Narrow claims to one session (the driver-per-sandbox topology). */
+  sessionId?: SessionId;
+}
+
+/**
+ * Claim and run work items until the process dies — there is no other
+ * exit, by design. Store failures outside the fence propagate; restart
+ * policy belongs to the host (in the cloud: the container restarting).
+ */
+export async function runDriver(deps: DriverDeps, opts: DriverOptions = {}): Promise<never> {
+  const leaseMs = opts.leaseMs ?? 60_000;
+  const idlePollMs = opts.idlePollMs ?? 1_000;
+  while (true) {
+    const claim = await deps.store.claimItem({ leaseMs, sessionId: opts.sessionId });
+    if (!claim) {
+      await sleep(idlePollMs);
+      continue;
+    }
+    await runStep(deps, claim, leaseMs);
+  }
+}
+
+/**
+ * One claim → at most one commit; the tested unit of the driver — the
+ * loop above is policy around it. Holds the lease via heartbeats for
+ * the step's duration; a lost lease aborts the step, and an interrupted
+ * step is dropped, never committed.
+ */
+export async function runStep(deps: DriverDeps, claim: Claim, leaseMs: number): Promise<void> {
+  const { store } = deps;
+  const { item, token } = claim;
+
+  // Fires only on lease loss — "stop working; this step will not commit".
+  const step = new AbortController();
+  const stopHeartbeat = startHeartbeat(store, item.id, token, leaseMs, () => step.abort());
+
+  try {
+    const entries = bySeq(await store.readEntries(item.sessionId));
+
+    // Claim boundary: a pending cancel ends the run without running the
+    // step. Nothing is appended — for an execute_tools item this is the
+    // cancel-before-execute path; buildContext synthesizes the interrupted
+    // results whenever the log is next read. "cancelled" parks pending
+    // inputs for the next intake instead of chaining.
+    if (cancelRequested(entries)) {
+      await store.commitStep({
+        itemId: item.id,
+        token,
+        append: [],
+        next: { kind: "end_run", status: "cancelled" },
+      });
+      return;
+    }
+
+    let append: AgentMessage[];
+    let consumeInputs: string[] | undefined;
+    // The last message this step commits — the log's tail once the
+    // commit lands, and the shape nextAction dispatches on.
+    let tail: AgentMessage;
+
+    if (item.type === "inference") {
+      const session = await store.getSession(item.sessionId);
+      if (!session) throw new Error(`driver: claimed item for unknown session ${item.sessionId}`);
+      const config = await store.getAgentConfig(session.agentConfigId);
+      if (!config) throw new Error(`driver: session ${item.sessionId} has no agent config`);
+      // Drain-at-inference-prep is what makes these inputs steering: they
+      // shape this context, ride in this commit before the step's output,
+      // and are consumed by it.
+      const pending = await store.pendingInputs(item.sessionId);
+      const steering = pending.map((input) => input.message);
+      // config.inference.provider picked the adapter at composition and
+      // is not part of the request.
+      const message = await inference(
+        { provider: deps.provider, onDelta: deps.onDelta },
+        {
+          model: config.inference.model,
+          maxTokens: config.inference.maxTokens,
+          temperature: config.inference.temperature,
+          system: config.systemPrompt,
+          context: buildContext(entries, steering),
+          tools: [...deps.tools.values()].map(toToolSpec),
+        },
+        step.signal,
+      );
+      append = [...steering, message];
+      consumeInputs = pending.map((input) => input.id);
+      tail = message;
+    } else {
+      const calls = tailCalls(entries);
+      const results = await executeTools(
+        { tools: deps.tools, onUpdate: deps.onUpdate },
+        { calls },
+        step.signal,
+      );
+      append = results;
+      // All results share one fate; the last one becomes the tail.
+      const last = results[results.length - 1];
+      if (!last) throw new Error("driver: executeTools returned no results");
+      tail = last;
+    }
+
+    // An interrupted step is never committed (see header). The lease will
+    // expire and the next claimer re-executes from the unchanged log.
+    if (step.signal.aborted) return;
+
+    // Commit boundary: pick up cancels that landed during the step. Only
+    // control entries can land mid-step — our open item bars intake from
+    // appending messages — so the context cannot have grown behind us.
+    const lastSeq = entries.length > 0 ? entries[entries.length - 1]?.seq : undefined;
+    const delta = bySeq(await store.readEntries(item.sessionId, lastSeq));
+    const action = nextAction(tail, cancelRequested([...entries, ...delta]));
+
+    await store.commitStep({
+      itemId: item.id,
+      token,
+      append,
+      consumeInputs,
+      next: toNext(action),
+    });
+  } catch (err) {
+    if (err instanceof FencedError) return; // reclaimed elsewhere — drop, claim again
+    throw err;
+  } finally {
+    stopHeartbeat();
+  }
+}
+
+/**
+ * Does a cancel address the run of the currently open item? A tail
+ * read, not a history walk — a theorem of the one-open-item invariant:
+ * while an item is open, message entries have exactly one writer, the
+ * transaction that created that item (intake's started branch requires
+ * no open item; commitStep requires holding the lease). So everything
+ * after the log's last message entry can only be cancels and decoration
+ * (custom, compaction); a trailing cancel necessarily landed during
+ * this run, and a cancel behind the last message entry was already
+ * answered or addressed a run that is over.
+ *
+ * Precondition: call only while holding the session's open item — the
+ * claim IS the run-liveness bit this function would otherwise have to
+ * re-derive. Consumers without a claim (a UI, the reaper, the verdict
+ * fold) need that derivation; it gets built with them.
+ *
+ * Best-effort edge, inherent to log-order scoping: a cancel that
+ * commits between the driver's boundary read and its commitStep lands
+ * behind the next batch and is not seen; re-cancelling works.
+ */
+export function cancelRequested(entries: SessionEntry[]): boolean {
+  const ordered = bySeq(entries);
+  for (let i = ordered.length - 1; i >= 0; i--) {
+    const entry = ordered[i];
+    if (entry?.type === "control") return true;
+    if (entry?.type === "message") return false;
+  }
+  return false;
+}
+
+/** The calls an execute_tools item exists to run: the log tail's. */
+function tailCalls(entries: SessionEntry[]): ToolCall[] {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (entry?.type !== "message") continue;
+    if (entry.message.role === "assistant") {
+      const calls = entry.message.content.filter((part) => part.type === "toolCall");
+      if (calls.length > 0) return calls;
+    }
+    break;
+  }
+  throw new Error("driver: execute_tools item but no tool calls at the log tail");
+}
+
+function toNext(action: Action): CommitStepRequest["next"] {
+  switch (action.kind) {
+    case "inference":
+      return { kind: "inference" };
+    case "execute_tools":
+      return { kind: "execute_tools" };
+    case "end_run":
+      return { kind: "end_run", status: action.status };
+    case "error":
+      // v1 retry policy: none. The provider failure is committed — the
+      // message in `append` says why — and the run ends as "error".
+      return { kind: "end_run", status: "error" };
+  }
+}
+
+/**
+ * Extend the lease every leaseMs / 3 until stopped. A heartbeat that
+ * throws gets the lost-lease response: abort the step and let the lease
+ * decide — if it was actually alive, the item is simply re-executed
+ * after expiry. Wasted work, never wrong work.
+ */
+function startHeartbeat(
+  store: Store,
+  itemId: ItemId,
+  token: LeaseToken,
+  leaseMs: number,
+  onLost: () => void,
+): () => void {
+  const period = Math.max(1, Math.floor(leaseMs / 3));
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout>;
+  const beat = async (): Promise<void> => {
+    let alive = false;
+    try {
+      alive = await store.heartbeat(itemId, token);
+    } catch {
+      alive = false;
+    }
+    if (stopped) return;
+    if (!alive) {
+      onLost();
+      return;
+    }
+    timer = setTimeout(() => void beat(), period);
+  };
+  timer = setTimeout(() => void beat(), period);
+  return () => {
+    stopped = true;
+    clearTimeout(timer);
+  };
+}
+
+function bySeq(entries: SessionEntry[]): SessionEntry[] {
+  return [...entries].sort((a, b) => a.seq - b.seq);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/agent/src/engine/README.md
+++ b/packages/agent/src/engine/README.md
@@ -1,10 +1,10 @@
 # engine/
 
 The step functions of the harness — pure, no I/O of their own. Their
-caller is the **driver**: the claim → step → commit loop, written as a
-library and hosted by a worker process (`apps/worker`) or a local CLI —
-the Store port's "two callers" are the api (intake) and this loop
-(commitStep). Nothing here knows that loop exists.
+caller is the **driver** (`../driver`): the claim → step → commit loop,
+written as a library and hosted by a worker process (`apps/worker`) —
+the Store port's "two callers" are the api (intake) and that loop
+(commitStep). Nothing here knows the loop exists.
 
 | function       | shape                                                            |
 | -------------- | ---------------------------------------------------------------- |

--- a/packages/agent/src/engine/build-context.ts
+++ b/packages/agent/src/engine/build-context.ts
@@ -17,6 +17,11 @@ import { interruptedResult } from "./execute-tools";
  *   a constraint on the future compactor; nothing enforces it yet.
  *   TODO(compaction): with multiple compaction entries (recompaction),
  *   the highest upToSeq governs; earlier ones are themselves superseded.
+ *   TODO(compaction): compaction edits the model's view, never the
+ *   control plane — a compactor must not compact past an unanswered
+ *   cancel (or control-plane reads must stay full-log), else a pending
+ *   cancel could vanish from a windowed read. Trailing cancels are safe
+ *   (they sit after the compaction entry); see cancelRequested.
  * - assistant messages with stopReason aborted/error stay in the log but
  *   are dropped here
  * - tool calls and results must pair up, repaired in both directions: a

--- a/packages/agent/src/engine/inference.ts
+++ b/packages/agent/src/engine/inference.ts
@@ -17,9 +17,13 @@ export interface InferenceDeps {
   onDelta?: (e: ProviderEvent) => void;
 }
 
-/** Serializable data only — loggable, replayable. */
+/** Serializable data only — loggable, replayable. The engine reads only
+ *  `model` (stamped onto the message); the sampling fields ride through
+ *  for the provider adapter to map. */
 export interface InferenceRequest {
   model: string;
+  maxTokens?: number;
+  temperature?: number;
   system: string;
   context: AgentMessage[];
   tools: ToolSpec[];

--- a/packages/agent/src/engine/tool.ts
+++ b/packages/agent/src/engine/tool.ts
@@ -1,5 +1,5 @@
-import type { z } from "zod";
-import type { ImageContent, JsonValue, TextContent } from "@funky/core";
+import { z } from "zod";
+import type { ImageContent, JsonValue, TextContent, ToolSpec } from "@funky/core";
 
 /**
  * The executable half of a tool — deliberately a different type from
@@ -14,6 +14,19 @@ export interface Tool {
   /** Zod schema for arguments; projected to the spec's JSON Schema at the edge. */
   input: z.ZodType;
   execute(args: unknown, ctx: ToolContext): Promise<ToolOutcome>;
+}
+
+/**
+ * The one projection from executable to declaration — "the edge" the type
+ * comments on both sides refer to. `io: "input"` because the spec
+ * describes what the model writes: the schema's pre-transform input side.
+ */
+export function toToolSpec(tool: Tool): ToolSpec {
+  return {
+    name: tool.name,
+    description: tool.description,
+    inputSchema: z.toJSONSchema(tool.input, { io: "input" }) as Record<string, JsonValue>,
+  };
 }
 
 /**

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,3 +1,5 @@
+export { cancelRequested, runDriver, runStep } from "./driver/loop";
+export type { DriverDeps, DriverOptions } from "./driver/loop";
 export { buildContext } from "./engine/build-context";
 export { inference } from "./engine/inference";
 export type { InferenceDeps, InferenceRequest } from "./engine/inference";
@@ -10,6 +12,8 @@ export type {
 } from "./engine/execute-tools";
 export { nextAction } from "./engine/next-action";
 export type { Action, RunEndStatus } from "./engine/next-action";
+export { toToolSpec } from "./engine/tool";
 export type { Tool, ToolContext, ToolOutcome } from "./engine/tool";
 export type { InferenceProvider, StreamRequest } from "./ports/inference-provider";
+export { FencedError } from "./ports/store";
 export type { Claim, CommitStepRequest, LeaseToken, Store } from "./ports/store";

--- a/packages/agent/src/ports/README.md
+++ b/packages/agent/src/ports/README.md
@@ -1,9 +1,9 @@
 # ports/
 
 The contracts the engine and the driver (the claim → step → commit loop
-hosted by a worker — see `../engine/README.md`) consume. Implementations
-live downstream in `packages/adapters`; this directory defines what they
-must be, never what they are.
+in `../driver`) consume. Implementations live downstream in
+`packages/adapters`; this directory defines what they must be, never
+what they are.
 
 | port                | one line                                                |
 | ------------------- | ------------------------------------------------------- |
@@ -29,5 +29,5 @@ Why the ports live here and not elsewhere:
 
 Adapters are held to these contracts behaviorally, not just structurally:
 the Store conformance suite (in `packages/adapters`) runs against every
-implementation, memory and pg alike. If a port's jsdoc promises it, the
+implementation on every binding. If a port's jsdoc promises it, the
 suite pins it.

--- a/packages/agent/src/ports/inference-provider.ts
+++ b/packages/agent/src/ports/inference-provider.ts
@@ -5,6 +5,12 @@ import type { AgentMessage, ProviderEvent, ToolSpec } from "@funky/core";
  * one request in, one live stream of increments out.
  *
  * Contract for implementations:
+ * - Map the request's sampling fields (`maxTokens`, `temperature`, …) to
+ *   vendor parameters; an absent field means the vendor's own default,
+ *   never a harness default. The config's `provider` field is consumed
+ *   before this port — it picks the adapter (the composition root today;
+ *   a registry or mux when a second vendor exists) and stops there, so a
+ *   stream() implementation never sees it.
  * - Translate `req` to the vendor wire format and the vendor's stream events
  *   to `ProviderEvent`s, one by one, as they arrive. Nothing else: no fold
  *   (the engine assembles the message), no retries (driver policy), no
@@ -20,9 +26,13 @@ export interface InferenceProvider {
   stream(req: StreamRequest, signal: AbortSignal): AsyncIterable<ProviderEvent>;
 }
 
-/** Serializable data only — the (req, signal) split mirrors the engine's. */
+/** Serializable data only — the (req, signal) split mirrors the engine's.
+ *  model/maxTokens/temperature come from the persisted InferenceConfig;
+ *  its `provider` field is not here — it picked the adapter and stopped. */
 export interface StreamRequest {
   model: string;
+  maxTokens?: number;
+  temperature?: number;
   system: string;
   context: AgentMessage[];
   tools: ToolSpec[];

--- a/packages/agent/src/ports/store.ts
+++ b/packages/agent/src/ports/store.ts
@@ -125,6 +125,20 @@ export interface Store {
   // P4 adds reaper operations (lease expiry, interrupted-result synthesis).
 }
 
+/**
+ * Thrown by commitStep when the fence rejects the write — a stale token
+ * or an expired lease. A typed class because the driver must tell this
+ * apart from infrastructure failure: fenced means the item's fate belongs
+ * to another claim, so the correct response is to drop the step's work
+ * and claim again; anything else means the commit's outcome is unknown.
+ */
+export class FencedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FencedError";
+  }
+}
+
 /** Minted by the store per claim; opaque to callers, checked by equality. */
 export type LeaseToken = string;
 

--- a/packages/agent/test/cancel-requested.test.ts
+++ b/packages/agent/test/cancel-requested.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import type { AgentMessage, SessionEntry } from "@funky/core";
+import { cancelRequested } from "../src/driver/loop";
+
+// cancelRequested is a tail read: while an item is open, only cancels and
+// decoration entries can trail the log's last message entry (the
+// one-open-item invariant), so the last message-or-control entry decides.
+// These logs are the shapes reachable at a driver boundary — the function
+// is only defined for callers holding the open item.
+
+const TS = "2026-08-15T00:00:00.000Z";
+
+const user = (): AgentMessage => ({ role: "user", content: [{ type: "text", text: "go" }] });
+
+const assistant = (withCall = false): AgentMessage => ({
+  role: "assistant",
+  content: withCall
+    ? [{ type: "toolCall", id: "call_1", name: "echo", arguments: {} }]
+    : [{ type: "text", text: "ok" }],
+  model: "m",
+  stopReason: withCall ? "tool_use" : "end_turn",
+});
+
+const toolResult = (): AgentMessage => ({
+  role: "toolResult",
+  toolCallId: "call_1",
+  toolName: "echo",
+  content: [{ type: "text", text: "ok" }],
+  isError: false,
+});
+
+function log(...items: (AgentMessage | "cancel" | "custom" | "compact")[]): SessionEntry[] {
+  return items.map((item, i) => {
+    if (item === "cancel") {
+      return { id: `e${i}`, seq: i, timestamp: TS, type: "control", control: "cancel" };
+    }
+    if (item === "custom") {
+      return { id: `e${i}`, seq: i, timestamp: TS, type: "custom", namespace: "app", data: null };
+    }
+    if (item === "compact") {
+      return { id: `e${i}`, seq: i, timestamp: TS, type: "compaction", summary: "s", upToSeq: i };
+    }
+    return { id: `e${i}`, seq: i, timestamp: TS, type: "message", message: item };
+  });
+}
+
+describe("cancelRequested", () => {
+  it("is false when the tail is the batch that created the open item", () => {
+    expect(cancelRequested([])).toBe(false);
+    expect(cancelRequested(log(user()))).toBe(false);
+    expect(cancelRequested(log(user(), assistant(true)))).toBe(false);
+    expect(cancelRequested(log(user(), assistant(true), toolResult()))).toBe(false);
+  });
+
+  it("is true when cancels trail the last message entry", () => {
+    expect(cancelRequested(log(user(), "cancel"))).toBe(true);
+    expect(cancelRequested(log(user(), assistant(true), "cancel"))).toBe(true);
+    expect(cancelRequested(log(user(), assistant(true), toolResult(), "cancel"))).toBe(true);
+    expect(cancelRequested(log(user(), "cancel", "cancel"))).toBe(true);
+  });
+
+  it("treats a cancel behind a later message entry as answered", () => {
+    // A consumed cancel is always covered before the next consultation:
+    // the run it ended creates no item, so the next open item arrives with
+    // intake's user entry (or a commit batch) after the cancel in the log.
+    expect(cancelRequested(log(user(), "cancel", user()))).toBe(false);
+    expect(cancelRequested(log(user(), assistant(), "cancel", user()))).toBe(false);
+  });
+
+  it("skips decoration entries when reading the tail", () => {
+    expect(cancelRequested(log(user(), "cancel", "custom"))).toBe(true);
+    expect(cancelRequested(log(user(), "custom"))).toBe(false);
+    // Compaction edits the model's view of history, not the control
+    // plane — it never answers (or voids) a pending cancel.
+    expect(cancelRequested(log(user(), "cancel", "compact"))).toBe(true);
+    expect(cancelRequested(log(user(), "compact"))).toBe(false);
+  });
+
+  it("orders by seq, not array position", () => {
+    const entries = log(user(), "cancel", user());
+    entries.reverse();
+    expect(cancelRequested(entries)).toBe(false);
+  });
+});

--- a/packages/core/src/inference.ts
+++ b/packages/core/src/inference.ts
@@ -2,10 +2,13 @@ import { z } from "zod";
 
 /**
  * The inference vocabulary — the declarative description of how a
- * session's inference runs: which model serves it and how to sample. The
- * InferenceProvider adapter is the interpreter: `provider` routes within
- * it ("anthropic", "openai", …) the way env recipes route within the
- * SandboxProvider — core does not enumerate vendors.
+ * session's inference runs: which provider serves it, which model, and
+ * how to sample. `provider` ("anthropic", "openai", …) names the
+ * interpreting adapter and is consumed picking it (2026-08-15) — the
+ * composition root today, a registry when a second vendor exists; it is
+ * not part of the StreamRequest. model/maxTokens/temperature ride the
+ * request for the chosen adapter to map. Core does not enumerate
+ * vendors.
  */
 export const InferenceConfig = z.object({
   provider: z.string(),


### PR DESCRIPTION
Adds the durable claim → step → commit driver with lease heartbeats, fencing, cancellation boundaries, steering drains, and follow-up run chaining. It projects executable tools into provider schemas and carries persisted model sampling settings through inference requests. The PostgreSQL integration suite now covers full turns, cancellation, provider failures, lease loss, and fenced commits; validation passed with typecheck, formatting, and the core, agent, and adapter test suites.