### PR TITLE
Add E2B sandbox provider

### DIFF
--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -14,6 +14,7 @@
     "@funky/core": "workspace:*",
     "ai": "^7.0.0",
     "drizzle-orm": "^1.0.0-beta.2",
+    "e2b": "^2.33.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,4 +1,6 @@
 export { createAiSdkProvider } from "./inference/aisdk";
 export type { AiSdkProviderOptions } from "./inference/aisdk";
+export { createE2bProvider } from "./sandbox/e2b";
+export type { E2bProviderOptions } from "./sandbox/e2b";
 export { createPgStore } from "./store/pg";
 export type { PgStoreOptions, StoreDb } from "./store/pg";

--- a/packages/adapters/src/sandbox/e2b.ts
+++ b/packages/adapters/src/sandbox/e2b.ts
@@ -1,0 +1,165 @@
+// The SandboxProvider port over E2B — every method a thin veneer on the
+// SDK call it names. `connect` needs no translation at all: e2b's
+// `Sandbox.connect` already has the port's contract — reattach, reviving
+// a paused sandbox in place, with the TTL only extended. Two spots do
+// translate:
+//
+// - The SDK's own `lifecycle.onTimeout` default is "kill", the port's is
+//   "pause", so create always passes the action explicitly.
+// - `commands.run` throws CommandExitError on a non-zero exit; the port
+//   wants a result. The catch converts. A command-deadline TimeoutError
+//   also settles as a result (see settledResult for the discrimination).
+//   Every other throw counts as the sandbox being unreachable: one
+//   transparent reconnect (which revives a TTL-paused sandbox) and
+//   retry, then the error propagates.
+//
+// E2B enforces every NetworkPolicy variant (allowOut takes hostnames;
+// allowInternetAccess: false is deny-all), so the port's reject-when-
+// unenforceable clause never triggers here.
+
+import { CommandExitError, Sandbox as E2bSandbox, TimeoutError } from "e2b";
+import type { SandboxInfo as E2bSandboxInfo, SandboxOpts } from "e2b";
+import type { NetworkPolicy } from "@funky/core";
+import type {
+  CommandResult,
+  CreateSandboxOptions,
+  RunOptions,
+  Sandbox,
+  SandboxInfo,
+  SandboxProvider,
+} from "@funky/agent";
+
+export interface E2bProviderOptions {
+  /** Defaults to the E2B_API_KEY environment variable. */
+  apiKey?: string;
+}
+
+export function createE2bProvider(options?: E2bProviderOptions): SandboxProvider {
+  const connection = { apiKey: options?.apiKey };
+
+  return {
+    async create(opts?: CreateSandboxOptions): Promise<Sandbox> {
+      const sandbox = await E2bSandbox.create({
+        ...connection,
+        timeoutMs: opts?.timeoutMs,
+        lifecycle: { onTimeout: opts?.lifecycle ?? "pause" },
+        metadata: opts?.metadata,
+        ...toNetworkOpts(opts?.network),
+      });
+      return wrap(sandbox, connection);
+    },
+
+    async connect(sandboxId: string): Promise<Sandbox> {
+      return wrap(await E2bSandbox.connect(sandboxId, connection), connection);
+    },
+
+    async list(filter?: { metadata?: Record<string, string> }): Promise<SandboxInfo[]> {
+      const paginator = E2bSandbox.list({
+        ...connection,
+        query: filter?.metadata ? { metadata: filter.metadata } : undefined,
+      });
+      const infos: SandboxInfo[] = [];
+      while (paginator.hasNext) {
+        for (const info of await paginator.nextItems()) infos.push(toInfo(info));
+      }
+      return infos;
+    },
+  };
+}
+
+function wrap(initial: E2bSandbox, connection: { apiKey?: string }): Sandbox {
+  let sandbox = initial;
+  const sandboxId = initial.sandboxId;
+
+  return {
+    sandboxId,
+
+    async getInfo(): Promise<SandboxInfo> {
+      return toInfo(await E2bSandbox.getInfo(sandboxId, connection));
+    },
+
+    async run(command: string, opts?: RunOptions): Promise<CommandResult> {
+      try {
+        return toResult(await exec(sandbox, command, opts));
+      } catch (error) {
+        const settled = settledResult(error);
+        if (settled) return settled;
+        sandbox = await E2bSandbox.connect(sandboxId, connection);
+        try {
+          return toResult(await exec(sandbox, command, opts));
+        } catch (retryError) {
+          const retried = settledResult(retryError);
+          if (retried) return retried;
+          throw retryError;
+        }
+      }
+    },
+
+    async readFile(path: string): Promise<Uint8Array> {
+      return sandbox.files.read(path, { format: "bytes" });
+    },
+
+    async writeFile(path: string, data: string | Uint8Array): Promise<void> {
+      // e2b's write takes string | ArrayBuffer | Blob | ReadableStream —
+      // no Uint8Array — so bytes are copied into a fresh ArrayBuffer.
+      await sandbox.files.write(path, typeof data === "string" ? data : toArrayBuffer(data));
+    },
+
+    async pause(): Promise<void> {
+      await sandbox.pause();
+    },
+
+    async kill(): Promise<void> {
+      await sandbox.kill();
+    },
+  };
+}
+
+function exec(sandbox: E2bSandbox, command: string, opts?: RunOptions) {
+  return sandbox.commands.run(command, {
+    cwd: opts?.cwd,
+    timeoutMs: opts?.timeoutMs,
+    onStdout: opts?.onStdout,
+    onStderr: opts?.onStderr,
+  });
+}
+
+function settledResult(error: unknown): CommandResult | undefined {
+  if (error instanceof CommandExitError) {
+    return { stdout: error.stdout, stderr: error.stderr, exitCode: error.exitCode };
+  }
+  // The SDK raises one TimeoutError class for four causes, told apart
+  // only by message: the command exceeding its own `timeoutMs`
+  // ("exceeding 'timeoutMs'"), a request exceeding `requestTimeoutMs`,
+  // the sandbox hitting its TTL, and the sandbox dying mid-request.
+  // Only the first is the command's own outcome (exit 124, the
+  // timeout(1) convention — rerunning a command that ran too long would
+  // double the damage). The other three mean the sandbox is unreachable
+  // and must fall through to the reconnect, which is what revives a
+  // TTL-paused sandbox. The live suite's timeout test fails loudly if
+  // an SDK rewording ever breaks the match.
+  if (error instanceof TimeoutError && error.message.includes("exceeding 'timeoutMs'")) {
+    return { stdout: "", stderr: error.message, exitCode: 124 };
+  }
+  return undefined;
+}
+
+function toResult(result: { stdout: string; stderr: string; exitCode: number }): CommandResult {
+  return { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode };
+}
+
+function toInfo(info: E2bSandboxInfo): SandboxInfo {
+  return { sandboxId: info.sandboxId, state: info.state, metadata: info.metadata };
+}
+
+function toNetworkOpts(policy?: NetworkPolicy): Partial<SandboxOpts> {
+  if (policy === undefined || policy.type === "unrestricted") return {};
+  if (policy.type === "none") return { allowInternetAccess: false };
+  return { network: { allowOut: policy.domains } };
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}

--- a/packages/adapters/test/e2b-live.test.ts
+++ b/packages/adapters/test/e2b-live.test.ts
@@ -1,0 +1,104 @@
+// The e2b adapter against real sandboxes — the behavior a mock can only
+// assert by fiat: exit codes settling as results, byte round-trips,
+// in-sandbox timeouts, metadata listing, and the pause → connect-revives
+// → filesystem-survives cycle. Runs only when E2B_API_KEY is set
+// (deliberate opt-in — every run creates a real sandbox):
+//
+//   E2B_API_KEY=... pnpm --filter @funky/adapters test e2b-live
+//
+// One sandbox serves the whole suite, serially; its TTL is lifecycle
+// "kill" so an aborted run leaves no orphan behind.
+
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it, test } from "vitest";
+import type { Sandbox, SandboxProvider } from "@funky/agent";
+import { createE2bProvider } from "../src/sandbox/e2b";
+
+const apiKey = process.env.E2B_API_KEY;
+
+if (!apiKey) {
+  describe.skip("e2b sandbox provider (live)", () => {
+    it("skipped — set E2B_API_KEY to run", () => {});
+  });
+} else {
+  describe("e2b sandbox provider (live)", () => {
+    const marker = `funky-e2b-live-${randomUUID()}`;
+    let provider: SandboxProvider;
+    let sandbox: Sandbox;
+
+    beforeAll(async () => {
+      provider = createE2bProvider({ apiKey });
+      sandbox = await provider.create({
+        timeoutMs: 300_000,
+        lifecycle: "kill",
+        metadata: { funkySuite: marker },
+      });
+    }, 120_000);
+
+    afterAll(async () => {
+      await sandbox?.kill().catch(() => {});
+    }, 60_000);
+
+    test("runs commands and settles non-zero exits as results", async () => {
+      const ok = await sandbox.run("echo hello");
+      expect(ok.exitCode).toBe(0);
+      expect(ok.stdout).toContain("hello");
+
+      const failed = await sandbox.run("echo boom >&2; exit 7");
+      expect(failed.exitCode).toBe(7);
+      expect(failed.stderr).toContain("boom");
+    }, 60_000);
+
+    test("honors cwd and streams output taps", async () => {
+      const chunks: string[] = [];
+      const result = await sandbox.run("pwd", { cwd: "/tmp", onStdout: (c) => chunks.push(c) });
+      expect(result.stdout.trim()).toBe("/tmp");
+      expect(chunks.join("")).toContain("/tmp");
+    }, 60_000);
+
+    test("bounds a runaway command by the in-sandbox timeout", async () => {
+      const result = await sandbox.run("sleep 30", { timeoutMs: 2_000 });
+      expect(result.exitCode).not.toBe(0);
+    }, 60_000);
+
+    test("round-trips text and binary through writeFile/readFile", async () => {
+      await sandbox.writeFile("/home/user/notes.txt", "written by funky\n");
+      const text = new TextDecoder().decode(await sandbox.readFile("/home/user/notes.txt"));
+      expect(text).toBe("written by funky\n");
+
+      const bytes = new Uint8Array([0, 1, 2, 255, 128, 0, 42]);
+      await sandbox.writeFile("/home/user/blob.bin", bytes);
+      expect(Array.from(await sandbox.readFile("/home/user/blob.bin"))).toEqual(Array.from(bytes));
+    }, 60_000);
+
+    test("lists by metadata equality", async () => {
+      const infos = await provider.list({ metadata: { funkySuite: marker } });
+      expect(infos.map((info) => info.sandboxId)).toEqual([sandbox.sandboxId]);
+      expect(infos[0]?.state).toBe("running");
+      expect(infos[0]?.metadata.funkySuite).toBe(marker);
+    }, 60_000);
+
+    test("pause keeps the filesystem and connect revives", async () => {
+      await sandbox.writeFile("/home/user/persist.txt", "survives pause\n");
+      await sandbox.pause();
+
+      const paused = await provider.list({ metadata: { funkySuite: marker } });
+      expect(paused[0]?.state).toBe("paused");
+
+      const revived = await provider.connect(sandbox.sandboxId);
+      expect(revived.sandboxId).toBe(sandbox.sandboxId);
+      const text = new TextDecoder().decode(await revived.readFile("/home/user/persist.txt"));
+      expect(text).toBe("survives pause\n");
+
+      // Idempotent on a running sandbox.
+      const again = await provider.connect(sandbox.sandboxId);
+      expect((await again.getInfo()).state).toBe("running");
+      sandbox = revived;
+    }, 240_000);
+
+    test("kill removes the sandbox from list", async () => {
+      await sandbox.kill();
+      await expect(provider.list({ metadata: { funkySuite: marker } })).resolves.toEqual([]);
+    }, 60_000);
+  });
+}

--- a/packages/adapters/test/e2b.test.ts
+++ b/packages/adapters/test/e2b.test.ts
@@ -1,0 +1,238 @@
+// The e2b adapter's translation layer, pinned against a mocked SDK: the
+// explicit lifecycle default (the SDK's own is "kill"), the NetworkPolicy
+// mapping, exit/timeout errors settling as results, the one-reconnect
+// recovery, and the Uint8Array → ArrayBuffer copy. The real SDK is
+// exercised by the key-gated live suite in e2b-live.test.ts.
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createE2bProvider } from "../src/sandbox/e2b";
+
+const mocks = vi.hoisted(() => {
+  class CommandExitError extends Error {
+    constructor(
+      readonly exitCode: number,
+      readonly stdout: string,
+      readonly stderr: string,
+    ) {
+      super(`exit status ${exitCode}`);
+    }
+  }
+  class TimeoutError extends Error {}
+  return {
+    CommandExitError,
+    TimeoutError,
+    create: vi.fn(),
+    connect: vi.fn(),
+    getInfo: vi.fn(),
+    list: vi.fn(),
+  };
+});
+
+vi.mock("e2b", () => ({
+  CommandExitError: mocks.CommandExitError,
+  TimeoutError: mocks.TimeoutError,
+  Sandbox: class {
+    static create = mocks.create;
+    static connect = mocks.connect;
+    static getInfo = mocks.getInfo;
+    static list = mocks.list;
+  },
+}));
+
+function fakeSandbox(overrides?: { run?: ReturnType<typeof vi.fn> }) {
+  return {
+    sandboxId: "sbx_1",
+    commands: { run: overrides?.run ?? vi.fn() },
+    files: { read: vi.fn(), write: vi.fn() },
+    pause: vi.fn(),
+    kill: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("createE2bProvider", () => {
+  test("create passes the port's pause default explicitly — the SDK's own onTimeout default is kill", async () => {
+    mocks.create.mockResolvedValue(fakeSandbox());
+    const provider = createE2bProvider();
+
+    await provider.create();
+    expect(mocks.create).toHaveBeenLastCalledWith(
+      expect.objectContaining({ lifecycle: { onTimeout: "pause" } }),
+    );
+
+    await provider.create({ timeoutMs: 60_000, lifecycle: "kill", metadata: { sessionId: "s1" } });
+    expect(mocks.create).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        timeoutMs: 60_000,
+        lifecycle: { onTimeout: "kill" },
+        metadata: { sessionId: "s1" },
+      }),
+    );
+  });
+
+  test("create maps every NetworkPolicy variant", async () => {
+    mocks.create.mockResolvedValue(fakeSandbox());
+    const provider = createE2bProvider();
+
+    await provider.create({ network: { type: "unrestricted" } });
+    expect(mocks.create.mock.lastCall?.[0]).not.toHaveProperty("allowInternetAccess");
+    expect(mocks.create.mock.lastCall?.[0]).not.toHaveProperty("network");
+
+    await provider.create({ network: { type: "none" } });
+    expect(mocks.create.mock.lastCall?.[0]).toMatchObject({ allowInternetAccess: false });
+
+    await provider.create({ network: { type: "allowlist", domains: ["api.example.com"] } });
+    expect(mocks.create.mock.lastCall?.[0]).toMatchObject({
+      network: { allowOut: ["api.example.com"] },
+    });
+  });
+
+  test("connect rides e2b's auto-resuming connect — no state check first", async () => {
+    const provider = createE2bProvider();
+    mocks.connect.mockResolvedValue(fakeSandbox());
+
+    await provider.connect("sbx_1");
+    expect(mocks.getInfo).not.toHaveBeenCalled();
+    expect(mocks.connect).toHaveBeenCalledWith("sbx_1", expect.anything());
+  });
+
+  test("list drains every page and maps to the port's info shape", async () => {
+    const pages = [
+      [{ sandboxId: "a", state: "running", metadata: { sessionId: "s1" }, extra: "dropped" }],
+      [{ sandboxId: "b", state: "paused", metadata: {} }],
+    ];
+    mocks.list.mockReturnValue({
+      get hasNext() {
+        return pages.length > 0;
+      },
+      nextItems: vi.fn(async () => pages.shift()),
+    });
+    const provider = createE2bProvider();
+
+    const infos = await provider.list({ metadata: { sessionId: "s1" } });
+    expect(mocks.list).toHaveBeenCalledWith(
+      expect.objectContaining({ query: { metadata: { sessionId: "s1" } } }),
+    );
+    expect(infos).toEqual([
+      { sandboxId: "a", state: "running", metadata: { sessionId: "s1" } },
+      { sandboxId: "b", state: "paused", metadata: {} },
+    ]);
+  });
+});
+
+describe("sandbox.run", () => {
+  async function createdSandbox(run: ReturnType<typeof vi.fn>) {
+    mocks.create.mockResolvedValue(fakeSandbox({ run }));
+    return createE2bProvider().create();
+  }
+
+  test("a non-zero exit settles as a result without reconnecting", async () => {
+    const run = vi.fn().mockRejectedValue(new mocks.CommandExitError(7, "partial", "boom"));
+    const sandbox = await createdSandbox(run);
+
+    await expect(sandbox.run("false")).resolves.toEqual({
+      stdout: "partial",
+      stderr: "boom",
+      exitCode: 7,
+    });
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+
+  test("a command-deadline timeout settles as exit 124 without retrying", async () => {
+    const message =
+      "[deadline_exceeded] the operation timed out: This error is likely due to exceeding 'timeoutMs'";
+    const run = vi.fn().mockRejectedValue(new mocks.TimeoutError(message));
+    const sandbox = await createdSandbox(run);
+
+    await expect(sandbox.run("sleep 99", { timeoutMs: 10 })).resolves.toEqual({
+      stdout: "",
+      stderr: message,
+      exitCode: 124,
+    });
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+
+  test("a sandbox-death timeout reconnects instead of settling", async () => {
+    const run = vi
+      .fn()
+      .mockRejectedValue(
+        new mocks.TimeoutError(
+          "[unavailable] error: The sandbox was killed or reached its end of life while the request was in flight.",
+        ),
+      );
+    const sandbox = await createdSandbox(run);
+    const revivedRun = vi.fn().mockResolvedValue({ stdout: "revived", stderr: "", exitCode: 0 });
+    mocks.connect.mockResolvedValue(fakeSandbox({ run: revivedRun }));
+
+    await expect(sandbox.run("echo hi")).resolves.toEqual({
+      stdout: "revived",
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(mocks.connect).toHaveBeenCalledWith("sbx_1", expect.anything());
+  });
+
+  test("an unreachable sandbox gets one reconnect-and-retry", async () => {
+    const run = vi.fn().mockRejectedValue(new Error("fetch failed"));
+    const sandbox = await createdSandbox(run);
+    const revivedRun = vi
+      .fn()
+      .mockResolvedValue({ stdout: "after revive", stderr: "", exitCode: 0 });
+    mocks.connect.mockResolvedValue(fakeSandbox({ run: revivedRun }));
+
+    await expect(sandbox.run("echo hi")).resolves.toEqual({
+      stdout: "after revive",
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(mocks.connect).toHaveBeenCalledWith("sbx_1", expect.anything());
+
+    // The reconnected instance stays in use for later commands.
+    await sandbox.run("echo again");
+    expect(revivedRun).toHaveBeenCalledTimes(2);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  test("run throws when the sandbox stays unreachable after recovery", async () => {
+    const run = vi.fn().mockRejectedValue(new Error("fetch failed"));
+    const sandbox = await createdSandbox(run);
+    mocks.connect.mockResolvedValue(fakeSandbox({ run }));
+
+    await expect(sandbox.run("echo hi")).rejects.toThrow("fetch failed");
+    expect(mocks.connect).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("sandbox files", () => {
+  async function createdSandbox() {
+    const inner = fakeSandbox();
+    mocks.create.mockResolvedValue(inner);
+    return { inner, sandbox: await createE2bProvider().create() };
+  }
+
+  test("readFile requests bytes", async () => {
+    const { inner, sandbox } = await createdSandbox();
+    inner.files.read.mockResolvedValue(new Uint8Array([1, 2]));
+
+    await expect(sandbox.readFile("/a.bin")).resolves.toEqual(new Uint8Array([1, 2]));
+    expect(inner.files.read).toHaveBeenCalledWith("/a.bin", { format: "bytes" });
+  });
+
+  test("writeFile copies a Uint8Array view into an exact ArrayBuffer", async () => {
+    const { inner, sandbox } = await createdSandbox();
+    // A view into a larger buffer — the copy must honor offset and length.
+    const view = new Uint8Array([9, 1, 2, 3, 9]).subarray(1, 4);
+
+    await sandbox.writeFile("/a.bin", view);
+    const payload = inner.files.write.mock.calls[0]?.[1] as ArrayBuffer;
+    expect(payload).toBeInstanceOf(ArrayBuffer);
+    expect(Array.from(new Uint8Array(payload))).toEqual([1, 2, 3]);
+
+    await sandbox.writeFile("/a.txt", "plain text");
+    expect(inner.files.write).toHaveBeenLastCalledWith("/a.txt", "plain text");
+  });
+});

--- a/packages/agent/src/ports/sandbox-provider.ts
+++ b/packages/agent/src/ports/sandbox-provider.ts
@@ -13,9 +13,10 @@
 // - `pause` frees compute and preserves the workspace FILESYSTEM;
 //   whether in-memory state survives is backend-dependent (E2B
 //   preserves it, docker does not) and callers must not rely on it.
-// - `connect` reattaches to a running sandbox and throws otherwise;
-//   `resume` revives a paused one and is idempotent on a running one,
-//   so find-or-revive needs no state check between list and resume.
+// - `connect` reattaches to a sandbox, reviving it in place when paused
+//   (idempotent on a running one), so find-or-revive needs no state
+//   check between list and connect. It throws only when the sandbox is
+//   unknown or killed.
 // - `run` executes through a shell; a non-zero exit is a result, never
 //   a throw. Throwing means the sandbox itself was unreachable, after
 //   one transparent recovery attempt. File content moves through
@@ -31,10 +32,8 @@ import type { NetworkPolicy } from "@funky/core";
 
 export interface SandboxProvider {
   create(opts?: CreateSandboxOptions): Promise<Sandbox>;
-  /** Reattach to a running sandbox; throws if paused or unknown. */
+  /** Reattach, reviving a paused sandbox; throws if unknown or killed. */
   connect(sandboxId: string): Promise<Sandbox>;
-  /** Revive a paused sandbox and reattach; idempotent on a running one. */
-  resume(sandboxId: string): Promise<Sandbox>;
   /** Every non-killed sandbox, optionally filtered by metadata equality. */
   list(filter?: { metadata?: Record<string, string> }): Promise<SandboxInfo[]>;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,9 @@ importers:
       drizzle-orm:
         specifier: ^1.0.0-beta.2
         version: 1.0.0-rc.4-5d5b77c(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)(typebox@1.3.7)(zod@4.4.3)
+      e2b:
+        specifier: ^2.33.0
+        version: 2.33.0
       zod:
         specifier: ^4.0.0
         version: 4.4.3


### PR DESCRIPTION
Adds an E2B-backed SandboxProvider with lifecycle, network-policy, metadata-listing, binary file I/O, and one reconnect-and-retry recovery attempt. Aligns connect with E2B's automatic paused-sandbox revival and removes the redundant resume method. Adds mocked error and translation coverage plus opt-in live tests for execution, timeouts, persistence, listing, and cleanup. Validation: pnpm typecheck, focused E2B tests, Prettier, and diff checks.