### PR TITLE
Prevent tool re-execution after crashes

### DIFF
--- a/packages/adapters/migrations/0000_init.sql
+++ b/packages/adapters/migrations/0000_init.sql
@@ -45,6 +45,9 @@ CREATE TABLE work_items (
   lease_token text,
   lease_expires_at timestamptz,
   lease_ms integer,
+  -- Times claimed (claimItem increments). The driver's at-most-once
+  -- guard for tool side effects keys on attempt > 1.
+  attempt integer NOT NULL DEFAULT 0,
   created_at timestamptz NOT NULL
 );
 

--- a/packages/adapters/src/store/pg.ts
+++ b/packages/adapters/src/store/pg.ts
@@ -230,7 +230,13 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         .where(eq(workItems.sessionId, sessionId))
         .orderBy(asc(workItems.createdAt));
       return rows.map((r) =>
-        WorkItem.parse({ id: r.id, sessionId: r.sessionId, type: r.type, status: r.status }),
+        WorkItem.parse({
+          id: r.id,
+          sessionId: r.sessionId,
+          type: r.type,
+          status: r.status,
+          attempt: r.attempt,
+        }),
       );
     },
 
@@ -259,7 +265,12 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
           and(eq(workItems.status, "leased"), lte(workItems.leaseExpiresAt, t)),
         );
         const [candidate] = await tx
-          .select({ id: workItems.id, sessionId: workItems.sessionId, type: workItems.type })
+          .select({
+            id: workItems.id,
+            sessionId: workItems.sessionId,
+            type: workItems.type,
+            attempt: workItems.attempt,
+          })
           .from(workItems)
           .where(
             req.sessionId === undefined
@@ -271,6 +282,8 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
           .for("update", { skipLocked: true });
         if (!candidate) return undefined;
         const token = randomUUID(); // fresh per claim — never re-issued
+        // The row is locked, so read-and-increment cannot race.
+        const attempt = candidate.attempt + 1;
         await tx
           .update(workItems)
           .set({
@@ -278,6 +291,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
             leaseToken: token,
             leaseMs: req.leaseMs,
             leaseExpiresAt: new Date(t.getTime() + req.leaseMs),
+            attempt,
           })
           .where(eq(workItems.id, candidate.id));
         return {
@@ -286,6 +300,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
             sessionId: candidate.sessionId,
             type: candidate.type,
             status: "leased",
+            attempt,
           }),
           token,
         };

--- a/packages/adapters/src/store/schema.ts
+++ b/packages/adapters/src/store/schema.ts
@@ -91,6 +91,9 @@ export const workItems = pgTable(
     leaseToken: text("lease_token"),
     leaseExpiresAt: timestamp("lease_expires_at", { withTimezone: true }),
     leaseMs: integer("lease_ms"),
+    // Times claimed; the driver's at-most-once guard for tool side
+    // effects keys on attempt > 1.
+    attempt: integer("attempt").notNull().default(0),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
   },
   (t) => [

--- a/packages/adapters/test/crash-resume.test.ts
+++ b/packages/adapters/test/crash-resume.test.ts
@@ -1,9 +1,12 @@
 // The crash-resume property test — the durability contract made
 // executable: for ANY kill point during a scripted two-turn run,
-// SIGKILL + resume by a fresh driver converges on a transcript
-// identical to the uninterrupted reference. This is also runDriver's
-// real coverage — a child process hosting the actual loop, killed the
-// only way it ever stops.
+// SIGKILL + resume by a fresh driver converges on the reference
+// transcript — verbatim, except that a batch whose execute_tools claim
+// was killed mid-flight commits interrupted results instead (the
+// attempt > 1 carve-out: tool side effects are at-most-once, so a
+// re-claim never re-executes them). This is also runDriver's real
+// coverage — a child process hosting the actual loop, killed the only
+// way it ever stops.
 //
 // Topology: PGlite is single-client, so data-dir ownership alternates —
 // the parent seeds and inspects only while no child is alive, and
@@ -105,10 +108,40 @@ async function intakeSecondPrompt(dir: string): Promise<void> {
   }
 }
 
-async function assertMatchesReference(dir: string): Promise<void> {
+/**
+ * The reference transcript with the given toolResult batches replaced by
+ * what a re-claimed execute_tools item commits: interrupted results,
+ * never re-executed side effects (the attempt > 1 carve-out).
+ */
+function withInterrupted(entries: unknown[], batches: number[]): unknown[] {
+  let batch = 0;
+  return entries.map((entry) => {
+    const e = entry as { message?: { role?: string; toolCallId?: string; toolName?: string } };
+    if (e.message?.role !== "toolResult") return entry;
+    if (!batches.includes(batch++)) return entry;
+    return {
+      ...(entry as object),
+      message: {
+        role: "toolResult",
+        toolCallId: e.message.toolCallId,
+        toolName: e.message.toolName,
+        content: [{ type: "text", text: "Tool execution was interrupted." }],
+        isError: true,
+      },
+    };
+  });
+}
+
+/** Every interruption shape the sweep's random kills can produce. */
+const ANY_INTERRUPTION: number[][] = [[], [0], [1], [0, 1]];
+
+async function assertMatchesReference(dir: string, acceptable: number[][] = [[]]): Promise<void> {
   const { store, close } = await openDir(dir);
   try {
-    expect(normalizeEntries(await store.readEntries(sessionId))).toEqual(refEntries);
+    const actual = normalizeEntries(await store.readEntries(sessionId));
+    const variants = acceptable.map((batches) => withInterrupted(refEntries, batches));
+    if (variants.length === 1) expect(actual).toEqual(variants[0]);
+    else expect(variants).toContainEqual(actual);
     const items = await store.listItems(sessionId);
     expect(items.map((i) => i.type)).toEqual(refItemTypes);
     expect(items.map((i) => i.status)).toEqual(refItemTypes.map(() => "done"));
@@ -306,6 +339,11 @@ interface Scenario {
    *  complete and turn two started, so child-local counts index turn two. */
   seed: "fresh" | "midway";
   spec: KillSpec;
+  /** toolResult batches the resume commits as interrupted results: set
+   *  exactly when the kill lands while an execute_tools claim is open
+   *  (claimed, uncommitted), so the re-claim sees attempt > 1 and never
+   *  re-executes. Omitted = the reference transcript verbatim. */
+  interrupted?: number[];
 }
 
 // Turn one exhaustively (claims/commits 0-2 are the child's whole life);
@@ -316,16 +354,18 @@ const MATRIX: Scenario[] = [
   { seed: "fresh", spec: { class: "mid-inference", n: 0 } },
   { seed: "fresh", spec: { class: "before-commit", n: 0 } },
   { seed: "fresh", spec: { class: "after-commit", n: 0 } },
-  { seed: "fresh", spec: { class: "after-claim", n: 1 } },
-  { seed: "fresh", spec: { class: "mid-tools", n: 0 } },
-  { seed: "fresh", spec: { class: "before-commit", n: 1 } },
+  { seed: "fresh", spec: { class: "after-claim", n: 1 }, interrupted: [0] },
+  { seed: "fresh", spec: { class: "mid-tools", n: 0 }, interrupted: [0] },
+  // Killed after executing but before committing: the tools DID run, the
+  // commit never landed — the re-claim still must not run them again.
+  { seed: "fresh", spec: { class: "before-commit", n: 1 }, interrupted: [0] },
   { seed: "fresh", spec: { class: "after-commit", n: 1 } },
   { seed: "fresh", spec: { class: "mid-inference", n: 1 } },
   { seed: "fresh", spec: { class: "before-commit", n: 2 } },
   { seed: "fresh", spec: { class: "after-commit", n: 2 } }, // after end_run
   { seed: "midway", spec: { class: "after-claim", n: 0 } },
   { seed: "midway", spec: { class: "mid-inference", n: 2 } },
-  { seed: "midway", spec: { class: "mid-tools", n: 1 } },
+  { seed: "midway", spec: { class: "mid-tools", n: 1 }, interrupted: [1] },
   { seed: "midway", spec: { class: "before-commit", n: 2 } }, // before turn-two end_run
 ];
 
@@ -356,7 +396,7 @@ async function runScenario(sc: Scenario): Promise<void> {
       endRuns += countEndRuns(resume.received);
     }
 
-    await assertMatchesReference(dir);
+    await assertMatchesReference(dir, [sc.interrupted ?? []]);
   } finally {
     for (const child of children) await child.kill();
   }
@@ -423,7 +463,9 @@ describe.concurrent("crash-resume: randomized sweep", () => {
           endRuns += countEndRuns(child.received);
         }
 
-        await assertMatchesReference(dir);
+        // Random kills may land on open execute_tools claims, so any
+        // interruption shape is legitimate — but nothing else is.
+        await assertMatchesReference(dir, ANY_INTERRUPTION);
       } finally {
         for (const child of children) await child.kill();
       }

--- a/packages/adapters/test/crash-resume.test.ts
+++ b/packages/adapters/test/crash-resume.test.ts
@@ -13,8 +13,8 @@
 // follows a live child's progress through IPC signals from the child's
 // store wrapper (see fixtures/crash-driver.ts). Children run on the
 // real clock with short leases (300ms), so a dead child's claim expires
-// almost immediately and the resuming child re-executes from the
-// unchanged log.
+// almost immediately and the resuming child picks up from the unchanged
+// log — re-running inference, interrupting a claimed tool batch.
 //
 // Two modes:
 // - a deterministic matrix: the child stalls at a scheduled point

--- a/packages/adapters/test/driver.test.ts
+++ b/packages/adapters/test/driver.test.ts
@@ -295,6 +295,47 @@ describe("driver steps over the pg store", () => {
     expect(await store.claimItem({ leaseMs: 60_000, sessionId })).toBeUndefined();
   });
 
+  it("synthesizes interrupted results on a re-claimed execute_tools item — no re-execution", async () => {
+    const sessionId = await newSession();
+    const provider = scriptedProvider([callEcho("hi"), sayText("recovered")]);
+    let executions = 0;
+    const spiedEcho: Tool = {
+      ...echo,
+      execute: async (args, ctx) => {
+        executions++;
+        return echo.execute(args, ctx);
+      },
+    };
+    const deps: StepDeps = { store, provider, toolSpecs: [...echoOnly.values()].map(toToolSpec) };
+
+    await store.intake(sessionId, user("go"));
+    await runStep(deps, await claim(sessionId), 60_000); // inference → tool call
+
+    // First claim of the execute_tools item dies without committing —
+    // whether its side effects ran is unknowable.
+    const first = await claim(sessionId, 300);
+    expect(first.item.attempt).toBe(1);
+    clock.advance(10_000);
+    const second = await claim(sessionId);
+    expect(second.item.attempt).toBe(2);
+
+    await runStep(deps, second, 60_000, new Map([[spiedEcho.name, spiedEcho]]));
+    expect(executions).toBe(0);
+    const log = messages(await store.readEntries(sessionId));
+    expect(log[2]).toMatchObject({
+      role: "toolResult",
+      toolName: "echo",
+      content: [{ type: "text", text: "Tool execution was interrupted." }],
+      isError: true,
+    });
+
+    // The run continues: the model sees the interruption and answers.
+    await runStep(deps, await claim(sessionId), 60_000);
+    const finalLog = messages(await store.readEntries(sessionId));
+    expect(finalLog.map((m) => m.role)).toEqual(["user", "assistant", "toolResult", "assistant"]);
+    expect(finalLog[3]).toMatchObject({ stopReason: "end_turn" });
+  });
+
   it("revalidates the lease at entry: an expired claim does no work at all", async () => {
     const sessionId = await newSession();
     await store.intake(sessionId, user("go"));

--- a/packages/adapters/test/driver.test.ts
+++ b/packages/adapters/test/driver.test.ts
@@ -358,7 +358,7 @@ describe("driver steps over the pg store", () => {
     ]);
   });
 
-  it("drops an interrupted step on lease loss; the next claim re-executes", async () => {
+  it("drops an interrupted inference step on lease loss; the next claim re-executes", async () => {
     const sessionId = await newSession();
     await store.intake(sessionId, user("go"));
     const provider = scriptedProvider([["untilAborted"], sayText("recovered")]);

--- a/packages/adapters/test/store-conformance.ts
+++ b/packages/adapters/test/store-conformance.ts
@@ -232,6 +232,22 @@ export function describeStoreConformance(
         expect(await store.claimItem({ leaseMs: 60_000 })).toBeUndefined();
       });
 
+      it("counts attempts: 0 until claimed, incremented by every claim", async () => {
+        const sessionId = await newSession();
+        await store.intake(sessionId, user("go"));
+        expect((await store.listItems(sessionId))[0]?.attempt).toBe(0);
+
+        const first = await store.claimItem({ leaseMs: 1_000 });
+        expect(first?.item.attempt).toBe(1);
+
+        // Expiry and re-claim — the signal the driver's at-most-once
+        // tool guard keys on.
+        clock.advance(5_000);
+        const second = await store.claimItem({ leaseMs: 1_000 });
+        expect(second?.item.attempt).toBe(2);
+        expect((await store.listItems(sessionId))[0]?.attempt).toBe(2);
+      });
+
       it("admits exactly one winner under contended claims", async () => {
         const sessionId = await newSession();
         await store.intake(sessionId, user("go"));

--- a/packages/agent/src/driver/README.md
+++ b/packages/agent/src/driver/README.md
@@ -21,10 +21,14 @@ What lives here is what neither the engine nor a host may own:
   zombie's side effects and spend, never correctness.
 - **The crash rule.** An interrupted step is never committed. A dying
   worker commits nothing mid-step; the lease expires and the next
-  claimer re-executes from the unchanged log — shutdown IS a crash, so
-  crash-safety is exercised on every shutdown and no drain logic exists.
-  `FencedError` on commit is the same rule from the other side — the
-  item's fate belongs to another claim; drop the work, claim again.
+  claimer resumes from the unchanged log — re-running an inference
+  item, but never an execute_tools item: `attempt > 1` marks the dead
+  claimer, and the re-claim commits interrupted results instead of
+  re-executing side effects (tools are at-most-once across claims).
+  Shutdown IS a crash, so crash-safety is exercised on every shutdown
+  and no drain logic exists. `FencedError` on commit is the same rule
+  from the other side — the item's fate belongs to another claim; drop
+  the work, claim again.
 - **Boundary cancel checks.** `cancelRequested` reads the log's tail:
   while an item is open, only cancels (and decoration entries) can
   trail the last message entry — a theorem of the one-open-item

--- a/packages/agent/src/driver/loop.ts
+++ b/packages/agent/src/driver/loop.ts
@@ -9,9 +9,13 @@
 //
 // The rule the durability story rests on: an interrupted step is never
 // committed. A dying worker — SIGKILL, OOM, node loss — commits nothing
-// mid-step; the lease expires and the next claimer re-executes from the
-// unchanged log. Shutdown IS a crash, so crash-safety is exercised on
-// every shutdown. FencedError on commit is the same rule from the other
+// mid-step; the lease expires and the next claimer resumes from the
+// unchanged log — re-running an inference item, but never an
+// execute_tools item: attempt > 1 marks the dead claimer, and the
+// re-claim commits interrupted results instead of re-executing side
+// effects (tools are at-most-once across claims). Shutdown IS a crash,
+// so crash-safety is exercised on every shutdown. FencedError on
+// commit is the same rule from the other
 // side: the item's fate belongs to another claim now — drop the work,
 // claim again. The only mid-step abort is internal: the heartbeat
 // losing (or failing to reach) the lease aborts the in-flight provider
@@ -66,9 +70,11 @@ export interface DriverDeps extends StepDeps {
    *  ensure the sandbox, bind the tools, hand the map to runStep. The
    *  composition root closes this over ensureSandbox +
    *  createSandboxTools; tests hand back a fixed map. A rejection is
-   *  worker trouble, not tool trouble: it propagates uncommitted, and
-   *  the crash rule applies — the lease expires and another claim
-   *  retries. */
+   *  worker trouble, not tool trouble: it propagates uncommitted and
+   *  the crash rule applies. Note the cost: the claim already counted,
+   *  so the re-claim sees attempt > 1 and interrupts the batch rather
+   *  than retrying the bind — a transient sandbox outage costs the
+   *  model one recoverable batch, never a duplicated side effect. */
   bindTools(sessionId: SessionId): Promise<Map<string, Tool>>;
 }
 
@@ -211,8 +217,9 @@ export async function runStep(
       tail = last;
     }
 
-    // An interrupted step is never committed (see header). The lease will
-    // expire and the next claimer re-executes from the unchanged log.
+    // An interrupted step is never committed (see header). The lease
+    // will expire and the next claimer resumes from the unchanged log —
+    // re-running inference, interrupting a tool batch (attempt > 1).
     if (step.signal.aborted) return;
 
     // Commit boundary: pick up cancels that landed during the step. Only
@@ -304,8 +311,9 @@ function toNext(action: Action): CommitStepRequest["next"] {
  * all the loop's sandbox bind — so a step whose lease is already gone
  * drops before executing a single tool. A heartbeat that throws gets
  * the lost-lease response: abort the step and let the lease decide —
- * if it was actually alive, the item is simply re-executed after
- * expiry. Wasted work, never wrong work.
+ * if it was actually alive, the item simply expires into a re-claim
+ * (inference re-runs; a tool batch interrupts). Wasted work, never
+ * wrong work.
  */
 function startHeartbeat(
   store: Store,

--- a/packages/agent/src/driver/loop.ts
+++ b/packages/agent/src/driver/loop.ts
@@ -34,7 +34,7 @@ import type {
   ToolSpec,
 } from "@funky/core";
 import { buildContext } from "../engine/build-context";
-import { executeTools, type ToolUpdate } from "../engine/execute-tools";
+import { executeTools, interruptedResult, type ToolUpdate } from "../engine/execute-tools";
 import { inference } from "../engine/inference";
 import { type Action, nextAction } from "../engine/next-action";
 import type { Tool } from "../engine/tool";
@@ -96,12 +96,16 @@ export async function runDriver(deps: DriverDeps, opts: DriverOptions = {}): Pro
       await sleep(idlePollMs);
       continue;
     }
-    // Ensure-on-claim: only an execute_tools item pays for a sandbox.
-    // The bind runs on the claim's initial lease — heartbeats start
-    // inside runStep — so if a slow sandbox create outlives the lease,
-    // the step's commit is fenced: wasted work, never wrong work.
+    // Ensure-on-claim: only an execute_tools item that will actually
+    // execute pays for a sandbox — a re-claim (attempt > 1) synthesizes
+    // interrupted results and needs none. The bind runs on the claim's
+    // initial lease — heartbeats start inside runStep — so if a slow
+    // sandbox create outlives the lease, the step's commit is fenced:
+    // wasted work, never wrong work.
     const tools =
-      claim.item.type === "execute_tools" ? await deps.bindTools(claim.item.sessionId) : undefined;
+      claim.item.type === "execute_tools" && claim.item.attempt === 1
+        ? await deps.bindTools(claim.item.sessionId)
+        : undefined;
     await runStep(deps, claim, leaseMs, tools);
   }
 }
@@ -189,16 +193,17 @@ export async function runStep(
       consumeInputs = pending.map((input) => input.id);
       tail = message;
     } else {
-      // TODO(attempt): a re-claimed execute_tools item re-executes its
-      // calls' side effects. Step 4's carve-out — `work_items.attempt` +
-      // synthesized interrupted results on attempt > 1 — lands with the
-      // Store schema change and its own crash-resume tests.
+      // Never-retry extends across claims: attempt > 1 means an earlier
+      // claimer died holding this item, and its side effects may have
+      // run uncommitted — indistinguishable from not having run at all.
+      // The step is not re-executed; every call settles as the same
+      // interrupted result buildContext synthesizes for dangling calls,
+      // and the model decides recovery from what it can see.
       const calls = tailCalls(entries);
-      const results = await executeTools(
-        { tools, onUpdate: deps.onUpdate },
-        { calls },
-        step.signal,
-      );
+      const results =
+        item.attempt > 1
+          ? calls.map((call) => interruptedResult(call))
+          : await executeTools({ tools, onUpdate: deps.onUpdate }, { calls }, step.signal);
       append = results;
       // All results share one fate; the last one becomes the tail.
       const last = results[results.length - 1];

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -107,6 +107,11 @@ export const WorkItem = z.object({
   sessionId: z.string(),
   type: ItemType,
   status: ItemStatus,
+  // Times claimed (claimItem increments; 0 = never claimed). attempt > 1
+  // means an earlier claimer died holding this item — its side effects
+  // may have run uncommitted, so the driver never re-executes tools on a
+  // re-claim; it synthesizes interrupted results instead.
+  attempt: z.number().int().min(0),
 });
 export type WorkItem = z.infer<typeof WorkItem>;
 

--- a/packages/core/test/store.test.ts
+++ b/packages/core/test/store.test.ts
@@ -129,7 +129,7 @@ describe("sessions", () => {
 
 describe("work items", () => {
   it("round-trips a work item", () => {
-    const item = { id: "i1", sessionId: "s1", type: "inference", status: "ready" };
+    const item = { id: "i1", sessionId: "s1", type: "inference", status: "ready", attempt: 0 };
     expect(roundTrip(WorkItem, item)).toEqual(item);
   });
 


### PR DESCRIPTION
Adds a persisted claim-attempt counter to work items and increments it atomically whenever an item is leased. Reclaimed tool-execution items now synthesize interrupted results instead of rebinding a sandbox and potentially repeating side effects, while inference items remain retryable. Expands store, driver, core, and crash-resume coverage for attempt counting and every accepted interruption shape. Validation passed with pnpm typecheck, pnpm format:check, and the core, agent, and adapter test suites.