### PR TITLE
Add the namespace tenancy boundary to the store

### DIFF
--- a/packages/adapters/migrations/0000_init.sql
+++ b/packages/adapters/migrations/0000_init.sql
@@ -3,10 +3,15 @@
 -- doc's "Postgres targets": the same DDL must run on PGlite, compose,
 -- k8s, Cloud SQL, PlanetScale-for-Postgres).
 
+-- namespace: the tenancy boundary (core/store.ts). Only the three
+-- ownable row types carry it; children derive theirs through
+-- session_id. No SQL DEFAULT — the adapter materializes the value, so
+-- the resolution lives in exactly one place.
 CREATE TABLE agent_configs (
   id text PRIMARY KEY,
   inference jsonb NOT NULL,
   system_prompt text NOT NULL,
+  namespace text NOT NULL,
   metadata jsonb,
   created_at timestamptz NOT NULL
 );
@@ -15,6 +20,7 @@ CREATE TABLE env_configs (
   id text PRIMARY KEY,
   network jsonb NOT NULL,
   packages jsonb NOT NULL,
+  namespace text NOT NULL,
   metadata jsonb,
   created_at timestamptz NOT NULL
 );
@@ -23,6 +29,7 @@ CREATE TABLE sessions (
   id text PRIMARY KEY,
   agent_config_id text NOT NULL REFERENCES agent_configs(id),
   env_config_id text NOT NULL REFERENCES env_configs(id),
+  namespace text NOT NULL,
   -- The session's one workspace; null until the driver's first
   -- execute_tools claim registers it (Store.bindSandbox, set-if-null).
   sandbox_id text,

--- a/packages/adapters/src/store/pg.ts
+++ b/packages/adapters/src/store/pg.ts
@@ -32,6 +32,7 @@ import {
   CreateAgentConfigRequest,
   CreateEnvConfigRequest,
   CreateSessionRequest,
+  DEFAULT_NAMESPACE,
   EnvConfig,
   IntakeResult,
   type JsonValue,
@@ -109,6 +110,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         id,
         inference: parsed.inference,
         systemPrompt: parsed.systemPrompt,
+        namespace: parsed.namespace ?? DEFAULT_NAMESPACE,
         metadata: wrap(parsed.metadata),
         createdAt: now(),
       });
@@ -122,6 +124,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         id: row.id,
         inference: row.inference,
         systemPrompt: row.systemPrompt,
+        namespace: row.namespace,
         ...unwrapped(row.metadata),
         createdAt: iso(row.createdAt),
       });
@@ -135,6 +138,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         // Materialized at create — resolved decisions, not restatable defaults.
         network: parsed.network ?? { type: "unrestricted" },
         packages: parsed.packages ?? {},
+        namespace: parsed.namespace ?? DEFAULT_NAMESPACE,
         metadata: wrap(parsed.metadata),
         createdAt: now(),
       });
@@ -148,6 +152,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         id: row.id,
         network: row.network,
         packages: row.packages,
+        namespace: row.namespace,
         ...unwrapped(row.metadata),
         createdAt: iso(row.createdAt),
       });
@@ -155,23 +160,30 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
 
     async createSession(req) {
       const parsed = CreateSessionRequest.parse(req);
+      const namespace = parsed.namespace ?? DEFAULT_NAMESPACE;
       // Configs are write-once and never deleted, so this pre-check cannot
       // go stale; the FK constraints remain as the structural backstop.
+      // The checks are namespace-scoped: a session and its configs always
+      // share one namespace, and a foreign config is "unknown" —
+      // indistinguishable from nonexistent, so nothing leaks.
       const [agent] = await db
         .select({ id: agentConfigs.id })
         .from(agentConfigs)
-        .where(eq(agentConfigs.id, parsed.agentConfigId));
+        .where(
+          and(eq(agentConfigs.id, parsed.agentConfigId), eq(agentConfigs.namespace, namespace)),
+        );
       if (!agent) throw new Error(`unknown agent config: ${parsed.agentConfigId}`);
       const [env] = await db
         .select({ id: envConfigs.id })
         .from(envConfigs)
-        .where(eq(envConfigs.id, parsed.envConfigId));
+        .where(and(eq(envConfigs.id, parsed.envConfigId), eq(envConfigs.namespace, namespace)));
       if (!env) throw new Error(`unknown env config: ${parsed.envConfigId}`);
       const id = randomUUID();
       await db.insert(sessions).values({
         id,
         agentConfigId: parsed.agentConfigId,
         envConfigId: parsed.envConfigId,
+        namespace,
         metadata: wrap(parsed.metadata),
         createdAt: now(),
       });
@@ -185,6 +197,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         id: row.id,
         agentConfigId: row.agentConfigId,
         envConfigId: row.envConfigId,
+        namespace: row.namespace,
         ...(row.sandboxId ? { sandboxId: row.sandboxId } : {}),
         ...unwrapped(row.metadata),
         createdAt: iso(row.createdAt),

--- a/packages/adapters/src/store/schema.ts
+++ b/packages/adapters/src/store/schema.ts
@@ -39,6 +39,9 @@ export const agentConfigs = pgTable("agent_configs", {
   id: text("id").primaryKey(),
   inference: jsonb("inference").$type<InferenceConfig>().notNull(),
   systemPrompt: text("system_prompt").notNull(),
+  // The tenancy boundary (core/store.ts) — the adapter materializes the
+  // default; no SQL DEFAULT, so the resolution lives in exactly one place.
+  namespace: text("namespace").notNull(),
   metadata: jsonb("metadata").$type<WrappedJson>(),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
 });
@@ -48,6 +51,7 @@ export const envConfigs = pgTable("env_configs", {
   // Materialized at create — never SQL NULL (resolved decisions, not defaults).
   network: jsonb("network").$type<NetworkPolicy>().notNull(),
   packages: jsonb("packages").$type<Packages>().notNull(),
+  namespace: text("namespace").notNull(),
   metadata: jsonb("metadata").$type<WrappedJson>(),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
 });
@@ -60,6 +64,7 @@ export const sessions = pgTable("sessions", {
   envConfigId: text("env_config_id")
     .notNull()
     .references(() => envConfigs.id),
+  namespace: text("namespace").notNull(),
   // The session's one workspace; null until bindSandbox registers it.
   sandboxId: text("sandbox_id"),
   metadata: jsonb("metadata").$type<WrappedJson>(),

--- a/packages/adapters/test/store-conformance.ts
+++ b/packages/adapters/test/store-conformance.ts
@@ -7,7 +7,7 @@
 // advancing time, never by sleeping.
 
 import { beforeEach, describe, expect, it } from "vitest";
-import type { AssistantMessage, UserMessage } from "@funky/core";
+import { type AssistantMessage, DEFAULT_NAMESPACE, type UserMessage } from "@funky/core";
 import { type CommitStepRequest, FencedError, type Store } from "@funky/agent";
 
 export interface StoreHarness {
@@ -178,6 +178,60 @@ export function describeStoreConformance(
           systemPrompt: "s",
         });
         await expect(store.createSession({ agentConfigId, envConfigId: "nope" })).rejects.toThrow();
+      });
+    });
+
+    describe("namespace", () => {
+      it("materializes DEFAULT_NAMESPACE when absent, on all three ownable rows", async () => {
+        const agentConfigId = await store.createAgentConfig({
+          inference: { provider: "fake", model: "m" },
+          systemPrompt: "s",
+        });
+        const envConfigId = await store.createEnvConfig({});
+        const sessionId = await store.createSession({ agentConfigId, envConfigId });
+        expect((await store.getAgentConfig(agentConfigId))?.namespace).toBe(DEFAULT_NAMESPACE);
+        expect((await store.getEnvConfig(envConfigId))?.namespace).toBe(DEFAULT_NAMESPACE);
+        expect((await store.getSession(sessionId))?.namespace).toBe(DEFAULT_NAMESPACE);
+      });
+
+      it("stores an explicit namespace verbatim", async () => {
+        const agentConfigId = await store.createAgentConfig({
+          inference: { provider: "fake", model: "m" },
+          systemPrompt: "s",
+          namespace: "tenant-a",
+        });
+        const envConfigId = await store.createEnvConfig({ namespace: "tenant-a" });
+        const sessionId = await store.createSession({
+          agentConfigId,
+          envConfigId,
+          namespace: "tenant-a",
+        });
+        expect((await store.getAgentConfig(agentConfigId))?.namespace).toBe("tenant-a");
+        expect((await store.getEnvConfig(envConfigId))?.namespace).toBe("tenant-a");
+        expect((await store.getSession(sessionId))?.namespace).toBe("tenant-a");
+      });
+
+      it("a foreign-namespace config is unknown — sessions and their configs share one namespace", async () => {
+        const agentA = await store.createAgentConfig({
+          inference: { provider: "fake", model: "m" },
+          systemPrompt: "s",
+          namespace: "tenant-a",
+        });
+        const envA = await store.createEnvConfig({ namespace: "tenant-a" });
+        const envB = await store.createEnvConfig({ namespace: "tenant-b" });
+
+        // Cross-namespace refs reject exactly like dangling refs — the
+        // error is the same "unknown", so existence never leaks.
+        await expect(
+          store.createSession({ agentConfigId: agentA, envConfigId: envB, namespace: "tenant-a" }),
+        ).rejects.toThrow("unknown env config");
+        await expect(
+          store.createSession({ agentConfigId: agentA, envConfigId: envA, namespace: "tenant-b" }),
+        ).rejects.toThrow("unknown agent config");
+        // The matched trio is accepted.
+        await expect(
+          store.createSession({ agentConfigId: agentA, envConfigId: envA, namespace: "tenant-a" }),
+        ).resolves.toBeDefined();
       });
     });
 

--- a/packages/agent/src/ports/store.ts
+++ b/packages/agent/src/ports/store.ts
@@ -54,7 +54,10 @@ export interface Store {
 
   // --- sessions ---
 
-  /** Rejects unknown config ids — a session never dangles. */
+  /** Rejects unknown config ids — a session never dangles — and the
+   *  checks are namespace-scoped: a config in a different namespace IS
+   *  unknown (indistinguishable from nonexistent, so nothing leaks). A
+   *  session and its configs therefore always share one namespace. */
   createSession(req: CreateSessionRequest): Promise<SessionId>;
   getSession(id: SessionId): Promise<Session | undefined>;
   /** Register the session's one sandbox: a compare-and-set on the

--- a/packages/agent/test/ensure-sandbox.test.ts
+++ b/packages/agent/test/ensure-sandbox.test.ts
@@ -45,6 +45,7 @@ function fakeStore(opts?: { sandboxId?: string; winner?: string }) {
     id: "s1",
     agentConfigId: "a1",
     envConfigId: "e1",
+    namespace: "default",
     createdAt: "2026-08-18T00:00:00.000Z",
     ...(opts?.sandboxId ? { sandboxId: opts.sandboxId } : {}),
   };

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -36,6 +36,20 @@ export type SessionId = string;
 export type ItemId = string;
 export type InputId = string;
 
+// --- namespace ---
+
+// The tenancy boundary, driven by the managed service's trusted gateway
+// (an OSS deployment runs single-tenant and never sets it). Ownership is
+// exactly-one and lives as a fact on the three ownable row types —
+// decided at create, immutable, resolved to DEFAULT_NAMESPACE when
+// absent, like every other materialized default. Work items, entries,
+// and pending inputs derive theirs through sessionId; the worker and
+// the driver never read it. Enforcement is split: the store guarantees
+// a session and its configs share one namespace (a foreign config is
+// "unknown" — indistinguishable from nonexistent, so nothing leaks);
+// scoping reads to a caller's namespace is the api's fetch-then-check.
+export const DEFAULT_NAMESPACE = "default";
+
 // --- configs ---
 
 // Config rows are write-once: the port exposes no update or delete, so
@@ -46,12 +60,14 @@ export type InputId = string;
 export const CreateAgentConfigRequest = z.object({
   inference: InferenceConfig,
   systemPrompt: z.string(),
+  namespace: z.string().min(1).optional(),
   metadata: JsonValue.optional(),
 });
 export type CreateAgentConfigRequest = z.infer<typeof CreateAgentConfigRequest>;
 
 export const AgentConfig = CreateAgentConfigRequest.extend({
   id: z.string(),
+  namespace: z.string().min(1), // materialized: absence resolved to DEFAULT_NAMESPACE
   createdAt: z.iso.datetime(),
 });
 export type AgentConfig = z.infer<typeof AgentConfig>;
@@ -63,6 +79,7 @@ export const CreateEnvConfigRequest = z.object({
   // Presence is guaranteed at create() or creation fails — missing deps
   // surface at provision, not mid-session.
   packages: Packages.optional(),
+  namespace: z.string().min(1).optional(),
   metadata: JsonValue.optional(),
 });
 export type CreateEnvConfigRequest = z.infer<typeof CreateEnvConfigRequest>;
@@ -72,6 +89,7 @@ export const EnvConfig = CreateEnvConfigRequest.extend({
   // Materialized at create — resolved decisions, not restatable defaults:
   network: NetworkPolicy, // absence resolved to { type: "unrestricted" }
   packages: Packages, // absence resolved to {}
+  namespace: z.string().min(1), // absence resolved to DEFAULT_NAMESPACE
   createdAt: z.iso.datetime(),
 });
 export type EnvConfig = z.infer<typeof EnvConfig>;
@@ -81,12 +99,17 @@ export type EnvConfig = z.infer<typeof EnvConfig>;
 export const CreateSessionRequest = z.object({
   agentConfigId: z.string(),
   envConfigId: z.string(),
+  // Explicit, not derived from the configs: deriving would let a leaked
+  // foreign config id pull a session into the wrong namespace. The store
+  // enforces the match instead.
+  namespace: z.string().min(1).optional(),
   metadata: JsonValue.optional(),
 });
 export type CreateSessionRequest = z.infer<typeof CreateSessionRequest>;
 
 export const Session = CreateSessionRequest.extend({
   id: z.string(),
+  namespace: z.string().min(1), // materialized: absence resolved to DEFAULT_NAMESPACE
   // The session's one workspace, registered by the driver's first
   // execute_tools claim (Store.bindSandbox); absent until then.
   sandboxId: z.string().optional(),

--- a/packages/core/test/store.test.ts
+++ b/packages/core/test/store.test.ts
@@ -25,6 +25,7 @@ describe("configs", () => {
         temperature: 0.7,
       },
       systemPrompt: "You are helpful.",
+      namespace: "tenant-a",
       metadata: { team: "growth" },
       createdAt: "2026-08-11T12:00:00Z",
     };
@@ -44,6 +45,7 @@ describe("configs", () => {
       id: "ac1",
       inference: { provider: "fake", model: "scripted" },
       systemPrompt: "s",
+      namespace: "default",
       createdAt: "2026-08-11T12:00:00Z",
     };
     expect(roundTrip(AgentConfig, config)).toEqual(config);
@@ -74,6 +76,7 @@ describe("env configs", () => {
       id: "ec1",
       network: { type: "allowlist", domains: ["api.anthropic.com", "pypi.org"] },
       packages: { pip: ["pandas==2.2.0", "numpy"], npm: ["express@4.18.0"] },
+      namespace: "tenant-a",
       metadata: { envId: "env_014588" },
       createdAt: "2026-08-11T12:00:00Z",
     };
@@ -111,9 +114,20 @@ describe("sessions", () => {
       id: "s1",
       agentConfigId: "ac1",
       envConfigId: "ec1",
+      namespace: "default",
       createdAt: "2026-08-11T12:00:00Z",
     };
     expect(roundTrip(Session, session)).toEqual(session);
+  });
+
+  it("rejects a stored session missing namespace — materialized decisions must be present", () => {
+    const result = Session.safeParse({
+      id: "s1",
+      agentConfigId: "ac1",
+      envConfigId: "ec1",
+      createdAt: "2026-08-11T12:00:00Z",
+    });
+    expect(result.success).toBe(false);
   });
 
   it("rejects a create request without an agent config id", () => {


### PR DESCRIPTION
## Summary

PR 1 of 2 (the api rebuild stacks on this). Ratified 2026-08-19: the managed Funky service owns identity and policy (users, tokens, quotas, billing); OSS ships the isolation **mechanism** — a namespace ownership fact the managed gateway drives via model 2 (one shared deployment, backend token held only by the control plane).

- **`core/store.ts`** — `DEFAULT_NAMESPACE`, plus `namespace` optional on the three `Create*Request`s and required (materialized) on the rows. Session namespace is explicit, not derived from its configs: deriving would let a leaked foreign config id pull a session into the wrong namespace.
- **Adapter** — `namespace text NOT NULL` on `agent_configs` / `env_configs` / `sessions` (migration amended in place, pre-release convention; no SQL `DEFAULT` — the adapter materializes, so the resolution lives in exactly one place).
- **`createSession` enforces the one store-side rule** — its existence pre-checks are namespace-scoped, and a foreign-namespace config throws the identical `unknown agent/env config` error: foreign and nonexistent are indistinguishable, so existence never leaks.
- **Not touched, by design** — `work_items`, `session_entries`, `pending_inputs` (children derive their namespace through `sessionId`), and the worker/driver/`claimItem`, which never read it. A solo self-hoster sees nothing: everything resolves to `"default"`.

## Test plan

- Conformance suite gains three tests (default materialization on all three rows, explicit round-trip, the cross-namespace rejection matrix), running on PGlite and the gated network-postgres binding.
- `tsc --noEmit`, prettier clean; core 29/29, agent 85/85, adapters 94/94 (+2 gated skips), worker 5/5 (+1 gated skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)