### PR TITLE
Bind sandbox tools on execution claims

### DIFF
--- a/packages/adapters/test/crash-resume.test.ts
+++ b/packages/adapters/test/crash-resume.test.ts
@@ -35,7 +35,7 @@ import { fileURLToPath } from "node:url";
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type DriverDeps, runStep, type Store } from "@funky/agent";
+import { runStep, type StepDeps, type Store, toToolSpec } from "@funky/agent";
 import { createPgStore, type StoreDb } from "../src";
 import {
   createProvider,
@@ -80,11 +80,16 @@ async function copyOf(template: string): Promise<string> {
 /** The parent's in-process driver — used only to build templates and the
  *  uninterrupted reference; the same runStep the children run. */
 async function driveToIdle(store: Store): Promise<void> {
-  const deps: DriverDeps = { store, provider: createProvider(), tools: createTools() };
+  const tools = createTools();
+  const deps: StepDeps = {
+    store,
+    provider: createProvider(),
+    toolSpecs: [...tools.values()].map(toToolSpec),
+  };
   for (;;) {
     const claim = await store.claimItem({ leaseMs: 60_000 });
     if (!claim) return;
-    await runStep(deps, claim, 60_000);
+    await runStep(deps, claim, 60_000, tools);
   }
 }
 

--- a/packages/adapters/test/driver.test.ts
+++ b/packages/adapters/test/driver.test.ts
@@ -14,13 +14,14 @@ import { z } from "zod";
 import type { ProviderEvent, SessionEntry, Usage, UserMessage } from "@funky/core";
 import {
   type Claim,
-  type DriverDeps,
   FencedError,
   type InferenceProvider,
   runStep,
+  type StepDeps,
   type Store,
   type StreamRequest,
   type Tool,
+  toToolSpec,
 } from "@funky/agent";
 import { createPgStore, type StoreDb } from "../src";
 
@@ -116,7 +117,6 @@ const echo: Tool = {
 };
 
 const echoOnly = new Map([[echo.name, echo]]);
-const noTools = new Map<string, Tool>();
 
 const user = (text: string): UserMessage => ({ role: "user", content: [{ type: "text", text }] });
 
@@ -169,11 +169,17 @@ describe("driver steps over the pg store", () => {
   it("runs a full turn: inference → tools → inference → completion", async () => {
     const sessionId = await newSession();
     const provider = scriptedProvider([callEcho("hi"), sayText("done!")]);
-    const deps: DriverDeps = { store, provider, tools: echoOnly };
+    const deps: StepDeps = {
+      store,
+      provider,
+      toolSpecs: [...echoOnly.values()].map(toToolSpec),
+    };
 
     await store.intake(sessionId, user("go"));
+    // Only the execute_tools step receives executables — the loop's
+    // ensure-on-claim; inference steps declare specs without a sandbox.
     await runStep(deps, await claim(sessionId), 60_000); // inference → tool call
-    await runStep(deps, await claim(sessionId), 60_000); // execute_tools
+    await runStep(deps, await claim(sessionId), 60_000, echoOnly); // execute_tools
     await runStep(deps, await claim(sessionId), 60_000); // inference → end_turn
     // The run ended: its end is the non-creation of a fourth item.
     expect(await store.claimItem({ leaseMs: 60_000, sessionId })).toBeUndefined();
@@ -207,7 +213,7 @@ describe("driver steps over the pg store", () => {
     expect(queued.kind).toBe("queued");
 
     const provider = scriptedProvider([sayText("ok")]);
-    await runStep({ store, provider, tools: noTools }, await claim(sessionId), 60_000);
+    await runStep({ store, provider, toolSpecs: [] }, await claim(sessionId), 60_000);
 
     // Steering shaped the context (appended at the tail)…
     expect(provider.requests[0]?.context.map((m) => m.role)).toEqual(["user", "user"]);
@@ -228,7 +234,7 @@ describe("driver steps over the pg store", () => {
       [...sayText("first").slice(0, 3), { wait: gate.promise }, sayText("first")[3] as Step],
       sayText("second"),
     ]);
-    const deps: DriverDeps = { store, provider, tools: noTools };
+    const deps: StepDeps = { store, provider, toolSpecs: [] };
 
     const inFlight = runStep(deps, await claim(sessionId), 60_000);
     // Arrive after run 1's inference prep: too late to steer this step.
@@ -256,7 +262,7 @@ describe("driver steps over the pg store", () => {
     expect(queued.kind).toBe("queued");
 
     const provider = scriptedProvider([sayText("fresh")]);
-    const deps: DriverDeps = { store, provider, tools: noTools };
+    const deps: StepDeps = { store, provider, toolSpecs: [] };
     await runStep(deps, await claim(sessionId), 60_000);
 
     // The run ended without inference, appending nothing; the queued
@@ -280,7 +286,7 @@ describe("driver steps over the pg store", () => {
     const sessionId = await newSession();
     await store.intake(sessionId, user("go"));
     const provider = scriptedProvider([[{ throw: new Error("provider exploded") }]]);
-    await runStep({ store, provider, tools: noTools }, await claim(sessionId), 60_000);
+    await runStep({ store, provider, toolSpecs: [] }, await claim(sessionId), 60_000);
 
     const log = messages(await store.readEntries(sessionId));
     expect(log).toHaveLength(2);
@@ -293,7 +299,7 @@ describe("driver steps over the pg store", () => {
     const sessionId = await newSession();
     await store.intake(sessionId, user("go"));
     const provider = scriptedProvider([["untilAborted"], sayText("recovered")]);
-    const deps: DriverDeps = { store, provider, tools: noTools };
+    const deps: StepDeps = { store, provider, toolSpecs: [] };
 
     const inFlight = runStep(deps, await claim(sessionId, 500), 500);
     await until(() => provider.requests.length === 1);
@@ -327,7 +333,7 @@ describe("driver steps over the pg store", () => {
     };
 
     const provider = scriptedProvider([sayText("a"), sayText("b")]);
-    const deps: DriverDeps = { store: fencingStore, provider, tools: noTools };
+    const deps: StepDeps = { store: fencingStore, provider, toolSpecs: [] };
 
     // First step's commit is fenced: runStep swallows it and drops the work.
     await runStep(deps, await claim(sessionId, 300), 300);

--- a/packages/adapters/test/fixtures/crash-driver.ts
+++ b/packages/adapters/test/fixtures/crash-driver.ts
@@ -9,7 +9,7 @@
 
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
-import { type DriverDeps, runDriver, type Store } from "@funky/agent";
+import { type DriverDeps, runDriver, type Store, toToolSpec } from "@funky/agent";
 import { createPgStore, type StoreDb } from "../../src";
 import { createProvider, createTools, type KillSpec, stallForever } from "./crash-script";
 
@@ -53,10 +53,12 @@ const wrapped: Store = {
   },
 };
 
+const tools = createTools({ spec, onStall });
 const deps: DriverDeps = {
   store: wrapped,
   provider: createProvider({ spec, onStall }),
-  tools: createTools({ spec, onStall }),
+  toolSpecs: [...tools.values()].map(toToolSpec),
+  bindTools: async () => tools,
 };
 
 send({ t: "ready" });

--- a/packages/agent/src/driver/ensure-sandbox.ts
+++ b/packages/agent/src/driver/ensure-sandbox.ts
@@ -1,0 +1,33 @@
+// Find-or-revive the session's sandbox — the ensure-on-claim half of
+// the ratified lifecycle, composed from the port's list/connect/create.
+// The provider is the registry: the sandbox is found by {sessionId}
+// metadata, so there is no Store column to keep consistent. connect
+// revives a paused sandbox in place; only when nothing is found is one
+// created, stamped with the session id.
+//
+// The composition root closes the driver's `bindTools` dep over this:
+//   bindTools: (sessionId) =>
+//     ensureSandbox(provider, sessionId, opts).then(createSandboxTools)
+//
+// Two claimers can race here — a zombie whose lease expired and its
+// replacement may both list nothing and both create. Harmless: the
+// zombie's step is never committed and its orphan is GC'd by the TTL.
+// The deterministic pick keeps every later claim converging on one
+// survivor in the meantime.
+
+import type { SessionId } from "@funky/core";
+import type { CreateSandboxOptions, Sandbox, SandboxProvider } from "../ports/sandbox-provider";
+
+export async function ensureSandbox(
+  provider: SandboxProvider,
+  sessionId: SessionId,
+  createOpts?: CreateSandboxOptions,
+): Promise<Sandbox> {
+  const infos = await provider.list({ metadata: { sessionId } });
+  const found = [...infos].sort((a, b) => a.sandboxId.localeCompare(b.sandboxId))[0];
+  if (found) return provider.connect(found.sandboxId);
+  return provider.create({
+    ...createOpts,
+    metadata: { ...createOpts?.metadata, sessionId },
+  });
+}

--- a/packages/agent/src/driver/loop.ts
+++ b/packages/agent/src/driver/loop.ts
@@ -31,12 +31,13 @@ import type {
   SessionEntry,
   SessionId,
   ToolCall,
+  ToolSpec,
 } from "@funky/core";
 import { buildContext } from "../engine/build-context";
 import { executeTools, type ToolUpdate } from "../engine/execute-tools";
 import { inference } from "../engine/inference";
 import { type Action, nextAction } from "../engine/next-action";
-import { type Tool, toToolSpec } from "../engine/tool";
+import type { Tool } from "../engine/tool";
 import type { InferenceProvider } from "../ports/inference-provider";
 import {
   type Claim,
@@ -46,14 +47,29 @@ import {
   type Store,
 } from "../ports/store";
 
-export interface DriverDeps {
+/** What one step needs. Executables are not here: runStep receives the
+ *  bound map as an argument, because binding is the loop's job. */
+export interface StepDeps {
   store: Store;
   provider: InferenceProvider;
-  /** Executables by name; projected to specs at the inference edge. */
-  tools: Map<string, Tool>;
+  /** Static tool declarations for the inference branch. Declaring tools
+   *  never needs a sandbox, so an inference-only turn never pays for
+   *  one — the ensure-on-claim half of the ratified lifecycle. */
+  toolSpecs: ToolSpec[];
   /** Decoration taps forwarded to the engine steps. Fire-and-forget. */
   onDelta?: (event: ProviderEvent) => void;
   onUpdate?: (update: ToolUpdate) => void;
+}
+
+export interface DriverDeps extends StepDeps {
+  /** Bind the executables for a claim whose item is execute_tools:
+   *  ensure the sandbox, bind the tools, hand the map to runStep. The
+   *  composition root closes this over ensureSandbox +
+   *  createSandboxTools; tests hand back a fixed map. A rejection is
+   *  worker trouble, not tool trouble: it propagates uncommitted, and
+   *  the crash rule applies — the lease expires and another claim
+   *  retries. */
+  bindTools(sessionId: SessionId): Promise<Map<string, Tool>>;
 }
 
 export interface DriverOptions {
@@ -80,17 +96,32 @@ export async function runDriver(deps: DriverDeps, opts: DriverOptions = {}): Pro
       await sleep(idlePollMs);
       continue;
     }
-    await runStep(deps, claim, leaseMs);
+    // Ensure-on-claim: only an execute_tools item pays for a sandbox.
+    // The bind runs on the claim's initial lease — heartbeats start
+    // inside runStep — so if a slow sandbox create outlives the lease,
+    // the step's commit is fenced: wasted work, never wrong work.
+    const tools =
+      claim.item.type === "execute_tools" ? await deps.bindTools(claim.item.sessionId) : undefined;
+    await runStep(deps, claim, leaseMs, tools);
   }
 }
+
+const EMPTY_TOOLS = new Map<string, Tool>();
 
 /**
  * One claim → at most one commit; the tested unit of the driver — the
  * loop above is policy around it. Holds the lease via heartbeats for
  * the step's duration; a lost lease aborts the step, and an interrupted
- * step is dropped, never committed.
+ * step is dropped, never committed. `tools` carries the executables the
+ * loop bound for an execute_tools claim; an inference step never reads
+ * it.
  */
-export async function runStep(deps: DriverDeps, claim: Claim, leaseMs: number): Promise<void> {
+export async function runStep(
+  deps: StepDeps,
+  claim: Claim,
+  leaseMs: number,
+  tools: Map<string, Tool> = EMPTY_TOOLS,
+): Promise<void> {
   const { store } = deps;
   const { item, token } = claim;
 
@@ -134,15 +165,16 @@ export async function runStep(deps: DriverDeps, claim: Claim, leaseMs: number): 
       const steering = pending.map((input) => input.message);
       // config.inference.provider picked the adapter at composition and
       // is not part of the request.
+      // StepDeps is structurally an InferenceDeps; no re-wrapping.
       const message = await inference(
-        { provider: deps.provider, onDelta: deps.onDelta },
+        deps,
         {
           model: config.inference.model,
           maxTokens: config.inference.maxTokens,
           temperature: config.inference.temperature,
           system: config.systemPrompt,
           context: buildContext(entries, steering),
-          tools: [...deps.tools.values()].map(toToolSpec),
+          tools: deps.toolSpecs,
         },
         step.signal,
       );
@@ -156,7 +188,7 @@ export async function runStep(deps: DriverDeps, claim: Claim, leaseMs: number): 
       // Store schema change and its own crash-resume tests.
       const calls = tailCalls(entries);
       const results = await executeTools(
-        { tools: deps.tools, onUpdate: deps.onUpdate },
+        { tools, onUpdate: deps.onUpdate },
         { calls },
         step.signal,
       );

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,5 +1,6 @@
 export { cancelRequested, runDriver, runStep } from "./driver/loop";
-export type { DriverDeps, DriverOptions } from "./driver/loop";
+export type { DriverDeps, DriverOptions, StepDeps } from "./driver/loop";
+export { ensureSandbox } from "./driver/ensure-sandbox";
 export { buildContext } from "./engine/build-context";
 export { inference } from "./engine/inference";
 export type { InferenceDeps, InferenceRequest } from "./engine/inference";

--- a/packages/agent/test/ensure-sandbox.test.ts
+++ b/packages/agent/test/ensure-sandbox.test.ts
@@ -1,0 +1,85 @@
+// ensure-on-claim over a fake provider: find by session metadata and
+// connect (which revives), create stamped with the session id when
+// nothing exists, and converge deterministically when a race left two.
+
+import { describe, expect, test } from "vitest";
+import { ensureSandbox } from "../src/driver/ensure-sandbox";
+import type {
+  CreateSandboxOptions,
+  Sandbox,
+  SandboxInfo,
+  SandboxProvider,
+} from "../src/ports/sandbox-provider";
+
+function stub(sandboxId: string): Sandbox {
+  return { sandboxId } as Sandbox;
+}
+
+function fakeProvider(existing: SandboxInfo[]) {
+  const calls = {
+    list: [] as ({ metadata?: Record<string, string> } | undefined)[],
+    connect: [] as string[],
+    create: [] as (CreateSandboxOptions | undefined)[],
+  };
+  const provider: SandboxProvider = {
+    create: async (opts) => {
+      calls.create.push(opts);
+      return stub("sbx_created");
+    },
+    connect: async (sandboxId) => {
+      calls.connect.push(sandboxId);
+      return stub(sandboxId);
+    },
+    list: async (filter) => {
+      calls.list.push(filter);
+      return existing;
+    },
+  };
+  return { provider, calls };
+}
+
+const info = (sandboxId: string): SandboxInfo => ({
+  sandboxId,
+  state: "paused",
+  metadata: { sessionId: "s1" },
+});
+
+describe("ensureSandbox", () => {
+  test("connects to the sandbox found by session metadata", async () => {
+    const { provider, calls } = fakeProvider([info("sbx_a")]);
+
+    const sandbox = await ensureSandbox(provider, "s1");
+    expect(sandbox.sandboxId).toBe("sbx_a");
+    expect(calls.list).toEqual([{ metadata: { sessionId: "s1" } }]);
+    expect(calls.connect).toEqual(["sbx_a"]);
+    expect(calls.create).toEqual([]);
+  });
+
+  test("creates with the session stamped into metadata when none exists", async () => {
+    const { provider, calls } = fakeProvider([]);
+
+    const sandbox = await ensureSandbox(provider, "s1", {
+      timeoutMs: 60_000,
+      network: { type: "none" },
+      metadata: { tier: "test" },
+    });
+    expect(sandbox.sandboxId).toBe("sbx_created");
+    expect(calls.connect).toEqual([]);
+    expect(calls.create).toEqual([
+      {
+        timeoutMs: 60_000,
+        network: { type: "none" },
+        metadata: { tier: "test", sessionId: "s1" },
+      },
+    ]);
+  });
+
+  test("converges on the lexicographically first sandbox when a race left two", async () => {
+    const { provider, calls } = fakeProvider([info("sbx_z"), info("sbx_a")]);
+
+    const sandbox = await ensureSandbox(provider, "s1");
+    expect(sandbox.sandboxId).toBe("sbx_a");
+    expect(calls.connect).toEqual(["sbx_a"]);
+    expect(calls.create).toEqual([]);
+  });
+});


### PR DESCRIPTION
Separates static tool specifications from executable bindings so inference-only claims do not provision a sandbox. Adds ensureSandbox to find or revive a session sandbox by metadata, or create it on the first tool-execution claim, and updates driver and crash tests for the new dependency shape. Validation passed with pnpm typecheck, pnpm format:check, pnpm -F @funky/agent test, and pnpm -F @funky/adapters test.