### PR TITLE
Make sandbox claims race-safe

### DIFF
--- a/packages/adapters/migrations/0000_init.sql
+++ b/packages/adapters/migrations/0000_init.sql
@@ -23,6 +23,9 @@ CREATE TABLE sessions (
   id text PRIMARY KEY,
   agent_config_id text NOT NULL REFERENCES agent_configs(id),
   env_config_id text NOT NULL REFERENCES env_configs(id),
+  -- The session's one workspace; null until the driver's first
+  -- execute_tools claim registers it (Store.bindSandbox, set-if-null).
+  sandbox_id text,
   metadata jsonb,
   created_at timestamptz NOT NULL
 );

--- a/packages/adapters/src/sandbox/e2b.ts
+++ b/packages/adapters/src/sandbox/e2b.ts
@@ -17,9 +17,15 @@
 // allowInternetAccess: false is deny-all), so the port's reject-when-
 // unenforceable clause never triggers here.
 
-import { CommandExitError, Sandbox as E2bSandbox, TimeoutError } from "e2b";
+import {
+  CommandExitError,
+  Sandbox as E2bSandbox,
+  SandboxNotFoundError as E2bSandboxNotFoundError,
+  TimeoutError,
+} from "e2b";
 import type { SandboxInfo as E2bSandboxInfo, SandboxOpts } from "e2b";
 import type { NetworkPolicy } from "@funky/core";
+import { SandboxNotFoundError } from "@funky/agent";
 import type {
   CommandResult,
   CreateSandboxOptions,
@@ -50,7 +56,16 @@ export function createE2bProvider(options?: E2bProviderOptions): SandboxProvider
     },
 
     async connect(sandboxId: string): Promise<Sandbox> {
-      return wrap(await E2bSandbox.connect(sandboxId, connection), connection);
+      try {
+        return wrap(await E2bSandbox.connect(sandboxId, connection), connection);
+      } catch (error) {
+        // e2b's own SandboxNotFoundError is the provider confirming the
+        // sandbox is gone — the port's typed rejection, not a transient.
+        if (error instanceof E2bSandboxNotFoundError) {
+          throw new SandboxNotFoundError(error.message);
+        }
+        throw error;
+      }
     },
 
     async list(filter?: { metadata?: Record<string, string> }): Promise<SandboxInfo[]> {

--- a/packages/adapters/src/store/pg.ts
+++ b/packages/adapters/src/store/pg.ts
@@ -24,7 +24,7 @@
 // comparisons use it — never SQL now().
 
 import { randomUUID } from "node:crypto";
-import { and, asc, eq, gt, inArray, lte, ne, or, sql } from "drizzle-orm";
+import { and, asc, eq, gt, inArray, isNull, lte, ne, or, sql } from "drizzle-orm";
 import type { PgAsyncDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 import {
   AgentConfig,
@@ -185,9 +185,29 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         id: row.id,
         agentConfigId: row.agentConfigId,
         envConfigId: row.envConfigId,
+        ...(row.sandboxId ? { sandboxId: row.sandboxId } : {}),
         ...unwrapped(row.metadata),
         createdAt: iso(row.createdAt),
       });
+    },
+
+    async bindSandbox(sessionId, sandboxId, previous) {
+      // The CAS: one UPDATE guarded by the expected current value — at
+      // most one writer ever matches, whatever the interleaving.
+      const expected =
+        previous === undefined ? isNull(sessions.sandboxId) : eq(sessions.sandboxId, previous);
+      const [bound] = await db
+        .update(sessions)
+        .set({ sandboxId })
+        .where(and(eq(sessions.id, sessionId), expected))
+        .returning({ sandboxId: sessions.sandboxId });
+      if (bound?.sandboxId) return bound.sandboxId;
+      const [row] = await db
+        .select({ sandboxId: sessions.sandboxId })
+        .from(sessions)
+        .where(eq(sessions.id, sessionId));
+      if (!row?.sandboxId) throw new Error(`unknown session: ${sessionId}`);
+      return row.sandboxId;
     },
 
     async readEntries(sessionId, after) {

--- a/packages/adapters/src/store/schema.ts
+++ b/packages/adapters/src/store/schema.ts
@@ -60,6 +60,8 @@ export const sessions = pgTable("sessions", {
   envConfigId: text("env_config_id")
     .notNull()
     .references(() => envConfigs.id),
+  // The session's one workspace; null until bindSandbox registers it.
+  sandboxId: text("sandbox_id"),
   metadata: jsonb("metadata").$type<WrappedJson>(),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
 });

--- a/packages/adapters/test/driver.test.ts
+++ b/packages/adapters/test/driver.test.ts
@@ -295,6 +295,28 @@ describe("driver steps over the pg store", () => {
     expect(await store.claimItem({ leaseMs: 60_000, sessionId })).toBeUndefined();
   });
 
+  it("revalidates the lease at entry: an expired claim does no work at all", async () => {
+    const sessionId = await newSession();
+    await store.intake(sessionId, user("go"));
+    const provider = scriptedProvider([sayText("later")]);
+    const deps: StepDeps = { store, provider, toolSpecs: [] };
+
+    // The lease dies between claim and runStep — the window the loop's
+    // sandbox bind occupies. The awaited first beat must catch it.
+    const expired = await claim(sessionId, 300);
+    clock.advance(10_000);
+    await runStep(deps, expired, 300);
+    expect(provider.requests).toHaveLength(0);
+    expect(messages(await store.readEntries(sessionId))).toHaveLength(1);
+
+    // The re-claim executes cleanly.
+    await runStep(deps, await claim(sessionId), 60_000);
+    expect(messages(await store.readEntries(sessionId)).map((m) => m.role)).toEqual([
+      "user",
+      "assistant",
+    ]);
+  });
+
   it("drops an interrupted step on lease loss; the next claim re-executes", async () => {
     const sessionId = await newSession();
     await store.intake(sessionId, user("go"));

--- a/packages/adapters/test/e2b-live.test.ts
+++ b/packages/adapters/test/e2b-live.test.ts
@@ -11,7 +11,7 @@
 
 import { randomUUID } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it, test } from "vitest";
-import type { Sandbox, SandboxProvider } from "@funky/agent";
+import { type Sandbox, SandboxNotFoundError, type SandboxProvider } from "@funky/agent";
 import { createE2bProvider } from "../src/sandbox/e2b";
 
 const apiKey = process.env.E2B_API_KEY;
@@ -103,9 +103,14 @@ if (!apiKey) {
       sandbox = revived;
     }, 240_000);
 
-    test("kill removes the sandbox from list", async () => {
+    test("kill removes the sandbox from list, and connect rejects as gone", async () => {
       await sandbox.kill();
       await expect(provider.list({ metadata: { funkySuite: marker } })).resolves.toEqual([]);
+      // The port's typed "definitively gone" rejection — the signal
+      // dead-binding recovery keys on.
+      await expect(provider.connect(sandbox.sandboxId)).rejects.toBeInstanceOf(
+        SandboxNotFoundError,
+      );
     }, 60_000);
   });
 }

--- a/packages/adapters/test/e2b.test.ts
+++ b/packages/adapters/test/e2b.test.ts
@@ -5,6 +5,7 @@
 // exercised by the key-gated live suite in e2b-live.test.ts.
 
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { SandboxNotFoundError } from "@funky/agent";
 import { createE2bProvider } from "../src/sandbox/e2b";
 
 const mocks = vi.hoisted(() => {
@@ -18,9 +19,11 @@ const mocks = vi.hoisted(() => {
     }
   }
   class TimeoutError extends Error {}
+  class SandboxNotFoundError extends Error {}
   return {
     CommandExitError,
     TimeoutError,
+    SandboxNotFoundError,
     create: vi.fn(),
     connect: vi.fn(),
     getInfo: vi.fn(),
@@ -31,6 +34,7 @@ const mocks = vi.hoisted(() => {
 vi.mock("e2b", () => ({
   CommandExitError: mocks.CommandExitError,
   TimeoutError: mocks.TimeoutError,
+  SandboxNotFoundError: mocks.SandboxNotFoundError,
   Sandbox: class {
     static create = mocks.create;
     static connect = mocks.connect;
@@ -97,6 +101,17 @@ describe("createE2bProvider", () => {
     await provider.connect("sbx_1");
     expect(mocks.getInfo).not.toHaveBeenCalled();
     expect(mocks.connect).toHaveBeenCalledWith("sbx_1", expect.anything());
+  });
+
+  test("connect maps a missing sandbox to the port's typed rejection", async () => {
+    const provider = createE2bProvider();
+    mocks.connect.mockRejectedValue(new mocks.SandboxNotFoundError("sandbox sbx_gone not found"));
+
+    await expect(provider.connect("sbx_gone")).rejects.toBeInstanceOf(SandboxNotFoundError);
+
+    // A transient failure stays untyped — recovery must not fire on it.
+    mocks.connect.mockRejectedValue(new Error("fetch failed"));
+    await expect(provider.connect("sbx_1")).rejects.toThrow("fetch failed");
   });
 
   test("list drains every page and maps to the port's info shape", async () => {

--- a/packages/adapters/test/store-conformance.ts
+++ b/packages/adapters/test/store-conformance.ts
@@ -140,6 +140,33 @@ export function describeStoreConformance(
         expect(session?.envConfigId).toBeDefined();
       });
 
+      it("bindSandbox: first writer wins, losers learn the winner", async () => {
+        const sessionId = await newSession();
+        expect((await store.getSession(sessionId))?.sandboxId).toBeUndefined();
+
+        expect(await store.bindSandbox(sessionId, "sbx_a")).toBe("sbx_a");
+        // The loser's candidate is not recorded; it gets the winner back.
+        expect(await store.bindSandbox(sessionId, "sbx_b")).toBe("sbx_a");
+        expect((await store.getSession(sessionId))?.sandboxId).toBe("sbx_a");
+      });
+
+      it("bindSandbox replaces only the expected previous binding", async () => {
+        const sessionId = await newSession();
+        await store.bindSandbox(sessionId, "sbx_a");
+
+        // Wrong expectation: nothing written, the current binding returns.
+        expect(await store.bindSandbox(sessionId, "sbx_c", "sbx_b")).toBe("sbx_a");
+        expect((await store.getSession(sessionId))?.sandboxId).toBe("sbx_a");
+
+        // Right expectation: the dead binding is replaced.
+        expect(await store.bindSandbox(sessionId, "sbx_c", "sbx_a")).toBe("sbx_c");
+        expect((await store.getSession(sessionId))?.sandboxId).toBe("sbx_c");
+      });
+
+      it("bindSandbox rejects an unknown session", async () => {
+        await expect(store.bindSandbox("nope", "sbx_a")).rejects.toThrow("unknown session");
+      });
+
       it("rejects a session naming an unknown agent config", async () => {
         const envConfigId = await store.createEnvConfig({});
         await expect(store.createSession({ agentConfigId: "nope", envConfigId })).rejects.toThrow();

--- a/packages/agent/src/driver/ensure-sandbox.ts
+++ b/packages/agent/src/driver/ensure-sandbox.ts
@@ -1,33 +1,65 @@
-// Find-or-revive the session's sandbox — the ensure-on-claim half of
-// the ratified lifecycle, composed from the port's list/connect/create.
-// The provider is the registry: the sandbox is found by {sessionId}
-// metadata, so there is no Store column to keep consistent. connect
-// revives a paused sandbox in place; only when nothing is found is one
-// created, stamped with the session id.
+// Find-or-create the session's one sandbox — the ensure-on-claim half
+// of the ratified lifecycle. Identity lives in the Store
+// (sessions.sandbox_id, set through the bindSandbox CAS), so every
+// claimer converges on one workspace BEFORE any tool executes: two
+// racers may both create, but exactly one registers; the loser kills
+// its own duplicate and connects to the winner. A pick made from
+// provider listings could not give this — racers see different lists,
+// and a committed step's workspace could be silently abandoned for the
+// duplicate. The {sessionId} metadata stamped at create is
+// observability, not identity.
+//
+// A binding can die under us — a "kill" TTL fired, or a paused sandbox
+// expired past recovery. Only the provider's definitive
+// SandboxNotFoundError triggers replacement (any other connect failure
+// propagates: treating an outage as gone would abandon a live
+// workspace), and the replacement runs the same convergence story one
+// level up: create, CAS expecting the dead id, loser kills its
+// duplicate and joins whoever replaced it first.
 //
 // The composition root closes the driver's `bindTools` dep over this:
 //   bindTools: (sessionId) =>
-//     ensureSandbox(provider, sessionId, opts).then(createSandboxTools)
-//
-// Two claimers can race here — a zombie whose lease expired and its
-// replacement may both list nothing and both create. Harmless: the
-// zombie's step is never committed and its orphan is GC'd by the TTL.
-// The deterministic pick keeps every later claim converging on one
-// survivor in the meantime.
+//     ensureSandbox(store, provider, sessionId, opts).then(createSandboxTools)
 
 import type { SessionId } from "@funky/core";
-import type { CreateSandboxOptions, Sandbox, SandboxProvider } from "../ports/sandbox-provider";
+import {
+  type CreateSandboxOptions,
+  type Sandbox,
+  SandboxNotFoundError,
+  type SandboxProvider,
+} from "../ports/sandbox-provider";
+import type { Store } from "../ports/store";
 
 export async function ensureSandbox(
+  store: Pick<Store, "getSession" | "bindSandbox">,
   provider: SandboxProvider,
   sessionId: SessionId,
   createOpts?: CreateSandboxOptions,
 ): Promise<Sandbox> {
-  const infos = await provider.list({ metadata: { sessionId } });
-  const found = [...infos].sort((a, b) => a.sandboxId.localeCompare(b.sandboxId))[0];
-  if (found) return provider.connect(found.sandboxId);
-  return provider.create({
-    ...createOpts,
-    metadata: { ...createOpts?.metadata, sessionId },
-  });
+  const session = await store.getSession(sessionId);
+  if (!session) throw new Error(`ensureSandbox: unknown session ${sessionId}`);
+  return acquire(session.sandboxId);
+
+  async function acquire(bound: string | undefined): Promise<Sandbox> {
+    if (bound !== undefined) {
+      try {
+        return await provider.connect(bound);
+      } catch (error) {
+        if (!(error instanceof SandboxNotFoundError)) throw error;
+        // Definitively gone — fall through and replace the binding.
+      }
+    }
+    const created = await provider.create({
+      ...createOpts,
+      metadata: { ...createOpts?.metadata, sessionId },
+    });
+    const winner = await store.bindSandbox(sessionId, created.sandboxId, bound);
+    if (winner === created.sandboxId) return created;
+
+    // Lost the registration race: discard the duplicate and join the
+    // winner — recursively, since the winner may itself be dead by now.
+    // A failed kill leaves an orphan for the TTL backstop.
+    await created.kill().catch(() => {});
+    return acquire(winner);
+  }
 }

--- a/packages/agent/src/driver/loop.ts
+++ b/packages/agent/src/driver/loop.ts
@@ -127,9 +127,16 @@ export async function runStep(
 
   // Fires only on lease loss — "stop working; this step will not commit".
   const step = new AbortController();
-  const stopHeartbeat = startHeartbeat(store, item.id, token, leaseMs, () => step.abort());
+  const heartbeat = startHeartbeat(store, item.id, token, leaseMs, () => step.abort());
 
   try {
+    // The first beat is awaited: no step work — not even reads — happens
+    // on a claim whose lease wasn't just revalidated. Without the await,
+    // a claim that expired during the loop's sandbox bind could execute
+    // a tool before the heartbeat noticed.
+    await heartbeat.validated;
+    if (step.signal.aborted) return;
+
     const entries = bySeq(await store.readEntries(item.sessionId));
 
     // Claim boundary: a pending cancel ends the run without running the
@@ -221,7 +228,7 @@ export async function runStep(
     if (err instanceof FencedError) return; // reclaimed elsewhere — drop, claim again
     throw err;
   } finally {
-    stopHeartbeat();
+    heartbeat.stop();
   }
 }
 
@@ -285,10 +292,15 @@ function toNext(action: Action): CommitStepRequest["next"] {
 }
 
 /**
- * Extend the lease every leaseMs / 3 until stopped. A heartbeat that
- * throws gets the lost-lease response: abort the step and let the lease
- * decide — if it was actually alive, the item is simply re-executed
- * after expiry. Wasted work, never wrong work.
+ * Extend the lease immediately and then every leaseMs / 3 until
+ * stopped. The first beat is an entry-time revalidation runStep AWAITS
+ * (`validated`) before doing any work: it re-covers whatever the
+ * claim's initial lease already spent before the step began — above
+ * all the loop's sandbox bind — so a step whose lease is already gone
+ * drops before executing a single tool. A heartbeat that throws gets
+ * the lost-lease response: abort the step and let the lease decide —
+ * if it was actually alive, the item is simply re-executed after
+ * expiry. Wasted work, never wrong work.
  */
 function startHeartbeat(
   store: Store,
@@ -296,7 +308,7 @@ function startHeartbeat(
   token: LeaseToken,
   leaseMs: number,
   onLost: () => void,
-): () => void {
+): { validated: Promise<void>; stop: () => void } {
   const period = Math.max(1, Math.floor(leaseMs / 3));
   let stopped = false;
   let timer: ReturnType<typeof setTimeout>;
@@ -314,10 +326,12 @@ function startHeartbeat(
     }
     timer = setTimeout(() => void beat(), period);
   };
-  timer = setTimeout(() => void beat(), period);
-  return () => {
-    stopped = true;
-    clearTimeout(timer);
+  return {
+    validated: beat(),
+    stop: () => {
+      stopped = true;
+      clearTimeout(timer);
+    },
   };
 }
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -17,6 +17,7 @@ export { toToolSpec } from "./engine/tool";
 export type { Tool, ToolContext, ToolDefinition, ToolOutcome } from "./engine/tool";
 export { createSandboxTools, sandboxToolSpecs } from "./tools/sandbox-tools";
 export type { InferenceProvider, StreamRequest } from "./ports/inference-provider";
+export { SandboxNotFoundError } from "./ports/sandbox-provider";
 export type {
   CommandResult,
   CreateSandboxOptions,

--- a/packages/agent/src/ports/README.md
+++ b/packages/agent/src/ports/README.md
@@ -8,7 +8,7 @@ what they are.
 | port                | one line                                                |
 | ------------------- | ------------------------------------------------------- |
 | `InferenceProvider` | one request in, one live stream of increments out       |
-| `Store`             | the single source of truth: 14 methods, two write paths |
+| `Store`             | the single source of truth: 15 methods, two write paths |
 
 Why the ports live here and not elsewhere:
 

--- a/packages/agent/src/ports/sandbox-provider.ts
+++ b/packages/agent/src/ports/sandbox-provider.ts
@@ -1,10 +1,12 @@
 // The SandboxProvider port
 //
-// The port is session-agnostic — sandboxes are addressed by sandboxId,
-// and the session mapping is data, not interface: the driver creates
-// with metadata {sessionId} and finds with list({metadata}). The
-// ratified ensure-on-claim lifecycle is therefore a driver-side helper
-// composed from list/connect/create, not a port method.
+// The port is session-agnostic — sandboxes are addressed by sandboxId.
+// The session mapping lives in the Store (sessions.sandbox_id via the
+// bindSandbox CAS); the {sessionId} metadata stamped at create is
+// observability, not identity — a listing can never say which sandbox
+// a session's committed history ran in. The ratified ensure-on-claim
+// lifecycle is a driver-side helper composed from connect/create plus
+// that CAS, not a port method.
 //
 // Contract for implementations:
 // - `create`'s timeout is a TTL the provider enforces on its own — the
@@ -30,9 +32,20 @@
 
 import type { NetworkPolicy } from "@funky/core";
 
+/**
+ * connect()'s "definitively gone" rejection: the sandbox no longer
+ * exists (killed, or expired past recovery) — as opposed to being
+ * unreachable. Rebinding a fresh sandbox over a dead one keys on this,
+ * so adapters MUST throw it only on provider confirmation, never for a
+ * transient failure — misclassifying an outage would abandon a live
+ * workspace.
+ */
+export class SandboxNotFoundError extends Error {}
+
 export interface SandboxProvider {
   create(opts?: CreateSandboxOptions): Promise<Sandbox>;
-  /** Reattach, reviving a paused sandbox; throws if unknown or killed. */
+  /** Reattach, reviving a paused sandbox. Rejects with
+   *  SandboxNotFoundError when the sandbox is unknown or killed. */
   connect(sandboxId: string): Promise<Sandbox>;
   /** Every non-killed sandbox, optionally filtered by metadata equality. */
   list(filter?: { metadata?: Record<string, string> }): Promise<SandboxInfo[]>;

--- a/packages/agent/src/ports/store.ts
+++ b/packages/agent/src/ports/store.ts
@@ -57,6 +57,14 @@ export interface Store {
   /** Rejects unknown config ids — a session never dangles. */
   createSession(req: CreateSessionRequest): Promise<SessionId>;
   getSession(id: SessionId): Promise<Session | undefined>;
+  /** Register the session's one sandbox: a compare-and-set on the
+   *  binding — fills a null binding when `previous` is omitted, or
+   *  replaces exactly `previous` when the caller is recovering a dead
+   *  sandbox. Returns the bound id either way: the atomic pick that
+   *  keeps every claimer executing in one workspace — a racer whose
+   *  candidate lost learns the winner and discards its own (see
+   *  driver/ensure-sandbox.ts). Rejects an unknown session. */
+  bindSandbox(sessionId: SessionId, sandboxId: string, previous?: string): Promise<string>;
 
   // --- reads — table-shaped; reads need no atomicity ---
 

--- a/packages/agent/test/ensure-sandbox.test.ts
+++ b/packages/agent/test/ensure-sandbox.test.ts
@@ -1,70 +1,90 @@
-// ensure-on-claim over a fake provider: find by session metadata and
-// connect (which revives), create stamped with the session id when
-// nothing exists, and converge deterministically when a race left two.
+// ensure-on-claim over fakes: connect when the Store already registered
+// the session's sandbox, create-and-register when none exists, kill the
+// duplicate and join the winner when the registration CAS is lost, and
+// replace a binding only when the provider says it is definitively gone.
 
 import { describe, expect, test } from "vitest";
+import type { Session } from "@funky/core";
 import { ensureSandbox } from "../src/driver/ensure-sandbox";
-import type {
-  CreateSandboxOptions,
-  Sandbox,
-  SandboxInfo,
-  SandboxProvider,
+import {
+  type CreateSandboxOptions,
+  type Sandbox,
+  SandboxNotFoundError,
+  type SandboxProvider,
 } from "../src/ports/sandbox-provider";
 
-function stub(sandboxId: string): Sandbox {
-  return { sandboxId } as Sandbox;
-}
-
-function fakeProvider(existing: SandboxInfo[]) {
-  const calls = {
-    list: [] as ({ metadata?: Record<string, string> } | undefined)[],
-    connect: [] as string[],
-    create: [] as (CreateSandboxOptions | undefined)[],
-  };
+function fakeProvider(opts?: { deadIds?: string[]; connectError?: Error }) {
+  const calls = { connect: [] as string[], create: [] as (CreateSandboxOptions | undefined)[] };
+  let killed = 0;
   const provider: SandboxProvider = {
-    create: async (opts) => {
-      calls.create.push(opts);
-      return stub("sbx_created");
+    create: async (createOpts) => {
+      calls.create.push(createOpts);
+      return {
+        sandboxId: "sbx_created",
+        kill: async () => {
+          killed++;
+        },
+      } as Sandbox;
     },
     connect: async (sandboxId) => {
       calls.connect.push(sandboxId);
-      return stub(sandboxId);
+      if (opts?.connectError) throw opts.connectError;
+      if (opts?.deadIds?.includes(sandboxId)) {
+        throw new SandboxNotFoundError(`sandbox ${sandboxId} not found`);
+      }
+      return { sandboxId } as Sandbox;
     },
-    list: async (filter) => {
-      calls.list.push(filter);
-      return existing;
-    },
+    list: async () => [],
   };
-  return { provider, calls };
+  return { provider, calls, killed: () => killed };
 }
 
-const info = (sandboxId: string): SandboxInfo => ({
-  sandboxId,
-  state: "paused",
-  metadata: { sessionId: "s1" },
-});
+function fakeStore(opts?: { sandboxId?: string; winner?: string }) {
+  const binds: { candidate: string; previous?: string }[] = [];
+  const session: Session = {
+    id: "s1",
+    agentConfigId: "a1",
+    envConfigId: "e1",
+    createdAt: "2026-08-18T00:00:00.000Z",
+    ...(opts?.sandboxId ? { sandboxId: opts.sandboxId } : {}),
+  };
+  return {
+    binds,
+    getSession: async (id: string) => (id === "s1" ? session : undefined),
+    bindSandbox: async (_sessionId: string, candidate: string, previous?: string) => {
+      binds.push({ candidate, previous });
+      return opts?.winner ?? candidate;
+    },
+  };
+}
 
 describe("ensureSandbox", () => {
-  test("connects to the sandbox found by session metadata", async () => {
-    const { provider, calls } = fakeProvider([info("sbx_a")]);
+  test("connects to the registered sandbox without creating or binding", async () => {
+    const store = fakeStore({ sandboxId: "sbx_bound" });
+    const { provider, calls } = fakeProvider();
 
-    const sandbox = await ensureSandbox(provider, "s1");
-    expect(sandbox.sandboxId).toBe("sbx_a");
-    expect(calls.list).toEqual([{ metadata: { sessionId: "s1" } }]);
-    expect(calls.connect).toEqual(["sbx_a"]);
+    const sandbox = await ensureSandbox(store, provider, "s1");
+    expect(sandbox.sandboxId).toBe("sbx_bound");
+    expect(calls.connect).toEqual(["sbx_bound"]);
     expect(calls.create).toEqual([]);
+    expect(store.binds).toEqual([]);
   });
 
-  test("creates with the session stamped into metadata when none exists", async () => {
-    const { provider, calls } = fakeProvider([]);
+  test("throws on an unknown session", async () => {
+    const { provider } = fakeProvider();
+    await expect(ensureSandbox(fakeStore(), provider, "nope")).rejects.toThrow("unknown session");
+  });
 
-    const sandbox = await ensureSandbox(provider, "s1", {
+  test("creates, stamps the session into metadata, and registers", async () => {
+    const store = fakeStore();
+    const { provider, calls, killed } = fakeProvider();
+
+    const sandbox = await ensureSandbox(store, provider, "s1", {
       timeoutMs: 60_000,
       network: { type: "none" },
       metadata: { tier: "test" },
     });
     expect(sandbox.sandboxId).toBe("sbx_created");
-    expect(calls.connect).toEqual([]);
     expect(calls.create).toEqual([
       {
         timeoutMs: 60_000,
@@ -72,14 +92,51 @@ describe("ensureSandbox", () => {
         metadata: { tier: "test", sessionId: "s1" },
       },
     ]);
+    expect(store.binds).toEqual([{ candidate: "sbx_created", previous: undefined }]);
+    expect(calls.connect).toEqual([]);
+    expect(killed()).toBe(0);
   });
 
-  test("converges on the lexicographically first sandbox when a race left two", async () => {
-    const { provider, calls } = fakeProvider([info("sbx_z"), info("sbx_a")]);
+  test("kills its duplicate and joins the winner when the CAS is lost", async () => {
+    const store = fakeStore({ winner: "sbx_theirs" });
+    const { provider, calls, killed } = fakeProvider();
 
-    const sandbox = await ensureSandbox(provider, "s1");
-    expect(sandbox.sandboxId).toBe("sbx_a");
-    expect(calls.connect).toEqual(["sbx_a"]);
+    const sandbox = await ensureSandbox(store, provider, "s1");
+    expect(sandbox.sandboxId).toBe("sbx_theirs");
+    expect(store.binds).toEqual([{ candidate: "sbx_created", previous: undefined }]);
+    expect(killed()).toBe(1);
+    expect(calls.connect).toEqual(["sbx_theirs"]);
+  });
+
+  test("replaces a binding the provider reports definitively gone", async () => {
+    const store = fakeStore({ sandboxId: "sbx_dead" });
+    const { provider, calls, killed } = fakeProvider({ deadIds: ["sbx_dead"] });
+
+    const sandbox = await ensureSandbox(store, provider, "s1");
+    expect(sandbox.sandboxId).toBe("sbx_created");
+    expect(calls.connect).toEqual(["sbx_dead"]);
+    // The CAS names the dead binding it expects to replace.
+    expect(store.binds).toEqual([{ candidate: "sbx_created", previous: "sbx_dead" }]);
+    expect(killed()).toBe(0);
+  });
+
+  test("joins whoever replaced the dead binding first", async () => {
+    const store = fakeStore({ sandboxId: "sbx_dead", winner: "sbx_theirs" });
+    const { provider, calls, killed } = fakeProvider({ deadIds: ["sbx_dead"] });
+
+    const sandbox = await ensureSandbox(store, provider, "s1");
+    expect(sandbox.sandboxId).toBe("sbx_theirs");
+    expect(store.binds).toEqual([{ candidate: "sbx_created", previous: "sbx_dead" }]);
+    expect(killed()).toBe(1);
+    expect(calls.connect).toEqual(["sbx_dead", "sbx_theirs"]);
+  });
+
+  test("propagates a transient connect failure without touching the binding", async () => {
+    const store = fakeStore({ sandboxId: "sbx_bound" });
+    const { provider, calls } = fakeProvider({ connectError: new Error("fetch failed") });
+
+    await expect(ensureSandbox(store, provider, "s1")).rejects.toThrow("fetch failed");
     expect(calls.create).toEqual([]);
+    expect(store.binds).toEqual([]);
   });
 });

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -87,6 +87,9 @@ export type CreateSessionRequest = z.infer<typeof CreateSessionRequest>;
 
 export const Session = CreateSessionRequest.extend({
   id: z.string(),
+  // The session's one workspace, registered by the driver's first
+  // execute_tools claim (Store.bindSandbox); absent until then.
+  sandboxId: z.string().optional(),
   createdAt: z.iso.datetime(),
 });
 export type Session = z.infer<typeof Session>;


### PR DESCRIPTION
Persists each session's sandbox binding with a compare-and-set store operation so racing claimers converge before tools execute and dead bindings can be safely replaced. Adds typed missing-sandbox handling in the E2B adapter while preserving transient failures, and awaits initial lease validation before doing any step work. Expands store, driver, sandbox, and E2B coverage for races, lease expiry, replacement, and error classification. Validation passed with pnpm typecheck, pnpm format:check, pnpm -F @funky/agent test, and pnpm -F @funky/adapters test.