### PR TITLE
Add sandbox workspace tools

### DIFF
--- a/packages/adapters/test/e2b-live.test.ts
+++ b/packages/adapters/test/e2b-live.test.ts
@@ -69,6 +69,13 @@ if (!apiKey) {
       const bytes = new Uint8Array([0, 1, 2, 255, 128, 0, 42]);
       await sandbox.writeFile("/home/user/blob.bin", bytes);
       expect(Array.from(await sandbox.readFile("/home/user/blob.bin"))).toEqual(Array.from(bytes));
+
+      // The port's writeFile promise: missing parent directories are created.
+      await sandbox.writeFile("/home/user/deep/nested/leaf.txt", "made the path\n");
+      const nested = new TextDecoder().decode(
+        await sandbox.readFile("/home/user/deep/nested/leaf.txt"),
+      );
+      expect(nested).toBe("made the path\n");
     }, 60_000);
 
     test("lists by metadata equality", async () => {

--- a/packages/agent/src/driver/loop.ts
+++ b/packages/agent/src/driver/loop.ts
@@ -150,6 +150,10 @@ export async function runStep(deps: DriverDeps, claim: Claim, leaseMs: number): 
       consumeInputs = pending.map((input) => input.id);
       tail = message;
     } else {
+      // TODO(attempt): a re-claimed execute_tools item re-executes its
+      // calls' side effects. Step 4's carve-out — `work_items.attempt` +
+      // synthesized interrupted results on attempt > 1 — lands with the
+      // Store schema change and its own crash-resume tests.
       const calls = tailCalls(entries);
       const results = await executeTools(
         { tools: deps.tools, onUpdate: deps.onUpdate },

--- a/packages/agent/src/engine/tool.ts
+++ b/packages/agent/src/engine/tool.ts
@@ -17,11 +17,19 @@ export interface Tool {
 }
 
 /**
+ * The declaration half of a Tool — everything but `execute`. Tool modules
+ * export their definition as a static constant and bind the executable
+ * separately, so specs project from the same source as the executable
+ * (drift is impossible) without needing one.
+ */
+export type ToolDefinition = Pick<Tool, "name" | "description" | "input">;
+
+/**
  * The one projection from executable to declaration — "the edge" the type
  * comments on both sides refer to. `io: "input"` because the spec
  * describes what the model writes: the schema's pre-transform input side.
  */
-export function toToolSpec(tool: Tool): ToolSpec {
+export function toToolSpec(tool: ToolDefinition): ToolSpec {
   return {
     name: tool.name,
     description: tool.description,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -13,7 +13,8 @@ export type {
 export { nextAction } from "./engine/next-action";
 export type { Action, RunEndStatus } from "./engine/next-action";
 export { toToolSpec } from "./engine/tool";
-export type { Tool, ToolContext, ToolOutcome } from "./engine/tool";
+export type { Tool, ToolContext, ToolDefinition, ToolOutcome } from "./engine/tool";
+export { createSandboxTools, sandboxToolSpecs } from "./tools/sandbox-tools";
 export type { InferenceProvider, StreamRequest } from "./ports/inference-provider";
 export type {
   CommandResult,

--- a/packages/agent/src/tools/bash.ts
+++ b/packages/agent/src/tools/bash.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import type { Tool, ToolDefinition } from "../engine/tool";
+import type { Sandbox } from "../ports/sandbox-provider";
+import { formatSize, MAX_BYTES, MAX_LINES, truncateTail } from "./truncate";
+
+export const bashDefinition = {
+  name: "bash",
+  description:
+    "Execute a bash command in the workspace. Returns stdout and stderr. " +
+    `Output is truncated to the last ${MAX_LINES} lines or ${MAX_BYTES / 1024}KB ` +
+    "(whichever is hit first). Optionally provide a timeout in seconds; " +
+    "the sandbox's default applies otherwise.",
+  input: z.object({
+    command: z.string().describe("Bash command to execute"),
+    timeout: z.number().positive().optional().describe("Timeout in seconds"),
+  }),
+} satisfies ToolDefinition;
+
+export function bindBash(sandbox: Sandbox): Tool {
+  return {
+    ...bashDefinition,
+    async execute(args, ctx) {
+      const { command, timeout } = args as z.infer<typeof bashDefinition.input>;
+      const result = await sandbox.run(command, {
+        timeoutMs: timeout === undefined ? undefined : Math.round(timeout * 1000),
+        onStdout: ctx.onChunk,
+        onStderr: ctx.onChunk,
+      });
+
+      // A command timeout surfaces here as exit 124 (the port settles it
+      // as the command's own outcome), so it reads like any other failure.
+      const merged = [result.stdout, result.stderr].filter((part) => part.length > 0).join("\n");
+      const truncation = truncateTail(merged);
+      let text = truncation.content || "(no output)";
+      if (truncation.truncated) {
+        const start = truncation.totalLines - truncation.outputLines + 1;
+        text += truncation.lineExceedsLimit
+          ? `\n\n[Showing the last ${formatSize(MAX_BYTES)} of line ${truncation.totalLines}]`
+          : `\n\n[Showing lines ${start}-${truncation.totalLines} of ${truncation.totalLines}]`;
+      }
+      if (result.exitCode !== 0) {
+        text += `\n\nCommand exited with code ${result.exitCode}`;
+      }
+      return { content: [{ type: "text", text }], isError: result.exitCode !== 0 };
+    },
+  };
+}

--- a/packages/agent/src/tools/edit.ts
+++ b/packages/agent/src/tools/edit.ts
@@ -1,0 +1,158 @@
+// Exact-text replacement with pi's exactly-once contract: every
+// edits[].oldText must match exactly one region of the ORIGINAL file —
+// never the output of an earlier edit — and regions must not overlap.
+// Matching runs on LF-normalized, BOM-stripped text so a CRLF file or an
+// invisible BOM can't fail an edit the model wrote correctly; the
+// original line endings and BOM are restored on write.
+
+import { z } from "zod";
+import type { Tool, ToolDefinition } from "../engine/tool";
+import type { Sandbox } from "../ports/sandbox-provider";
+import type { FileQueue } from "./file-queue";
+
+const editEntry = z.object({
+  oldText: z
+    .string()
+    .describe(
+      "Exact text for one targeted replacement. It must be unique in the " +
+        "original file and must not overlap with any other edits[].oldText " +
+        "in the same call.",
+    ),
+  newText: z.string().describe("Replacement text for this targeted edit."),
+});
+
+export const editDefinition = {
+  name: "edit",
+  description:
+    "Edit a single file using exact text replacement. Every " +
+    "edits[].oldText must match a unique, non-overlapping region of the " +
+    "original file. If two changes affect the same block or nearby lines, " +
+    "merge them into one edit. Keep oldText as small as possible while " +
+    "still being unique.",
+  input: z.object({
+    path: z.string().describe("Path to the file to edit"),
+    edits: z
+      .array(editEntry)
+      .min(1)
+      .describe(
+        "One or more targeted replacements. Each edit is matched against " +
+          "the original file, not incrementally.",
+      ),
+  }),
+} satisfies ToolDefinition;
+
+export function bindEdit(sandbox: Sandbox, queue: FileQueue): Tool {
+  return {
+    ...editDefinition,
+    async execute(args) {
+      const { path, edits } = args as z.infer<typeof editDefinition.input>;
+      return queue(path, async () => {
+        // ignoreBOM keeps a BOM visible to the code below — the default
+        // decoder would silently strip it and the write would drop it.
+        const raw = new TextDecoder("utf-8", { ignoreBOM: true }).decode(
+          await sandbox.readFile(path),
+        );
+        const bom = raw.startsWith("\uFEFF") ? "\uFEFF" : "";
+        const original = raw.slice(bom.length);
+        const ending = detectLineEnding(original);
+        const content = normalizeToLF(original);
+
+        const applied = applyEdits(content, edits, path);
+        const restored = ending === "\r\n" ? applied.replaceAll("\n", "\r\n") : applied;
+        await sandbox.writeFile(path, bom + restored);
+        return {
+          content: [
+            { type: "text", text: `Successfully replaced ${edits.length} block(s) in ${path}.` },
+          ],
+        };
+      });
+    },
+  };
+}
+
+interface Match {
+  editIndex: number;
+  start: number;
+  length: number;
+  newText: string;
+}
+
+function applyEdits(
+  content: string,
+  edits: { oldText: string; newText: string }[],
+  path: string,
+): string {
+  const matches: Match[] = edits.map((edit, editIndex) => {
+    const oldText = normalizeToLF(edit.oldText);
+    if (oldText.length === 0)
+      throw editError(path, edits.length, editIndex, "oldText must not be empty");
+    const occurrences = content.split(oldText).length - 1;
+    if (occurrences === 0) {
+      throw editError(
+        path,
+        edits.length,
+        editIndex,
+        "the oldText was not found — it must match exactly, including all whitespace and newlines",
+      );
+    }
+    if (occurrences > 1) {
+      throw editError(
+        path,
+        edits.length,
+        editIndex,
+        `the oldText matches ${occurrences} times and must be unique — provide more surrounding context`,
+      );
+    }
+    return {
+      editIndex,
+      start: content.indexOf(oldText),
+      length: oldText.length,
+      newText: normalizeToLF(edit.newText),
+    };
+  });
+
+  matches.sort((a, b) => a.start - b.start);
+  for (let i = 1; i < matches.length; i++) {
+    const previous = matches[i - 1] as Match;
+    const current = matches[i] as Match;
+    if (previous.start + previous.length > current.start) {
+      throw new Error(
+        `edits[${previous.editIndex}] and edits[${current.editIndex}] overlap in ${path}. ` +
+          "Merge them into one edit or target disjoint regions.",
+      );
+    }
+  }
+
+  // Reverse order keeps earlier offsets valid as later regions change size.
+  let result = content;
+  for (const match of [...matches].reverse()) {
+    result =
+      result.slice(0, match.start) + match.newText + result.slice(match.start + match.length);
+  }
+  if (result === content) {
+    throw new Error(`No changes made to ${path}. The replacements produced identical content.`);
+  }
+  return result;
+}
+
+function editError(path: string, totalEdits: number, editIndex: number, reason: string): Error {
+  const subject = totalEdits === 1 ? "" : `edits[${editIndex}]: `;
+  return new Error(`Could not edit ${path}. ${subject}${reason}.`);
+}
+
+/**
+ * The file's ending is judged by its FIRST newline (pi's heuristic), so
+ * one stray CRLF in an LF file rewrites only the stray line on restore —
+ * any-CRLF-wins would flip every line in the file.
+ */
+function detectLineEnding(content: string): "\r\n" | "\n" {
+  const crlfIdx = content.indexOf("\r\n");
+  const lfIdx = content.indexOf("\n");
+  if (lfIdx === -1 || crlfIdx === -1) return "\n";
+  return crlfIdx < lfIdx ? "\r\n" : "\n";
+}
+
+/** Folds CRLF and lone CR (classic-Mac) endings, like pi's. */
+function normalizeToLF(text: string): string {
+  return text.replaceAll("\r\n", "\n").replaceAll("\r", "\n");
+}

--- a/packages/agent/src/tools/file-queue.ts
+++ b/packages/agent/src/tools/file-queue.ts
@@ -1,0 +1,38 @@
+// Per-path serialization for the file-mutating tools (write, edit),
+// with pi's deliberate boundary. executeTools runs a batch's calls in
+// parallel, so two same-path mutations in one assistant message would
+// interleave — an edit's read-modify-write against a concurrent write
+// silently loses one while both report success, and the model then acts
+// on a world that doesn't exist. That silent, unrecoverable race is the
+// only one guarded. A read (or bash command) racing a same-batch
+// mutation is deliberately not queued: bash is opaque about the paths
+// it touches, and a stale or missing read is a visible result the model
+// corrects on the next step. Parallel calls are the model's own
+// assertion that the calls are independent.
+//
+// Keys are lexically normalized path strings — "./a" and "a" share a
+// queue; relative-vs-absolute spellings and symlinks do not (resolving
+// those needs a sandbox round-trip per call, which the guard isn't
+// worth; pi resolves realpath only because its filesystem is local).
+// Across steps there is no race at all: the one-open-item invariant
+// means a session's tools have exactly one executor at a time.
+
+import { posix } from "node:path";
+
+export type FileQueue = <T>(path: string, task: () => Promise<T>) => Promise<T>;
+
+export function createFileQueue(): FileQueue {
+  const tails = new Map<string, Promise<unknown>>();
+  return (path, task) => {
+    const key = posix.normalize(path);
+    const run = (tails.get(key) ?? Promise.resolve()).then(task, task);
+    tails.set(
+      key,
+      run.then(
+        () => undefined,
+        () => undefined,
+      ),
+    );
+    return run;
+  };
+}

--- a/packages/agent/src/tools/read.ts
+++ b/packages/agent/src/tools/read.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+import type { Tool, ToolDefinition } from "../engine/tool";
+import type { Sandbox } from "../ports/sandbox-provider";
+import { formatSize, MAX_BYTES, MAX_LINES, truncateHead } from "./truncate";
+
+// Images are detected by extension — the tool's ratified contract; the
+// model names the file it wants, it can rename if an extension lies.
+const IMAGE_MIME: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  bmp: "image/bmp",
+};
+
+// Provider request limits sit around 5MB per image; cap below it. There
+// is no resizing in the sandbox, so an oversized image is an error the
+// model can route around (e.g. convert via bash).
+export const MAX_IMAGE_BYTES = 4 * 1024 * 1024;
+
+export const readDefinition = {
+  name: "read",
+  description:
+    "Read the contents of a file. Supports text files and images " +
+    "(jpg, png, gif, webp, bmp). For text files, output is truncated to " +
+    `${MAX_LINES} lines or ${MAX_BYTES / 1024}KB (whichever is hit first). ` +
+    "Use offset/limit for large files; when you need the full file, " +
+    "continue with offset until complete.",
+  input: z.object({
+    path: z.string().describe("Path to the file to read"),
+    offset: z.number().int().min(1).optional().describe("Line number to start from (1-indexed)"),
+    limit: z.number().int().min(1).optional().describe("Maximum number of lines to read"),
+  }),
+} satisfies ToolDefinition;
+
+export function bindRead(sandbox: Sandbox): Tool {
+  return {
+    ...readDefinition,
+    async execute(args) {
+      const { path, offset, limit } = args as z.infer<typeof readDefinition.input>;
+      const bytes = await sandbox.readFile(path);
+
+      const mimeType = IMAGE_MIME[path.split(".").pop()?.toLowerCase() ?? ""];
+      if (mimeType) {
+        if (bytes.byteLength > MAX_IMAGE_BYTES) {
+          throw new Error(
+            `Image is ${formatSize(bytes.byteLength)}, exceeds the ` +
+              `${formatSize(MAX_IMAGE_BYTES)} limit for ${path}.`,
+          );
+        }
+        return {
+          content: [
+            { type: "text", text: `Read image file [${mimeType}]` },
+            { type: "image", data: Buffer.from(bytes).toString("base64"), mimeType },
+          ],
+        };
+      }
+
+      const lines = new TextDecoder().decode(bytes).split("\n");
+      const start = offset === undefined ? 0 : offset - 1;
+      if (start >= lines.length) {
+        throw new Error(`Offset ${offset} is beyond end of file (${lines.length} lines total)`);
+      }
+      const end = limit === undefined ? lines.length : Math.min(start + limit, lines.length);
+      const truncation = truncateHead(lines.slice(start, end).join("\n"));
+
+      let text = truncation.content;
+      if (truncation.lineExceedsLimit) {
+        // Even one line blows the byte budget; point the model at bash.
+        text =
+          `[Line ${start + 1} exceeds the ${formatSize(MAX_BYTES)} limit. ` +
+          `Use bash: sed -n '${start + 1}p' ${path} | head -c ${MAX_BYTES}]`;
+      } else if (truncation.truncated) {
+        const lastShown = start + truncation.outputLines;
+        text +=
+          `\n\n[Showing lines ${start + 1}-${lastShown} of ${lines.length}. ` +
+          `Use offset=${lastShown + 1} to continue.]`;
+      } else if (end < lines.length) {
+        text +=
+          `\n\n[${lines.length - end} more lines in file. ` + `Use offset=${end + 1} to continue.]`;
+      }
+      return { content: [{ type: "text", text }] };
+    },
+  };
+}

--- a/packages/agent/src/tools/sandbox-tools.ts
+++ b/packages/agent/src/tools/sandbox-tools.ts
@@ -1,0 +1,35 @@
+// The four workspace tools — bash, read, write, edit — as pi-contract
+// wrappers over the Sandbox handle. The spec/executable split does its
+// job here: `sandboxToolSpecs` is static (the inference branch declares
+// tools without ever touching a sandbox), `createSandboxTools` binds the
+// executables to a handle per step. Both project from the same
+// definition constants, so spec and executable cannot drift.
+
+import { type Tool, type ToolDefinition, toToolSpec } from "../engine/tool";
+import type { Sandbox } from "../ports/sandbox-provider";
+import type { ToolSpec } from "@funky/core";
+import { bashDefinition, bindBash } from "./bash";
+import { createFileQueue } from "./file-queue";
+import { bindEdit, editDefinition } from "./edit";
+import { bindRead, readDefinition } from "./read";
+import { bindWrite, writeDefinition } from "./write";
+
+const definitions: ToolDefinition[] = [
+  bashDefinition,
+  readDefinition,
+  writeDefinition,
+  editDefinition,
+];
+
+export const sandboxToolSpecs: ToolSpec[] = definitions.map(toToolSpec);
+
+export function createSandboxTools(sandbox: Sandbox): Map<string, Tool> {
+  const queue = createFileQueue();
+  const tools = [
+    bindBash(sandbox),
+    bindRead(sandbox),
+    bindWrite(sandbox, queue),
+    bindEdit(sandbox, queue),
+  ];
+  return new Map(tools.map((tool) => [tool.name, tool]));
+}

--- a/packages/agent/src/tools/truncate.ts
+++ b/packages/agent/src/tools/truncate.ts
@@ -1,0 +1,109 @@
+// Output truncation shared by the workspace tools, following pi's
+// contract: two independent limits — 2000 lines and 50KB — whichever is
+// hit first, and never a partial line. read keeps the head (the model
+// pages forward with offset); bash keeps the tail (errors and final
+// results live at the end).
+
+export const MAX_LINES = 2000;
+export const MAX_BYTES = 50 * 1024;
+
+export interface Truncation {
+  content: string;
+  truncated: boolean;
+  /** Line counts of the original input and the kept slice. */
+  totalLines: number;
+  outputLines: number;
+  /** True when even the first (head) or last (tail) line alone exceeds
+   *  the byte limit, so content is empty or byte-clipped. */
+  lineExceedsLimit: boolean;
+}
+
+export function truncateHead(text: string): Truncation {
+  const lines = splitLines(text);
+  if (fits(text, lines)) return whole(text, lines);
+
+  const kept: string[] = [];
+  let bytes = 0;
+  for (const line of lines.slice(0, MAX_LINES)) {
+    const lineBytes = Buffer.byteLength(line, "utf-8") + (kept.length > 0 ? 1 : 0);
+    if (bytes + lineBytes > MAX_BYTES) break;
+    kept.push(line);
+    bytes += lineBytes;
+  }
+  return {
+    content: kept.join("\n"),
+    truncated: true,
+    totalLines: lines.length,
+    outputLines: kept.length,
+    lineExceedsLimit: kept.length === 0,
+  };
+}
+
+export function truncateTail(text: string): Truncation {
+  const lines = splitLines(text);
+  if (fits(text, lines)) return whole(text, lines);
+
+  const kept: string[] = [];
+  let bytes = 0;
+  for (let i = lines.length - 1; i >= 0 && kept.length < MAX_LINES; i--) {
+    const line = lines[i] as string;
+    const lineBytes = Buffer.byteLength(line, "utf-8") + (kept.length > 0 ? 1 : 0);
+    if (bytes + lineBytes > MAX_BYTES) break;
+    kept.unshift(line);
+    bytes += lineBytes;
+  }
+  if (kept.length === 0) {
+    // The last line alone exceeds the limit; keep its byte-clipped end.
+    return {
+      content: tailBytes(lines[lines.length - 1] as string, MAX_BYTES),
+      truncated: true,
+      totalLines: lines.length,
+      outputLines: 1,
+      lineExceedsLimit: true,
+    };
+  }
+  return {
+    content: kept.join("\n"),
+    truncated: true,
+    totalLines: lines.length,
+    outputLines: kept.length,
+    lineExceedsLimit: false,
+  };
+}
+
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+/** Split for counting: a trailing newline does not add an empty line. */
+function splitLines(text: string): string[] {
+  if (text.length === 0) return [];
+  const lines = text.split("\n");
+  if (text.endsWith("\n")) lines.pop();
+  return lines;
+}
+
+function fits(text: string, lines: string[]): boolean {
+  return lines.length <= MAX_LINES && Buffer.byteLength(text, "utf-8") <= MAX_BYTES;
+}
+
+function whole(text: string, lines: string[]): Truncation {
+  return {
+    content: text,
+    truncated: false,
+    totalLines: lines.length,
+    outputLines: lines.length,
+    lineExceedsLimit: false,
+  };
+}
+
+/** The last maxBytes of a string, clipped on a UTF-8 character boundary. */
+function tailBytes(text: string, maxBytes: number): string {
+  const bytes = Buffer.from(text, "utf-8");
+  if (bytes.length <= maxBytes) return text;
+  let start = bytes.length - maxBytes;
+  while (start < bytes.length && ((bytes[start] as number) & 0xc0) === 0x80) start++;
+  return bytes.subarray(start).toString("utf-8");
+}

--- a/packages/agent/src/tools/write.ts
+++ b/packages/agent/src/tools/write.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+import type { Tool, ToolDefinition } from "../engine/tool";
+import type { Sandbox } from "../ports/sandbox-provider";
+import type { FileQueue } from "./file-queue";
+
+export const writeDefinition = {
+  name: "write",
+  description:
+    "Create or overwrite a file with the given content. Parent " +
+    "directories are created as needed. Use write only for new files or " +
+    "complete rewrites; use edit for targeted changes.",
+  input: z.object({
+    path: z.string().describe("Path to the file to write"),
+    content: z.string().describe("Content to write to the file"),
+  }),
+} satisfies ToolDefinition;
+
+export function bindWrite(sandbox: Sandbox, queue: FileQueue): Tool {
+  return {
+    ...writeDefinition,
+    async execute(args) {
+      const { path, content } = args as z.infer<typeof writeDefinition.input>;
+      await queue(path, () => sandbox.writeFile(path, content));
+      return {
+        content: [
+          { type: "text", text: `Wrote ${Buffer.byteLength(content, "utf-8")} bytes to ${path}.` },
+        ],
+      };
+    },
+  };
+}

--- a/packages/agent/test/sandbox-tools.test.ts
+++ b/packages/agent/test/sandbox-tools.test.ts
@@ -1,0 +1,320 @@
+// The four workspace tools against an in-memory Sandbox fake: pi's
+// contracts — bash tail truncation and exit-code reporting, read's
+// offset/limit paging and image-by-extension, edit's exactly-once
+// matching with CRLF/BOM preservation — plus the same-path serialization
+// that makes parallel batches safe. The static-spec projection is pinned
+// so the inference branch can declare tools without a sandbox.
+
+import { posix } from "node:path";
+import { describe, expect, test } from "vitest";
+import type { ToolContext } from "../src/engine/tool";
+import type { CommandResult, RunOptions, Sandbox } from "../src/ports/sandbox-provider";
+import { MAX_IMAGE_BYTES } from "../src/tools/read";
+import { createSandboxTools, sandboxToolSpecs } from "../src/tools/sandbox-tools";
+import { MAX_LINES } from "../src/tools/truncate";
+
+type RunFn = (command: string, opts?: RunOptions) => Promise<CommandResult>;
+
+function memorySandbox(run?: RunFn) {
+  const files = new Map<string, Uint8Array>();
+  const sandbox: Sandbox = {
+    sandboxId: "sbx_test",
+    getInfo: async () => ({ sandboxId: "sbx_test", state: "running", metadata: {} }),
+    run: run ?? (async () => ({ stdout: "", stderr: "", exitCode: 0 })),
+    readFile: async (path) => {
+      // normalize so lexical aliases hit the same entry, as on a real FS.
+      const data = files.get(posix.normalize(path));
+      if (!data) throw new Error(`no such file: ${path}`);
+      return data;
+    },
+    writeFile: async (path, data) => {
+      files.set(
+        posix.normalize(path),
+        typeof data === "string" ? new TextEncoder().encode(data) : data,
+      );
+    },
+    pause: async () => {},
+    kill: async () => {},
+  };
+  return { sandbox, files };
+}
+
+function ctx(onChunk?: (chunk: string) => void): ToolContext {
+  return { signal: new AbortController().signal, onChunk };
+}
+
+function textOf(outcome: { content: { type: string; text?: string }[] }): string {
+  return outcome.content
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("\n");
+}
+
+function fileText(files: Map<string, Uint8Array>, path: string): string {
+  // ignoreBOM so the assertions can see whether a BOM survived.
+  return new TextDecoder("utf-8", { ignoreBOM: true }).decode(files.get(path));
+}
+
+async function runTool(sandbox: Sandbox, name: string, args: unknown, context = ctx()) {
+  const tool = createSandboxTools(sandbox).get(name);
+  if (!tool) throw new Error(`missing tool ${name}`);
+  return tool.execute(tool.input.parse(args), context);
+}
+
+describe("sandboxToolSpecs", () => {
+  test("declares the four tools statically, projected from the same definitions", () => {
+    expect(sandboxToolSpecs.map((spec) => spec.name)).toEqual(["bash", "read", "write", "edit"]);
+    for (const spec of sandboxToolSpecs) {
+      expect(spec.description).toBeTruthy();
+      expect(spec.inputSchema).toMatchObject({ type: "object" });
+    }
+    const { sandbox } = memorySandbox();
+    expect([...createSandboxTools(sandbox).keys()]).toEqual(sandboxToolSpecs.map((s) => s.name));
+  });
+});
+
+describe("bash", () => {
+  test("passes the command with seconds converted to timeoutMs and taps output", async () => {
+    let seen: { command: string; opts?: RunOptions } | undefined;
+    const { sandbox } = memorySandbox(async (command, opts) => {
+      seen = { command, opts };
+      opts?.onStdout?.("chunk-out");
+      opts?.onStderr?.("chunk-err");
+      return { stdout: "done", stderr: "", exitCode: 0 };
+    });
+    const chunks: string[] = [];
+
+    const outcome = await runTool(
+      sandbox,
+      "bash",
+      { command: "make build", timeout: 90 },
+      ctx((c) => chunks.push(c)),
+    );
+    expect(seen?.command).toBe("make build");
+    expect(seen?.opts?.timeoutMs).toBe(90_000);
+    expect(chunks).toEqual(["chunk-out", "chunk-err"]);
+    expect(textOf(outcome)).toBe("done");
+    expect(outcome.isError).toBe(false);
+  });
+
+  test("reports a non-zero exit as an error result with both streams", async () => {
+    const { sandbox } = memorySandbox(async () => ({
+      stdout: "partial",
+      stderr: "boom",
+      exitCode: 7,
+    }));
+
+    const outcome = await runTool(sandbox, "bash", { command: "false" });
+    expect(textOf(outcome)).toBe("partial\nboom\n\nCommand exited with code 7");
+    expect(outcome.isError).toBe(true);
+  });
+
+  test("shows (no output) for a silent command", async () => {
+    const { sandbox } = memorySandbox();
+    expect(textOf(await runTool(sandbox, "bash", { command: "true" }))).toBe("(no output)");
+  });
+
+  test("keeps the tail of oversized output", async () => {
+    const stdout = Array.from({ length: 3000 }, (_, i) => `line ${i + 1}`).join("\n");
+    const { sandbox } = memorySandbox(async () => ({ stdout, stderr: "", exitCode: 0 }));
+
+    const text = textOf(await runTool(sandbox, "bash", { command: "spam" }));
+    expect(text).toContain("line 3000");
+    expect(text).not.toContain("line 1\n");
+    expect(text).toContain(`[Showing lines 1001-3000 of 3000]`);
+  });
+});
+
+describe("read", () => {
+  test("reads a text file whole", async () => {
+    const { sandbox } = memorySandbox();
+    await sandbox.writeFile("/w/a.txt", "alpha\nbeta\n");
+
+    expect(textOf(await runTool(sandbox, "read", { path: "/w/a.txt" }))).toBe("alpha\nbeta\n");
+  });
+
+  test("pages with offset/limit and points at the next offset", async () => {
+    const { sandbox } = memorySandbox();
+    await sandbox.writeFile("/w/a.txt", "one\ntwo\nthree\nfour\nfive");
+
+    const text = textOf(await runTool(sandbox, "read", { path: "/w/a.txt", offset: 2, limit: 2 }));
+    expect(text).toBe("two\nthree\n\n[2 more lines in file. Use offset=4 to continue.]");
+  });
+
+  test("rejects an offset beyond the end of the file", async () => {
+    const { sandbox } = memorySandbox();
+    await sandbox.writeFile("/w/a.txt", "only\n");
+
+    await expect(runTool(sandbox, "read", { path: "/w/a.txt", offset: 10 })).rejects.toThrow(
+      "beyond end of file",
+    );
+  });
+
+  test("truncates a long file head-first with a continuation notice", async () => {
+    const { sandbox } = memorySandbox();
+    const body = Array.from({ length: 2500 }, (_, i) => `l${i + 1}`).join("\n");
+    await sandbox.writeFile("/w/big.txt", body);
+
+    const text = textOf(await runTool(sandbox, "read", { path: "/w/big.txt" }));
+    expect(text).toContain(`l${MAX_LINES}`);
+    expect(text).not.toContain(`l${MAX_LINES + 1}\n`);
+    expect(text).toContain(
+      `[Showing lines 1-${MAX_LINES} of 2500. Use offset=${MAX_LINES + 1} to continue.]`,
+    );
+  });
+
+  test("returns images by extension as base64 content", async () => {
+    const { sandbox } = memorySandbox();
+    const bytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+    await sandbox.writeFile("/w/shot.PNG", bytes);
+
+    const outcome = await runTool(sandbox, "read", { path: "/w/shot.PNG" });
+    expect(outcome.content).toEqual([
+      { type: "text", text: "Read image file [image/png]" },
+      { type: "image", data: Buffer.from(bytes).toString("base64"), mimeType: "image/png" },
+    ]);
+  });
+
+  test("rejects an image over the size cap", async () => {
+    const { sandbox } = memorySandbox();
+    await sandbox.writeFile("/w/huge.png", new Uint8Array(MAX_IMAGE_BYTES + 1));
+
+    await expect(runTool(sandbox, "read", { path: "/w/huge.png" })).rejects.toThrow(
+      "exceeds the 4.0MB limit",
+    );
+  });
+});
+
+describe("write", () => {
+  test("writes content and reports the byte count", async () => {
+    const { sandbox, files } = memorySandbox();
+
+    const outcome = await runTool(sandbox, "write", { path: "/w/new.txt", content: "fresh\n" });
+    expect(fileText(files, "/w/new.txt")).toBe("fresh\n");
+    expect(textOf(outcome)).toBe("Wrote 6 bytes to /w/new.txt.");
+  });
+});
+
+describe("edit", () => {
+  test("applies a single exact replacement", async () => {
+    const { sandbox, files } = memorySandbox();
+    await sandbox.writeFile("/w/a.ts", "const a = 1;\nconst b = 2;\n");
+
+    const outcome = await runTool(sandbox, "edit", {
+      path: "/w/a.ts",
+      edits: [{ oldText: "const b = 2;", newText: "const b = 3;" }],
+    });
+    expect(fileText(files, "/w/a.ts")).toBe("const a = 1;\nconst b = 3;\n");
+    expect(textOf(outcome)).toBe("Successfully replaced 1 block(s) in /w/a.ts.");
+  });
+
+  test("matches every edit against the original file, whatever the given order", async () => {
+    const { sandbox, files } = memorySandbox();
+    await sandbox.writeFile("/w/a.txt", "first\nsecond\nthird\n");
+
+    await runTool(sandbox, "edit", {
+      path: "/w/a.txt",
+      edits: [
+        { oldText: "third", newText: "3rd" },
+        { oldText: "first", newText: "1st" },
+      ],
+    });
+    expect(fileText(files, "/w/a.txt")).toBe("1st\nsecond\n3rd\n");
+  });
+
+  const rejections: [string, { oldText: string; newText: string }[], string][] = [
+    ["a missing oldText", [{ oldText: "absent", newText: "x" }], "not found"],
+    ["an ambiguous oldText", [{ oldText: "dup", newText: "x" }], "matches 2 times"],
+    [
+      "overlapping edits",
+      [
+        { oldText: "dup one dup", newText: "x" },
+        { oldText: "one", newText: "y" },
+      ],
+      "overlap",
+    ],
+    ["an empty oldText", [{ oldText: "", newText: "x" }], "must not be empty"],
+    ["a no-op replacement", [{ oldText: "one", newText: "one" }], "identical content"],
+  ];
+  test.each(rejections)("rejects %s", async (_label, edits, message) => {
+    const { sandbox, files } = memorySandbox();
+    await sandbox.writeFile("/w/a.txt", "dup one dup\n");
+
+    await expect(runTool(sandbox, "edit", { path: "/w/a.txt", edits })).rejects.toThrow(message);
+    expect(fileText(files, "/w/a.txt")).toBe("dup one dup\n"); // untouched on failure
+  });
+
+  test("matches LF-authored edits in a CRLF file and preserves its endings and BOM", async () => {
+    const { sandbox, files } = memorySandbox();
+    await sandbox.writeFile("/w/win.txt", "\uFEFFalpha\r\nbeta\r\n");
+
+    await runTool(sandbox, "edit", {
+      path: "/w/win.txt",
+      edits: [{ oldText: "alpha\nbeta", newText: "alpha\ngamma" }],
+    });
+    expect(fileText(files, "/w/win.txt")).toBe("\uFEFFalpha\r\ngamma\r\n");
+  });
+
+  test("judges a mixed-ending file by its first newline \u2014 a stray CRLF doesn't flip the file", async () => {
+    const { sandbox, files } = memorySandbox();
+    await sandbox.writeFile("/w/mixed.txt", "one\ntwo\r\nthree\n");
+
+    await runTool(sandbox, "edit", {
+      path: "/w/mixed.txt",
+      edits: [{ oldText: "three", newText: "3rd" }],
+    });
+    // LF-first file stays LF; only the stray CRLF line is homogenized.
+    expect(fileText(files, "/w/mixed.txt")).toBe("one\ntwo\n3rd\n");
+  });
+
+  test("folds lone CR endings so exact matching still works", async () => {
+    const { sandbox, files } = memorySandbox();
+    await sandbox.writeFile("/w/mac.txt", "a\rb");
+
+    await runTool(sandbox, "edit", {
+      path: "/w/mac.txt",
+      edits: [{ oldText: "a\nb", newText: "a\nc" }],
+    });
+    expect(fileText(files, "/w/mac.txt")).toBe("a\nc");
+  });
+
+  test("serializes same-path mutations fired in parallel", async () => {
+    const { sandbox, files } = memorySandbox();
+    await sandbox.writeFile("/w/a.txt", "seed");
+    const tools = createSandboxTools(sandbox);
+    const write = tools.get("write");
+    const edit = tools.get("edit");
+    if (!write || !edit) throw new Error("missing tools");
+
+    // The edit's oldText exists only in the write's content: without the
+    // per-path queue its read could see "seed" and fail or lose the write.
+    await Promise.all([
+      write.execute(write.input.parse({ path: "/w/a.txt", content: "hello world" }), ctx()),
+      edit.execute(
+        edit.input.parse({ path: "/w/a.txt", edits: [{ oldText: "world", newText: "funky" }] }),
+        ctx(),
+      ),
+    ]);
+    expect(fileText(files, "/w/a.txt")).toBe("hello funky");
+  });
+
+  test("serializes lexical aliases of the same path", async () => {
+    const { sandbox, files } = memorySandbox();
+    await sandbox.writeFile("/w/a.txt", "seed");
+    const tools = createSandboxTools(sandbox);
+    const write = tools.get("write");
+    const edit = tools.get("edit");
+    if (!write || !edit) throw new Error("missing tools");
+
+    // "/w/./a.txt" and "/w/a.txt" are the same file; the queue must key
+    // them together or the edit could read "seed" and lose the write.
+    await Promise.all([
+      write.execute(write.input.parse({ path: "/w/./a.txt", content: "hello world" }), ctx()),
+      edit.execute(
+        edit.input.parse({ path: "/w/a.txt", edits: [{ oldText: "world", newText: "funky" }] }),
+        ctx(),
+      ),
+    ]);
+    expect(fileText(files, "/w/a.txt")).toBe("hello funky");
+  });
+});


### PR DESCRIPTION
## Summary
- Add sandbox-backed bash, read, write, and exact-edit tools with static definitions, output limits, image handling, timeouts, and per-path mutation serialization.
- Export the tool factory and specs, document the remaining execute-tool replay work, and verify nested E2B writes.
- Cover the workspace-tool contracts with focused unit tests.

## Validation
- `pnpm --filter @funky/agent test`
- `pnpm --filter @funky/adapters test`
- `pnpm typecheck`
- `pnpm format:check`