### PR TITLE
Add the agent-configs route

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,6 +6,7 @@ import type { NamespaceSource } from "./config";
 import { errorHandler, errorResponse } from "./http";
 import { auth } from "./middleware/auth";
 import { requestId } from "./middleware/request-id";
+import { agentConfigRoutes } from "./routes/agent-configs";
 import { envConfigRoutes } from "./routes/env-configs";
 
 export type AppDeps = {
@@ -33,6 +34,7 @@ export function buildApp(deps: AppDeps) {
   });
 
   app.use("/v1/*", auth(deps.authToken, deps.namespaceSource));
+  app.route("/v1/agent-configs", agentConfigRoutes(deps.store));
   app.route("/v1/env-configs", envConfigRoutes(deps.store));
 
   app.notFound((c) => errorResponse(c, 404, "not_found_error", "unknown route"));

--- a/apps/api/src/routes/agent-configs.ts
+++ b/apps/api/src/routes/agent-configs.ts
@@ -1,0 +1,42 @@
+// apps/api/src/routes/agent-configs.ts
+// The agent-config resource — write-once behavior recipes (inference +
+// system prompt), tenant-private like every config. Same shape as
+// env-configs.ts: two verbs, core schemas as the wire format, the
+// middleware's namespace stamped on create and checked on read.
+import { Hono } from "hono";
+import { CreateAgentConfigRequest } from "@funky/core";
+import type { Store } from "@funky/agent";
+import { errorResponse } from "../http";
+import { validate } from "./common";
+
+/** The slice of the harness Store this resource needs. */
+export type AgentConfigStore = Pick<Store, "createAgentConfig" | "getAgentConfig">;
+
+type Env = { Variables: { requestId: string; namespace: string } };
+
+const WireCreateAgentConfig = CreateAgentConfigRequest.omit({ namespace: true });
+
+export function agentConfigRoutes(store: AgentConfigStore) {
+  const r = new Hono<Env>();
+
+  r.post("/", validate("json", WireCreateAgentConfig), async (c) => {
+    const id = await store.createAgentConfig({
+      ...c.req.valid("json"),
+      namespace: c.get("namespace"),
+    });
+    const config = await store.getAgentConfig(id);
+    if (!config) throw new Error(`agent config ${id} missing after create`);
+    return c.json(config, 201);
+  });
+
+  r.get("/:id", async (c) => {
+    const id = c.req.param("id");
+    const config = await store.getAgentConfig(id);
+    if (!config || config.namespace !== c.get("namespace")) {
+      return errorResponse(c, 404, "not_found_error", `no agent config ${id}`);
+    }
+    return c.json(config);
+  });
+
+  return r;
+}

--- a/apps/api/test/agent-configs.test.ts
+++ b/apps/api/test/agent-configs.test.ts
@@ -1,0 +1,91 @@
+// Route tests over the REAL store — PGlite + the pg adapter — same
+// pattern as env-configs.test.ts. The middleware machinery (auth,
+// header source validation) is covered there and in app.test.ts; here
+// we pin this resource's wiring, materialization, and its own
+// fetch-then-check scoping.
+import { readFileSync } from "node:fs";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createPgStore, type StoreDb } from "@funky/adapters";
+import { buildApp } from "../src/app";
+import { get, post } from "./helpers";
+
+const ddl = readFileSync(
+  new URL("../../../packages/adapters/migrations/0000_init.sql", import.meta.url),
+  "utf8",
+);
+
+const RECIPE = {
+  inference: { provider: "anthropic", model: "claude-sonnet-5", maxTokens: 8192 },
+  systemPrompt: "You are a data analyst.",
+};
+
+let client: PGlite;
+let app: ReturnType<typeof buildApp>;
+let scoped: ReturnType<typeof buildApp>; // namespaceSource "header" over the SAME store
+
+beforeAll(async () => {
+  client = new PGlite();
+  await client.exec(ddl);
+  const store = createPgStore(drizzle({ client }) as unknown as StoreDb);
+  app = buildApp({ store, authToken: null, namespaceSource: "static", ping: async () => ({}) });
+  scoped = buildApp({ store, authToken: null, namespaceSource: "header", ping: async () => ({}) });
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+describe("POST /v1/agent-configs", () => {
+  it("creates and returns the stored row, 201", async () => {
+    const res = await post(app, "/v1/agent-configs", RECIPE);
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.inference).toEqual(RECIPE.inference);
+    expect(body.systemPrompt).toBe(RECIPE.systemPrompt);
+    expect(body.namespace).toBe("default");
+    expect(typeof body.id).toBe("string");
+    expect(typeof body.createdAt).toBe("string");
+
+    const fetched = await get(app, `/v1/agent-configs/${body.id}`);
+    expect(fetched.status).toBe(200);
+    expect(await fetched.json()).toEqual(body);
+  });
+
+  it("rejects a bare-string inference config, 400", async () => {
+    const res = await post(app, "/v1/agent-configs", {
+      inference: "claude-sonnet-5",
+      systemPrompt: "s",
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("rejects a missing system prompt, 400", async () => {
+    const res = await post(app, "/v1/agent-configs", { inference: RECIPE.inference });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /v1/agent-configs/:id", () => {
+  it("404s an unknown id with the error envelope", async () => {
+    const res = await get(app, "/v1/agent-configs/nope");
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.type).toBe("not_found_error");
+  });
+
+  it("scopes by namespace: a foreign row 404s exactly like a nonexistent one", async () => {
+    const asTenant = (tenant: string) => ({ "X-Funky-Namespace": tenant });
+    const created = await (
+      await post(scoped, "/v1/agent-configs", RECIPE, asTenant("tenant-a"))
+    ).json();
+    expect(created.namespace).toBe("tenant-a");
+
+    const foreign = await get(scoped, `/v1/agent-configs/${created.id}`, asTenant("tenant-b"));
+    expect(foreign.status).toBe(404);
+
+    const own = await get(scoped, `/v1/agent-configs/${created.id}`, asTenant("tenant-a"));
+    expect(own.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

The second write-once resource on the harness Store, mirroring env-configs (#113/#114):

- `POST /v1/agent-configs` — body is core's `CreateAgentConfigRequest` minus `namespace` (the middleware's decision is the only source); 201 with the stored row.
- `GET /v1/agent-configs/:id` — fetch-then-check: a foreign-namespace row 404s identically to a nonexistent one.
- Two verbs only, by construction — the Store port has no update/delete/list for config rows.

## Test plan

`test/agent-configs.test.ts` over a real PGlite-backed pg store: create/round-trip with `namespace: "default"`, 400s (bare-string inference, missing system prompt), 404 unknown, and the per-route scoping check (foreign 404 / own 200). Middleware machinery itself is covered by the existing app/env-configs suites. `tsc --noEmit` + prettier clean; api 24/24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)