### PR TITLE
Add the sessions routes: intake, cancel, and inspection

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -8,6 +8,7 @@ import { auth } from "./middleware/auth";
 import { requestId } from "./middleware/request-id";
 import { agentConfigRoutes } from "./routes/agent-configs";
 import { envConfigRoutes } from "./routes/env-configs";
+import { sessionRoutes } from "./routes/sessions";
 
 export type AppDeps = {
   /** the harness Store — each route narrows it to the slice it needs */
@@ -36,6 +37,7 @@ export function buildApp(deps: AppDeps) {
   app.use("/v1/*", auth(deps.authToken, deps.namespaceSource));
   app.route("/v1/agent-configs", agentConfigRoutes(deps.store));
   app.route("/v1/env-configs", envConfigRoutes(deps.store));
+  app.route("/v1/sessions", sessionRoutes(deps.store));
 
   app.notFound((c) => errorResponse(c, 404, "not_found_error", "unknown route"));
   app.onError(errorHandler);

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -1,0 +1,110 @@
+// apps/api/src/routes/sessions.ts
+// The sessions resource — the intake half of the Store port, plus the
+// inspection reads. Every route under /:id does the ownership check
+// once at the top: a foreign session 404s exactly like a nonexistent
+// one, so nothing leaks across namespaces.
+//
+// The api writes nothing itself: intake and requestCancel are the only
+// mutations, both Store transactions. Whether a message starts a run or
+// queues as a pending input is intake's in-transaction branch — the
+// IntakeResult (started | queued) is returned verbatim, and both answer
+// 202: the work itself happens in a worker, asynchronously.
+import { Hono } from "hono";
+import { z } from "zod";
+import { CreateSessionRequest, UserMessage } from "@funky/core";
+import type { Store } from "@funky/agent";
+import { errorResponse } from "../http";
+import { validate } from "./common";
+
+/** The slice of the harness Store this resource needs. */
+export type SessionStore = Pick<
+  Store,
+  "createSession" | "getSession" | "intake" | "requestCancel" | "readEntries" | "listItems"
+>;
+
+type Env = { Variables: { requestId: string; namespace: string } };
+
+const WireCreateSession = CreateSessionRequest.omit({ namespace: true });
+
+// "Always an array; plain strings are normalized at intake"
+// (core/messages.ts) — this is the intake boundary, so the wire accepts
+// both spellings and the role is stamped, never sent.
+const WireMessage = z.object({
+  content: z.union([z.string(), UserMessage.shape.content]),
+});
+
+const EntriesQuery = z.object({
+  after: z.coerce.number().int().nonnegative().optional(),
+});
+
+export function sessionRoutes(store: SessionStore) {
+  const r = new Hono<Env>();
+
+  r.post("/", validate("json", WireCreateSession), async (c) => {
+    let id: string;
+    try {
+      id = await store.createSession({ ...c.req.valid("json"), namespace: c.get("namespace") });
+    } catch (err) {
+      // The store's namespace-scoped existence check: a dangling config
+      // ref and a foreign-namespace one throw the same "unknown".
+      if (err instanceof Error && err.message.startsWith("unknown ")) {
+        return errorResponse(c, 400, "invalid_request_error", err.message);
+      }
+      throw err;
+    }
+    const session = await store.getSession(id);
+    if (!session) throw new Error(`session ${id} missing after create`);
+    return c.json(session, 201);
+  });
+
+  r.get("/:id", async (c) => {
+    const session = await owned(c);
+    if (!session) return notFound(c);
+    return c.json(session);
+  });
+
+  r.post("/:id/messages", validate("json", WireMessage), async (c) => {
+    const session = await owned(c);
+    if (!session) return notFound(c);
+    const { content } = c.req.valid("json");
+    const message: UserMessage = {
+      role: "user",
+      content: typeof content === "string" ? [{ type: "text", text: content }] : content,
+    };
+    return c.json(await store.intake(session.id, message), 202);
+  });
+
+  r.post("/:id/cancel", async (c) => {
+    const session = await owned(c);
+    if (!session) return notFound(c);
+    // Appends a control entry; the worker answers it at a step boundary,
+    // so cancellation is accepted here, not completed.
+    await store.requestCancel(session.id);
+    return c.body(null, 202);
+  });
+
+  r.get("/:id/entries", validate("query", EntriesQuery), async (c) => {
+    const session = await owned(c);
+    if (!session) return notFound(c);
+    return c.json(await store.readEntries(session.id, c.req.valid("query").after));
+  });
+
+  r.get("/:id/items", async (c) => {
+    const session = await owned(c);
+    if (!session) return notFound(c);
+    return c.json(await store.listItems(session.id));
+  });
+
+  /** The one ownership check: undefined for unknown AND foreign rows. */
+  async function owned(c: { req: { param(k: "id"): string }; get(k: "namespace"): string }) {
+    const session = await store.getSession(c.req.param("id"));
+    if (!session || session.namespace !== c.get("namespace")) return undefined;
+    return session;
+  }
+
+  function notFound(c: Parameters<typeof errorResponse>[0]) {
+    return errorResponse(c, 404, "not_found_error", "no such session");
+  }
+
+  return r;
+}

--- a/apps/api/test/sessions.test.ts
+++ b/apps/api/test/sessions.test.ts
@@ -1,0 +1,184 @@
+// Route tests over the REAL store — PGlite + the pg adapter. The
+// worker is deliberately absent: what these pin is the intake half
+// (create, started/queued branching, cancel-as-control-entry) and the
+// inspection reads, all through HTTP, plus the ownership boundary.
+import { readFileSync } from "node:fs";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createPgStore, type StoreDb } from "@funky/adapters";
+import { buildApp } from "../src/app";
+import { get, post } from "./helpers";
+
+const ddl = readFileSync(
+  new URL("../../../packages/adapters/migrations/0000_init.sql", import.meta.url),
+  "utf8",
+);
+
+let client: PGlite;
+let app: ReturnType<typeof buildApp>;
+let scoped: ReturnType<typeof buildApp>; // namespaceSource "header" over the SAME store
+
+beforeAll(async () => {
+  client = new PGlite();
+  await client.exec(ddl);
+  const store = createPgStore(drizzle({ client }) as unknown as StoreDb);
+  app = buildApp({ store, authToken: null, namespaceSource: "static", ping: async () => ({}) });
+  scoped = buildApp({ store, authToken: null, namespaceSource: "header", ping: async () => ({}) });
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+const asTenant = (tenant: string) => ({ "X-Funky-Namespace": tenant });
+
+/** Seed the two configs over HTTP; returns their ids. */
+async function seedConfigs(
+  on: ReturnType<typeof buildApp>,
+  headers: Record<string, string> = {},
+): Promise<{ agentConfigId: string; envConfigId: string }> {
+  const agent = await (
+    await post(
+      on,
+      "/v1/agent-configs",
+      { inference: { provider: "fake", model: "m" }, systemPrompt: "s" },
+      headers,
+    )
+  ).json();
+  const env = await (await post(on, "/v1/env-configs", {}, headers)).json();
+  return { agentConfigId: agent.id, envConfigId: env.id };
+}
+
+async function seedSession(
+  on: ReturnType<typeof buildApp>,
+  headers: Record<string, string> = {},
+): Promise<string> {
+  const configs = await seedConfigs(on, headers);
+  const res = await post(on, "/v1/sessions", configs, headers);
+  expect(res.status).toBe(201);
+  return (await res.json()).id;
+}
+
+describe("POST /v1/sessions", () => {
+  it("creates and returns the materialized session, 201", async () => {
+    const configs = await seedConfigs(app);
+    const res = await post(app, "/v1/sessions", configs);
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.agentConfigId).toBe(configs.agentConfigId);
+    expect(body.envConfigId).toBe(configs.envConfigId);
+    expect(body.namespace).toBe("default");
+    expect(typeof body.id).toBe("string");
+  });
+
+  it("400s a dangling config reference", async () => {
+    const { envConfigId } = await seedConfigs(app);
+    const res = await post(app, "/v1/sessions", { agentConfigId: "nope", envConfigId });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("400s a foreign-namespace config identically to a dangling one", async () => {
+    const configs = await seedConfigs(scoped, asTenant("tenant-a"));
+    const res = await post(scoped, "/v1/sessions", configs, asTenant("tenant-b"));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.message).toMatch(/^unknown /);
+  });
+});
+
+describe("GET /v1/sessions/:id", () => {
+  it("404s unknown and foreign sessions alike", async () => {
+    expect((await get(app, "/v1/sessions/nope")).status).toBe(404);
+
+    const sessionId = await seedSession(scoped, asTenant("tenant-a"));
+    expect((await get(scoped, `/v1/sessions/${sessionId}`, asTenant("tenant-b"))).status).toBe(404);
+    expect((await get(scoped, `/v1/sessions/${sessionId}`, asTenant("tenant-a"))).status).toBe(200);
+  });
+});
+
+describe("POST /v1/sessions/:id/messages", () => {
+  it("starts a run on an idle session, queues while one is active", async () => {
+    const sessionId = await seedSession(app);
+
+    const first = await post(app, `/v1/sessions/${sessionId}/messages`, { content: "hi" });
+    expect(first.status).toBe(202);
+    const started = await first.json();
+    expect(started.kind).toBe("started");
+    expect(typeof started.itemId).toBe("string");
+
+    // The open item bars a second run: the message parks as pending input.
+    const second = await post(app, `/v1/sessions/${sessionId}/messages`, {
+      content: [{ type: "text", text: "also this" }],
+    });
+    expect(second.status).toBe(202);
+    const queued = await second.json();
+    expect(queued.kind).toBe("queued");
+    expect(typeof queued.inputId).toBe("string");
+  });
+
+  it("normalizes a plain string into text content", async () => {
+    const sessionId = await seedSession(app);
+    await post(app, `/v1/sessions/${sessionId}/messages`, { content: "plain" });
+    const entries = await (await get(app, `/v1/sessions/${sessionId}/entries`)).json();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].message).toEqual({
+      role: "user",
+      content: [{ type: "text", text: "plain" }],
+    });
+  });
+
+  it("404s an unknown session", async () => {
+    const res = await post(app, "/v1/sessions/nope/messages", { content: "hi" });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("inspection", () => {
+  it("entries?after= is a seq cursor", async () => {
+    const sessionId = await seedSession(app);
+    await post(app, `/v1/sessions/${sessionId}/messages`, { content: "hi" });
+
+    const all = await (await get(app, `/v1/sessions/${sessionId}/entries`)).json();
+    expect(all).toHaveLength(1);
+    const afterTail = await (
+      await get(app, `/v1/sessions/${sessionId}/entries?after=${all[0].seq}`)
+    ).json();
+    expect(afterTail).toHaveLength(0);
+  });
+
+  it("items shows the started run's ready inference item", async () => {
+    const sessionId = await seedSession(app);
+    const started = await (
+      await post(app, `/v1/sessions/${sessionId}/messages`, { content: "hi" })
+    ).json();
+
+    const items = await (await get(app, `/v1/sessions/${sessionId}/items`)).json();
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ id: started.itemId, type: "inference", status: "ready" });
+  });
+});
+
+describe("POST /v1/sessions/:id/cancel", () => {
+  it("accepts and appends a control entry", async () => {
+    const sessionId = await seedSession(app);
+    await post(app, `/v1/sessions/${sessionId}/messages`, { content: "hi" });
+
+    const res = await post(app, `/v1/sessions/${sessionId}/cancel`);
+    expect(res.status).toBe(202);
+
+    const entries = await (await get(app, `/v1/sessions/${sessionId}/entries`)).json();
+    expect(entries[entries.length - 1].type).toBe("control");
+  });
+
+  it("404s a foreign session", async () => {
+    const sessionId = await seedSession(scoped, asTenant("tenant-a"));
+    const res = await post(
+      scoped,
+      `/v1/sessions/${sessionId}/cancel`,
+      undefined,
+      asTenant("tenant-b"),
+    );
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

The substantive api PR: sessions connect the HTTP surface to the harness Store's write path. With this merged, api + worker + postgres can run a real turn end to end (the two-process e2e comes with the topology PR).

- `POST /v1/sessions` — create with the middleware's namespace; a dangling config ref and a foreign-namespace one answer the **same** 400 (the store's namespace-scoped existence check makes them literally one error — nothing leaks).
- `POST /v1/sessions/:id/messages` — `intake` verbatim: 202 with `{kind:"started", itemId}` on an idle session, `{kind:"queued", inputId}` while a run is active (the one-open-item invariant decides, in the store's transaction). Plain-string content is normalized to `[{type:"text",...}]` here — this is the intake boundary the core comment reserves that job for.
- `POST /v1/sessions/:id/cancel` — appends the control entry, 202: accepted, not completed; the worker answers at a step boundary (v1 cancel latency is one step).
- `GET /v1/sessions/:id`, `/entries?after=<seq>`, `/items` — inspection reads, core rows verbatim.
- **Ownership once per route**: every `/:id` route resolves the session and 404s foreign rows identically to nonexistent ones.

## Test plan

`test/sessions.test.ts` over a real PGlite-backed pg store, all through HTTP: create/materialize, dangling-vs-foreign 400 equivalence, started→queued branching, string normalization pinned in the stored entry, seq-cursor behavior, ready-inference-item inspection, cancel's control entry at the tail, and the foreign-404 matrix. `tsc --noEmit` + prettier clean; api 35/35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)