### PR TITLE
Add AI SDK inference adapter

### DIFF
--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@funky/agent": "workspace:*",
     "@funky/core": "workspace:*",
+    "ai": "^7.0.0",
     "drizzle-orm": "^1.0.0-beta.2",
     "zod": "^4.0.0"
   },

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,2 +1,4 @@
+export { createAiSdkProvider } from "./inference/aisdk";
+export type { AiSdkProviderOptions } from "./inference/aisdk";
 export { createPgStore } from "./store/pg";
 export type { PgStoreOptions, StoreDb } from "./store/pg";

--- a/packages/adapters/src/inference/aisdk.ts
+++ b/packages/adapters/src/inference/aisdk.ts
@@ -1,0 +1,326 @@
+// The InferenceProvider port over the Vercel AI SDK — one adapter, N
+// vendors.
+// The composition root's vendor choice arrives as the injected
+// `languageModel` factory (e.g. `createAnthropic({ apiKey })`), so this
+// file depends only on the vendor-neutral `ai` package.
+//
+// A dumb translator, per the port contract: StreamRequest → one
+// streamText call, TextStreamPart → ProviderEvent one by one, and every
+// failure is a throw — error and abort parts become exceptions, the
+// engine assigns stopReasons. maxRetries is 0: retry policy belongs to
+// the driver (v1: none). The SDK's parts address blocks by string id;
+// the port addresses them by contentIndex — ids are mapped to indexes
+// in order of first appearance, which is also the block order the
+// engine's fold reconstructs.
+//
+// The one vendor-specific patch: Anthropic's extended-thinking protocol
+// requires signatures (and redacted payloads) to round-trip verbatim,
+// and the AI SDK carries them in the `anthropic` provider-metadata
+// namespace — signatures arrive as empty reasoning deltas, redacted
+// blocks as reasoning-start metadata, and replay wants the same values
+// back as reasoning-part providerOptions. Capturing and re-attaching
+// that namespace is inert for every other vendor.
+
+import {
+  type AssistantModelMessage,
+  type FinishReason,
+  jsonSchema,
+  type LanguageModel,
+  type LanguageModelUsage,
+  type ModelMessage,
+  type ProviderMetadata,
+  streamText,
+  tool,
+  type ToolResultPart,
+  type ToolSet,
+} from "ai";
+import type {
+  AgentMessage,
+  ProviderStopReason,
+  ThinkingContent,
+  ToolResultMessage,
+  ToolSpec,
+  Usage,
+} from "@funky/core";
+import type { InferenceProvider, StreamRequest } from "@funky/agent";
+
+export interface AiSdkProviderOptions {
+  /** The request's model string → an AI SDK model. This injection IS the
+   *  composition root's vendor choice — a vendor package's provider
+   *  function (`createAnthropic({ apiKey })`) fits directly. */
+  languageModel: (modelId: string) => LanguageModel;
+}
+
+export function createAiSdkProvider(opts: AiSdkProviderOptions): InferenceProvider {
+  return {
+    async *stream(req: StreamRequest, signal: AbortSignal) {
+      const result = streamText({
+        model: opts.languageModel(req.model),
+        // ai@7 takes the system prompt as `instructions`, never in messages.
+        instructions: req.system === "" ? undefined : req.system,
+        messages: toModelMessages(req.context),
+        tools: toToolSet(req.tools),
+        maxOutputTokens: req.maxTokens,
+        temperature: req.temperature,
+        abortSignal: signal,
+        maxRetries: 0,
+      });
+
+      interface Block {
+        index: number;
+        signature?: string;
+        redactedData?: string;
+      }
+      const blocks = new Map<string, Block>();
+      let nextIndex = 0;
+      const open = (kind: string, id: string): Block => {
+        const block: Block = { index: nextIndex++ };
+        blocks.set(`${kind}:${id}`, block);
+        return block;
+      };
+      const at = (kind: string, id: string): Block => {
+        const block = blocks.get(`${kind}:${id}`);
+        if (!block) throw new Error(`aisdk: ${kind} part for unopened block ${id}`);
+        return block;
+      };
+
+      let finish:
+        | { finishReason: FinishReason; raw: string | undefined; usage: LanguageModelUsage }
+        | undefined;
+
+      for await (const part of result.stream) {
+        switch (part.type) {
+          case "text-start":
+            yield { type: "text_start" as const, contentIndex: open("text", part.id).index };
+            break;
+          case "text-delta":
+            yield {
+              type: "text_delta" as const,
+              contentIndex: at("text", part.id).index,
+              delta: part.text,
+            };
+            break;
+          case "text-end":
+            yield { type: "text_end" as const, contentIndex: at("text", part.id).index };
+            break;
+          case "reasoning-start": {
+            const block = open("reasoning", part.id);
+            block.redactedData = anthropicString(part.providerMetadata, "redactedData");
+            yield { type: "thinking_start" as const, contentIndex: block.index };
+            break;
+          }
+          case "reasoning-delta": {
+            const block = at("reasoning", part.id);
+            const signature = anthropicString(part.providerMetadata, "signature");
+            if (signature !== undefined) block.signature = signature;
+            if (part.text !== "") {
+              yield {
+                type: "thinking_delta" as const,
+                contentIndex: block.index,
+                delta: part.text,
+              };
+            }
+            break;
+          }
+          case "reasoning-end": {
+            const block = at("reasoning", part.id);
+            const signature =
+              anthropicString(part.providerMetadata, "signature") ?? block.signature;
+            yield block.redactedData !== undefined
+              ? {
+                  type: "thinking_end" as const,
+                  contentIndex: block.index,
+                  signature: block.redactedData,
+                  redacted: true,
+                }
+              : { type: "thinking_end" as const, contentIndex: block.index, signature };
+            break;
+          }
+          case "tool-input-start":
+            // The part's id IS the vendor's tool call id.
+            yield {
+              type: "toolcall_start" as const,
+              contentIndex: open("tool", part.id).index,
+              toolCallId: part.id,
+              toolName: part.toolName,
+            };
+            break;
+          case "tool-input-delta":
+            yield {
+              type: "toolcall_delta" as const,
+              contentIndex: at("tool", part.id).index,
+              argsDelta: part.delta,
+            };
+            break;
+          case "tool-input-end":
+            yield { type: "toolcall_end" as const, contentIndex: at("tool", part.id).index };
+            break;
+          case "finish":
+            finish = {
+              finishReason: part.finishReason,
+              raw: part.rawFinishReason,
+              usage: part.totalUsage,
+            };
+            break;
+          case "error":
+            throw part.error instanceof Error ? part.error : new Error(String(part.error));
+          case "abort":
+            throw new DOMException("The operation was aborted.", "AbortError");
+          default:
+            // start / step markers, assembled tool-call parts (already
+            // streamed as input parts), sources, files, raw chunks.
+            break;
+        }
+      }
+
+      // No finish part → the generator just ends, and the engine treats a
+      // stream without done as an error.
+      if (finish) {
+        yield {
+          type: "done" as const,
+          stopReason: toStopReason(finish.finishReason, finish.raw),
+          usage: toUsage(finish.usage),
+        };
+      }
+    },
+  };
+}
+
+function toToolSet(specs: ToolSpec[]): ToolSet {
+  return Object.fromEntries(
+    specs.map((spec) => [
+      spec.name,
+      // No execute: the model's calls come back to the driver; nothing
+      // runs inside the SDK.
+      tool({
+        description: spec.description,
+        inputSchema: jsonSchema(spec.inputSchema as Parameters<typeof jsonSchema>[0]),
+      }),
+    ]),
+  );
+}
+
+type AssistantPart = Exclude<AssistantModelMessage["content"], string>[number];
+
+function toModelMessages(context: AgentMessage[]): ModelMessage[] {
+  const out: ModelMessage[] = [];
+  for (const message of context) {
+    switch (message.role) {
+      case "user":
+        out.push({
+          role: "user",
+          content: message.content.map((part) =>
+            part.type === "text"
+              ? { type: "text" as const, text: part.text }
+              : { type: "image" as const, image: part.data, mediaType: part.mimeType },
+          ),
+        });
+        break;
+      case "assistant": {
+        const parts: AssistantPart[] = [];
+        for (const part of message.content) {
+          if (part.type === "text") {
+            // Vendors reject empty text blocks; an empty part carries nothing.
+            if (part.text !== "") parts.push({ type: "text", text: part.text });
+          } else if (part.type === "thinking") {
+            parts.push(toReasoningPart(part));
+          } else {
+            parts.push({
+              type: "tool-call",
+              toolCallId: part.id,
+              toolName: part.name,
+              input: part.arguments,
+            });
+          }
+        }
+        if (parts.length > 0) out.push({ role: "assistant", content: parts });
+        break;
+      }
+      case "toolResult":
+        out.push({
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: message.toolCallId,
+              toolName: message.toolName,
+              output: toToolOutput(message),
+            },
+          ],
+        });
+        break;
+    }
+  }
+  return out;
+}
+
+/** Replay of a thinking part: signed → an Anthropic thinking block,
+ *  redacted → redacted_thinking (the opaque payload rides in
+ *  `thinkingSignature`, see core). @ai-sdk/anthropic reads exactly these
+ *  providerOptions keys; unsigned parts ride as plain reasoning text. */
+function toReasoningPart(part: ThinkingContent): AssistantPart {
+  if (part.redacted && part.thinkingSignature !== undefined) {
+    return {
+      type: "reasoning",
+      text: "",
+      providerOptions: { anthropic: { redactedData: part.thinkingSignature } },
+    };
+  }
+  if (part.thinkingSignature !== undefined) {
+    return {
+      type: "reasoning",
+      text: part.thinking,
+      providerOptions: { anthropic: { signature: part.thinkingSignature } },
+    };
+  }
+  return { type: "reasoning", text: part.thinking };
+}
+
+function toToolOutput(message: ToolResultMessage): ToolResultPart["output"] {
+  const images = message.content.some((part) => part.type === "image");
+  if (!images) {
+    const value = message.content.map((part) => (part.type === "text" ? part.text : "")).join("\n");
+    return message.isError ? { type: "error-text", value } : { type: "text", value };
+  }
+  // The content form has no error variant; isError is dropped for image
+  // results — the text of the result still says what failed.
+  return {
+    type: "content",
+    value: message.content.map((part) =>
+      part.type === "text"
+        ? { type: "text" as const, text: part.text }
+        : { type: "image-data" as const, data: part.data, mediaType: part.mimeType },
+    ),
+  };
+}
+
+function toStopReason(reason: FinishReason, raw: string | undefined): ProviderStopReason {
+  switch (reason) {
+    case "stop":
+      return "end_turn";
+    case "tool-calls":
+      return "tool_use";
+    case "length":
+      return "max_tokens";
+    default:
+      // Outside the port's vocabulary (content-filter, error, other): no
+      // silent coercion — the throw becomes an error-stopped message.
+      throw new Error(`provider finished with ${reason}${raw ? ` (${raw})` : ""}`);
+  }
+}
+
+function toUsage(usage: LanguageModelUsage): Usage {
+  const reasoning = usage.outputTokenDetails.reasoningTokens;
+  return {
+    input: usage.inputTokens ?? 0,
+    output: usage.outputTokens ?? 0,
+    cacheRead: usage.inputTokenDetails.cacheReadTokens ?? 0,
+    cacheWrite: usage.inputTokenDetails.cacheWriteTokens ?? 0,
+    ...(reasoning !== undefined ? { reasoning } : {}),
+  };
+}
+
+function anthropicString(metadata: ProviderMetadata | undefined, key: string): string | undefined {
+  const value = metadata?.["anthropic"]?.[key];
+  return typeof value === "string" ? value : undefined;
+}

--- a/packages/adapters/test/aisdk.test.ts
+++ b/packages/adapters/test/aisdk.test.ts
@@ -1,0 +1,384 @@
+// The AI SDK adapter against a spec-level mock model — the real
+// streamText pipeline runs between the mock and the adapter, so these
+// tests cover the adapter's actual seam: spec stream parts in,
+// ProviderEvents out, and the request mapping the mock records
+// (doStreamCalls) on the way in. The Anthropic thinking-signature
+// shapes mirror what @ai-sdk/anthropic actually emits and reads
+// (signature as an empty reasoning-delta's metadata, redactedData on
+// reasoning-start, providerOptions on replayed reasoning parts).
+
+import { describe, expect, it } from "vitest";
+import { MockLanguageModelV3, convertArrayToReadableStream, simulateReadableStream } from "ai/test";
+import type { AgentMessage, ProviderEvent } from "@funky/core";
+import type { InferenceProvider, StreamRequest } from "@funky/agent";
+import { createAiSdkProvider } from "../src";
+
+// The spec-level stream part type, derived through the mock's own option
+// type so the test needs no direct @ai-sdk/provider dependency.
+type DoStreamOption = NonNullable<
+  NonNullable<ConstructorParameters<typeof MockLanguageModelV3>[0]>["doStream"]
+>;
+type SpecPart =
+  Extract<DoStreamOption, { stream: ReadableStream<unknown> }>["stream"] extends ReadableStream<
+    infer T
+  >
+    ? T
+    : never;
+
+const usage = {
+  inputTokens: { total: 100, noCache: 60, cacheRead: 30, cacheWrite: 10 },
+  outputTokens: { total: 20, text: 15, reasoning: 5 },
+};
+
+const finish = (unified: "stop" | "tool-calls" | "length" | "content-filter"): SpecPart => ({
+  type: "finish",
+  finishReason: { unified, raw: undefined },
+  usage,
+});
+
+function providerWith(parts: SpecPart[]): {
+  provider: InferenceProvider;
+  model: MockLanguageModelV3;
+} {
+  const model = new MockLanguageModelV3({
+    doStream: {
+      stream: convertArrayToReadableStream<SpecPart>([
+        { type: "stream-start", warnings: [] },
+        ...parts,
+      ]),
+    },
+  });
+  return { provider: createAiSdkProvider({ languageModel: () => model }), model };
+}
+
+const request = (overrides: Partial<StreamRequest> = {}): StreamRequest => ({
+  model: "model-1",
+  system: "be brief",
+  context: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+  tools: [],
+  ...overrides,
+});
+
+const live = (): AbortSignal => new AbortController().signal;
+
+async function collect(provider: InferenceProvider, req: StreamRequest): Promise<ProviderEvent[]> {
+  const events: ProviderEvent[] = [];
+  for await (const event of provider.stream(req, live())) events.push(event);
+  return events;
+}
+
+describe("aisdk adapter: stream mapping", () => {
+  it("maps a text stream to indexed events and folds usage into done", async () => {
+    const { provider } = providerWith([
+      { type: "text-start", id: "0" },
+      { type: "text-delta", id: "0", delta: "Hello" },
+      { type: "text-delta", id: "0", delta: " world" },
+      { type: "text-end", id: "0" },
+      finish("stop"),
+    ]);
+
+    expect(await collect(provider, request())).toEqual([
+      { type: "text_start", contentIndex: 0 },
+      { type: "text_delta", contentIndex: 0, delta: "Hello" },
+      { type: "text_delta", contentIndex: 0, delta: " world" },
+      { type: "text_end", contentIndex: 0 },
+      {
+        type: "done",
+        stopReason: "end_turn",
+        usage: { input: 100, output: 20, cacheRead: 30, cacheWrite: 10, reasoning: 5 },
+      },
+    ]);
+  });
+
+  it("maps a tool-call stream; the part id is the tool call id", async () => {
+    const { provider } = providerWith([
+      { type: "tool-input-start", id: "call_9", toolName: "echo" },
+      { type: "tool-input-delta", id: "call_9", delta: '{"text":' },
+      { type: "tool-input-delta", id: "call_9", delta: '"hi"}' },
+      { type: "tool-input-end", id: "call_9" },
+      finish("tool-calls"),
+    ]);
+
+    const events = await collect(provider, request());
+    expect(events).toEqual([
+      { type: "toolcall_start", contentIndex: 0, toolCallId: "call_9", toolName: "echo" },
+      { type: "toolcall_delta", contentIndex: 0, argsDelta: '{"text":' },
+      { type: "toolcall_delta", contentIndex: 0, argsDelta: '"hi"}' },
+      { type: "toolcall_end", contentIndex: 0 },
+      expect.objectContaining({ type: "done", stopReason: "tool_use" }),
+    ]);
+  });
+
+  it("captures the thinking signature from an empty reasoning-delta and delivers it at thinking_end", async () => {
+    const { provider } = providerWith([
+      { type: "reasoning-start", id: "0" },
+      { type: "reasoning-delta", id: "0", delta: "because" },
+      {
+        type: "reasoning-delta",
+        id: "0",
+        delta: "",
+        providerMetadata: { anthropic: { signature: "sig-1" } },
+      },
+      { type: "reasoning-end", id: "0" },
+      { type: "text-start", id: "1" },
+      { type: "text-delta", id: "1", delta: "ok" },
+      { type: "text-end", id: "1" },
+      finish("stop"),
+    ]);
+
+    const events = await collect(provider, request());
+    expect(events.slice(0, 3)).toEqual([
+      { type: "thinking_start", contentIndex: 0 },
+      { type: "thinking_delta", contentIndex: 0, delta: "because" },
+      { type: "thinking_end", contentIndex: 0, signature: "sig-1" },
+    ]);
+    // The following text block gets the next contentIndex.
+    expect(events[3]).toEqual({ type: "text_start", contentIndex: 1 });
+  });
+
+  it("maps a redacted thinking block to an empty pair carrying the opaque payload", async () => {
+    const { provider } = providerWith([
+      {
+        type: "reasoning-start",
+        id: "0",
+        providerMetadata: { anthropic: { redactedData: "opaque-payload" } },
+      },
+      { type: "reasoning-end", id: "0" },
+      finish("stop"),
+    ]);
+
+    const events = await collect(provider, request());
+    expect(events.slice(0, 2)).toEqual([
+      { type: "thinking_start", contentIndex: 0 },
+      { type: "thinking_end", contentIndex: 0, signature: "opaque-payload", redacted: true },
+    ]);
+  });
+
+  it("throws on an error part instead of emitting an event", async () => {
+    const { provider } = providerWith([
+      { type: "text-start", id: "0" },
+      { type: "error", error: new Error("overloaded (529)") },
+    ]);
+
+    await expect(collect(provider, request())).rejects.toThrow("overloaded (529)");
+  });
+
+  it("throws on outcomes outside the port's vocabulary", async () => {
+    const { provider } = providerWith([finish("content-filter")]);
+    await expect(collect(provider, request())).rejects.toThrow("content-filter");
+  });
+
+  it("throws when the model stream ends without finishing", async () => {
+    const { provider } = providerWith([
+      { type: "text-start", id: "0" },
+      { type: "text-delta", id: "0", delta: "Hel" },
+      { type: "text-end", id: "0" },
+    ]);
+
+    // streamText guarantees a finish event, synthesizing 'other' for a
+    // truncated model stream — which lands in the vocabulary throw, so
+    // every truncation path reaches the engine as an exception.
+    await expect(collect(provider, request())).rejects.toThrow("other");
+  });
+
+  it("surfaces an abort as a throw when the signal fires mid-stream", async () => {
+    const model = new MockLanguageModelV3({
+      doStream: {
+        stream: simulateReadableStream<SpecPart>({
+          chunks: [
+            { type: "stream-start", warnings: [] },
+            { type: "text-start", id: "0" },
+            { type: "text-delta", id: "0", delta: "Hel" },
+            { type: "text-delta", id: "0", delta: "lo" },
+            { type: "text-end", id: "0" },
+            finish("stop"),
+          ] satisfies SpecPart[],
+          chunkDelayInMs: 20,
+        }),
+      },
+    });
+    const provider = createAiSdkProvider({ languageModel: () => model });
+
+    const controller = new AbortController();
+    const events: ProviderEvent[] = [];
+    await expect(
+      (async () => {
+        for await (const event of provider.stream(request(), controller.signal)) {
+          events.push(event);
+          if (event.type === "text_delta") controller.abort();
+        }
+      })(),
+    ).rejects.toThrow();
+    expect(events.some((event) => event.type === "done")).toBe(false);
+  });
+});
+
+describe("aisdk adapter: request mapping", () => {
+  it("passes model, sampling, system, and tool specs through to the SDK call", async () => {
+    const { provider, model } = providerWith([finish("stop")]);
+    const inputSchema = {
+      type: "object",
+      properties: { text: { type: "string" } },
+      required: ["text"],
+    };
+
+    await collect(
+      provider,
+      request({
+        model: "model-x",
+        maxTokens: 512,
+        temperature: 0.2,
+        tools: [{ name: "echo", description: "echoes", inputSchema }],
+      }),
+    );
+
+    const call = model.doStreamCalls[0]!;
+    expect(call.maxOutputTokens).toBe(512);
+    expect(call.temperature).toBe(0.2);
+    expect(call.prompt[0]).toEqual({ role: "system", content: "be brief" });
+    expect(call.tools).toEqual([
+      expect.objectContaining({ type: "function", name: "echo", description: "echoes" }),
+    ]);
+    expect((call.tools?.[0] as { inputSchema: unknown }).inputSchema).toMatchObject(inputSchema);
+  });
+
+  it("leaves absent sampling fields absent — the vendor's defaults, never a harness default", async () => {
+    const { provider, model } = providerWith([finish("stop")]);
+    await collect(provider, request());
+
+    const call = model.doStreamCalls[0]!;
+    expect(call.maxOutputTokens).toBeUndefined();
+    expect(call.temperature).toBeUndefined();
+  });
+
+  it("round-trips the context: thinking signatures, tool pairs, redacted blocks", async () => {
+    const context: AgentMessage[] = [
+      { role: "user", content: [{ type: "text", text: "go" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "because", thinkingSignature: "sig-1" },
+          { type: "text", text: "running echo" },
+          { type: "toolCall", id: "call_1", name: "echo", arguments: { text: "hi" } },
+        ],
+        model: "model-1",
+        stopReason: "tool_use",
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "echo",
+        content: [{ type: "text", text: "hi" }],
+        isError: false,
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "", thinkingSignature: "opaque", redacted: true },
+          { type: "text", text: "done" },
+        ],
+        model: "model-1",
+        stopReason: "end_turn",
+      },
+    ];
+
+    const { provider, model } = providerWith([finish("stop")]);
+    await collect(provider, request({ context }));
+
+    // prompt[0] is the system message; the context follows.
+    const prompt = model.doStreamCalls[0]!.prompt.slice(1);
+    expect(prompt).toEqual([
+      { role: "user", content: [{ type: "text", text: "go" }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "reasoning",
+            text: "because",
+            providerOptions: { anthropic: { signature: "sig-1" } },
+          },
+          { type: "text", text: "running echo" },
+          { type: "tool-call", toolCallId: "call_1", toolName: "echo", input: { text: "hi" } },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call_1",
+            toolName: "echo",
+            output: { type: "text", value: "hi" },
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "reasoning",
+            text: "",
+            providerOptions: { anthropic: { redactedData: "opaque" } },
+          },
+          { type: "text", text: "done" },
+        ],
+      },
+    ]);
+  });
+
+  it("marks failed tool results as error output and filters empty text parts", async () => {
+    const context: AgentMessage[] = [
+      { role: "user", content: [{ type: "text", text: "go" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "" },
+          { type: "toolCall", id: "call_1", name: "echo", arguments: {} },
+        ],
+        model: "model-1",
+        stopReason: "tool_use",
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "echo",
+        content: [{ type: "text", text: "boom" }],
+        isError: true,
+      },
+    ];
+
+    const { provider, model } = providerWith([finish("stop")]);
+    await collect(provider, request({ context }));
+
+    const prompt = model.doStreamCalls[0]!.prompt.slice(1);
+    expect(prompt[1]).toEqual({
+      role: "assistant",
+      content: [{ type: "tool-call", toolCallId: "call_1", toolName: "echo", input: {} }],
+    });
+    expect(prompt[2]).toMatchObject({
+      role: "tool",
+      content: [expect.objectContaining({ output: { type: "error-text", value: "boom" } })],
+    });
+  });
+
+  it("resolves the model through the injected factory with the request's model string", async () => {
+    const requested: string[] = [];
+    const model = new MockLanguageModelV3({
+      doStream: {
+        stream: convertArrayToReadableStream<SpecPart>([
+          { type: "stream-start", warnings: [] },
+          finish("stop"),
+        ]),
+      },
+    });
+    const provider = createAiSdkProvider({
+      languageModel: (modelId) => {
+        requested.push(modelId);
+        return model;
+      },
+    });
+
+    await collect(provider, request({ model: "claude-x" }));
+    expect(requested).toEqual(["claude-x"]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       '@funky/core':
         specifier: workspace:*
         version: link:../core
+      ai:
+        specifier: ^7.0.0
+        version: 7.0.22(zod@4.4.3)
       drizzle-orm:
         specifier: ^1.0.0-beta.2
         version: 1.0.0-rc.4-5d5b77c(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)(typebox@1.3.7)(zod@4.4.3)


### PR DESCRIPTION
Adds a vendor-neutral AI SDK implementation of the agent inference provider, including stream event, stop reason, usage, tool, image, and abort/error translation. Preserves Anthropic thinking signatures and redacted reasoning payloads across persisted context replay. Exports the adapter, adds the AI SDK dependency, and covers request and stream mapping with focused tests; the full workspace test suite, typecheck, formatting, and diff checks pass.