### PR TITLE
Add the SSE stream route: replay from cursor, then tail the entries

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -8,7 +8,7 @@ import { auth } from "./middleware/auth";
 import { requestId } from "./middleware/request-id";
 import { agentConfigRoutes } from "./routes/agent-configs";
 import { envConfigRoutes } from "./routes/env-configs";
-import { sessionRoutes } from "./routes/sessions";
+import { sessionRoutes, type StreamPacing } from "./routes/sessions";
 
 export type AppDeps = {
   /** the harness Store — each route narrows it to the slice it needs */
@@ -19,6 +19,8 @@ export type AppDeps = {
   namespaceSource: NamespaceSource;
   /** liveness of the DB, e.g. () => pool.query("SELECT 1") */
   ping: () => Promise<unknown>;
+  /** SSE tail pacing for /sessions/:id/stream */
+  stream: StreamPacing;
 };
 
 type Env = { Variables: { requestId: string; namespace: string } };
@@ -37,7 +39,7 @@ export function buildApp(deps: AppDeps) {
   app.use("/v1/*", auth(deps.authToken, deps.namespaceSource));
   app.route("/v1/agent-configs", agentConfigRoutes(deps.store));
   app.route("/v1/env-configs", envConfigRoutes(deps.store));
-  app.route("/v1/sessions", sessionRoutes(deps.store));
+  app.route("/v1/sessions", sessionRoutes(deps.store, deps.stream));
 
   app.notFound((c) => errorResponse(c, 404, "not_found_error", "unknown route"));
   app.onError(errorHandler);

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -19,6 +19,10 @@ const EnvSchema = z
     FUNKY_AUTH: z.enum(["enabled", "disabled"]).default("enabled"),
     FUNKY_AUTH_TOKEN: z.string().min(16, "FUNKY_AUTH_TOKEN must be ≥16 chars").optional(),
     FUNKY_NAMESPACE_SOURCE: z.enum(["static", "header"]).default("static"),
+    /** SSE tail pacing: how often /stream re-polls the entries cursor,
+     *  and how long a quiet stream goes before a keep-alive comment. */
+    FUNKY_STREAM_POLL_MS: z.coerce.number().int().min(1).default(1000),
+    FUNKY_STREAM_HEARTBEAT_MS: z.coerce.number().int().min(1).default(15_000),
   })
   .refine((e) => e.FUNKY_AUTH === "disabled" || e.FUNKY_AUTH_TOKEN !== undefined, {
     message:
@@ -37,6 +41,8 @@ export type Config = {
   /** null = auth explicitly disabled (dev only) */
   authToken: string | null;
   namespaceSource: NamespaceSource;
+  streamPollMs: number;
+  streamHeartbeatMs: number;
 };
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
@@ -58,5 +64,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     dbPoolMax: e.DB_POOL_MAX,
     authToken: e.FUNKY_AUTH === "disabled" ? null : e.FUNKY_AUTH_TOKEN!,
     namespaceSource: e.FUNKY_NAMESPACE_SOURCE,
+    streamPollMs: e.FUNKY_STREAM_POLL_MS,
+    streamHeartbeatMs: e.FUNKY_STREAM_HEARTBEAT_MS,
   };
 }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -20,6 +20,7 @@ const app = buildApp({
   authToken: cfg.authToken,
   namespaceSource: cfg.namespaceSource,
   ping: () => pool.query("SELECT 1"),
+  stream: { pollMs: cfg.streamPollMs, heartbeatMs: cfg.streamHeartbeatMs },
 });
 
 serve({ fetch: app.fetch, port: cfg.port }, (info) => {

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -10,6 +10,7 @@
 // IntakeResult (started | queued) is returned verbatim, and both answer
 // 202: the work itself happens in a worker, asynchronously.
 import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
 import { z } from "zod";
 import { CreateSessionRequest, UserMessage } from "@funky/core";
 import type { Store } from "@funky/agent";
@@ -21,6 +22,14 @@ export type SessionStore = Pick<
   Store,
   "createSession" | "getSession" | "intake" | "requestCancel" | "readEntries" | "listItems"
 >;
+
+/** SSE tail pacing — from config in production, shrunk by tests. */
+export type StreamPacing = {
+  /** delay between entries-cursor polls */
+  pollMs: number;
+  /** quiet time before a keep-alive comment (defeats idle proxy timeouts) */
+  heartbeatMs: number;
+};
 
 type Env = { Variables: { requestId: string; namespace: string } };
 
@@ -37,7 +46,7 @@ const EntriesQuery = z.object({
   after: z.coerce.number().int().nonnegative().optional(),
 });
 
-export function sessionRoutes(store: SessionStore) {
+export function sessionRoutes(store: SessionStore, pacing: StreamPacing) {
   const r = new Hono<Env>();
 
   r.post("/", validate("json", WireCreateSession), async (c) => {
@@ -93,6 +102,52 @@ export function sessionRoutes(store: SessionStore) {
     const session = await owned(c);
     if (!session) return notFound(c);
     return c.json(await store.listItems(session.id));
+  });
+
+  // The entries read, delivered incrementally: replay past the cursor,
+  // then tail by re-polling it. Each event is `id: <seq>` + `data:
+  // <entry JSON>` — the same objects GET /entries returns, unnamed so a
+  // plain EventSource onmessage sees everything and `data.type`
+  // discriminates. `id: seq` makes resume SSE-native: an auto-reconnect
+  // sends Last-Event-ID, honored over ?after=. This is the truth lane
+  // only — committed entries, message granularity; the lossy delta fast
+  // lane (DeltaSink) is a later, additive event type on this same
+  // stream. Polling, not LISTEN/NOTIFY, by ratified decision: a
+  // Notifier would change latency inside this loop, never the wire.
+  //
+  // The stream has no server-side end — sessions don't terminate. The
+  // client hangs up; `aborted` stops the loop.
+  r.get("/:id/stream", validate("query", EntriesQuery), async (c) => {
+    const session = await owned(c);
+    if (!session) return notFound(c);
+    let after = c.req.valid("query").after;
+    const lastEventId = c.req.header("Last-Event-ID");
+    if (lastEventId !== undefined) {
+      const resumed = EntriesQuery.shape.after.safeParse(lastEventId);
+      if (!resumed.success) {
+        return errorResponse(c, 400, "invalid_request_error", "malformed Last-Event-ID");
+      }
+      after = resumed.data;
+    }
+    return streamSSE(c, async (stream) => {
+      let cursor = after;
+      let quietSince = Date.now();
+      while (!stream.aborted) {
+        const entries = [...(await store.readEntries(session.id, cursor))].sort(
+          (a, b) => a.seq - b.seq,
+        );
+        for (const entry of entries) {
+          await stream.writeSSE({ id: String(entry.seq), data: JSON.stringify(entry) });
+          cursor = entry.seq;
+          quietSince = Date.now();
+        }
+        if (Date.now() - quietSince >= pacing.heartbeatMs) {
+          await stream.write(": ping\n\n");
+          quietSince = Date.now();
+        }
+        await stream.sleep(pacing.pollMs);
+      }
+    });
   });
 
   /** The one ownership check: undefined for unknown AND foreign rows. */

--- a/apps/api/test/agent-configs.test.ts
+++ b/apps/api/test/agent-configs.test.ts
@@ -29,8 +29,10 @@ beforeAll(async () => {
   client = new PGlite();
   await client.exec(ddl);
   const store = createPgStore(drizzle({ client }) as unknown as StoreDb);
-  app = buildApp({ store, authToken: null, namespaceSource: "static", ping: async () => ({}) });
-  scoped = buildApp({ store, authToken: null, namespaceSource: "header", ping: async () => ({}) });
+  const base = { store, authToken: null, ping: async () => ({}) };
+  const stream = { pollMs: 1000, heartbeatMs: 15_000 };
+  app = buildApp({ ...base, namespaceSource: "static", stream });
+  scoped = buildApp({ ...base, namespaceSource: "header", stream });
 });
 
 afterAll(async () => {

--- a/apps/api/test/config.test.ts
+++ b/apps/api/test/config.test.ts
@@ -30,7 +30,19 @@ describe("loadConfig — valid input", () => {
       dbPoolMax: 10,
       authToken: BASE.FUNKY_AUTH_TOKEN,
       namespaceSource: "static",
+      streamPollMs: 1000,
+      streamHeartbeatMs: 15_000,
     });
+  });
+
+  it("coerces the stream pacing overrides", () => {
+    const cfg = loadConfig({
+      ...BASE,
+      FUNKY_STREAM_POLL_MS: "250",
+      FUNKY_STREAM_HEARTBEAT_MS: "5000",
+    });
+    expect(cfg.streamPollMs).toBe(250);
+    expect(cfg.streamHeartbeatMs).toBe(5000);
   });
 
   it("FUNKY_AUTH=disabled yields a null token (and no token required)", () => {

--- a/apps/api/test/env-configs.test.ts
+++ b/apps/api/test/env-configs.test.ts
@@ -22,8 +22,10 @@ beforeAll(async () => {
   client = new PGlite();
   await client.exec(ddl);
   const store = createPgStore(drizzle({ client }) as unknown as StoreDb);
-  app = buildApp({ store, authToken: null, namespaceSource: "static", ping: async () => ({}) });
-  scoped = buildApp({ store, authToken: null, namespaceSource: "header", ping: async () => ({}) });
+  const base = { store, authToken: null, ping: async () => ({}) };
+  const stream = { pollMs: 1000, heartbeatMs: 15_000 };
+  app = buildApp({ ...base, namespaceSource: "static", stream });
+  scoped = buildApp({ ...base, namespaceSource: "header", stream });
 });
 
 afterAll(async () => {

--- a/apps/api/test/helpers.ts
+++ b/apps/api/test/helpers.ts
@@ -15,6 +15,7 @@ export function makeApp(
     authToken: opts.authToken ?? null,
     namespaceSource: opts.namespaceSource ?? "static",
     ping: async () => ({}),
+    stream: { pollMs: 1000, heartbeatMs: 15_000 },
   });
 }
 

--- a/apps/api/test/sessions.test.ts
+++ b/apps/api/test/sessions.test.ts
@@ -18,13 +18,25 @@ const ddl = readFileSync(
 let client: PGlite;
 let app: ReturnType<typeof buildApp>;
 let scoped: ReturnType<typeof buildApp>; // namespaceSource "header" over the SAME store
+let heartbeatApp: ReturnType<typeof buildApp>; // heartbeat fires within a test's patience
+
+// Fast enough that stream tests never wait on the poll; a heartbeat
+// would mark the test hung, so it is effectively off everywhere but
+// heartbeatApp.
+const PACING = { pollMs: 10, heartbeatMs: 60_000 };
 
 beforeAll(async () => {
   client = new PGlite();
   await client.exec(ddl);
   const store = createPgStore(drizzle({ client }) as unknown as StoreDb);
-  app = buildApp({ store, authToken: null, namespaceSource: "static", ping: async () => ({}) });
-  scoped = buildApp({ store, authToken: null, namespaceSource: "header", ping: async () => ({}) });
+  const base = { store, authToken: null, ping: async () => ({}) };
+  app = buildApp({ ...base, namespaceSource: "static", stream: PACING });
+  scoped = buildApp({ ...base, namespaceSource: "header", stream: PACING });
+  heartbeatApp = buildApp({
+    ...base,
+    namespaceSource: "static",
+    stream: { pollMs: 10, heartbeatMs: 25 },
+  });
 });
 
 afterAll(async () => {
@@ -180,5 +192,118 @@ describe("POST /v1/sessions/:id/cancel", () => {
       asTenant("tenant-b"),
     );
     expect(res.status).toBe(404);
+  });
+});
+
+/** Incremental SSE consumer over a fetch Response. Always cancel() —
+ *  the server loop only stops when the client hangs up. */
+function sseReader(res: Response) {
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const nextFrame = async (): Promise<string> => {
+    while (true) {
+      const cut = buffer.indexOf("\n\n");
+      if (cut !== -1) {
+        const frame = buffer.slice(0, cut);
+        buffer = buffer.slice(cut + 2);
+        return frame;
+      }
+      const { done, value } = await reader.read();
+      if (done) throw new Error("stream ended before an event arrived");
+      buffer += decoder.decode(value, { stream: true });
+    }
+  };
+  return {
+    /** raw frame, comments included */
+    nextFrame,
+    /** next data event, comments skipped */
+    async next(): Promise<{ id?: string; data: string }> {
+      while (true) {
+        const event: { id?: string; data: string } = { data: "" };
+        for (const line of (await nextFrame()).split("\n")) {
+          if (line.startsWith("id:")) event.id = line.slice(3).trim();
+          else if (line.startsWith("data:")) event.data += line.slice(5).trim();
+        }
+        if (event.data !== "") return event;
+      }
+    },
+    cancel: () => reader.cancel(),
+  };
+}
+
+describe("GET /v1/sessions/:id/stream", () => {
+  it("replays committed entries, then tails ones landing while open", async () => {
+    const sessionId = await seedSession(app);
+    await post(app, `/v1/sessions/${sessionId}/messages`, { content: "hi" });
+    const expected = await (await get(app, `/v1/sessions/${sessionId}/entries`)).json();
+
+    const res = await get(app, `/v1/sessions/${sessionId}/stream`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    const reader = sseReader(res);
+    try {
+      const replayed = await reader.next();
+      expect(replayed.id).toBe(String(expected[0].seq));
+      expect(JSON.parse(replayed.data)).toEqual(expected[0]);
+
+      // Cancel is the one entry writer these worker-less tests have; its
+      // control entry landing mid-stream is the live-tail proof.
+      await post(app, `/v1/sessions/${sessionId}/cancel`);
+      const tailed = await reader.next();
+      expect(JSON.parse(tailed.data).type).toBe("control");
+      expect(Number(tailed.id)).toBeGreaterThan(expected[0].seq);
+    } finally {
+      await reader.cancel();
+    }
+  });
+
+  it("resumes from ?after=, and Last-Event-ID wins over it", async () => {
+    // Three entries: the message, then two cancels (re-cancelling is legal).
+    const sessionId = await seedSession(app);
+    await post(app, `/v1/sessions/${sessionId}/messages`, { content: "hi" });
+    await post(app, `/v1/sessions/${sessionId}/cancel`);
+    await post(app, `/v1/sessions/${sessionId}/cancel`);
+    const entries = await (await get(app, `/v1/sessions/${sessionId}/entries`)).json();
+    expect(entries).toHaveLength(3);
+
+    // ?after= alone would skip everything; the header rewinds to the
+    // first entry and must win: the stream resumes at the second.
+    const res = await get(app, `/v1/sessions/${sessionId}/stream?after=${entries[2].seq}`, {
+      "Last-Event-ID": String(entries[0].seq),
+    });
+    const reader = sseReader(res);
+    try {
+      expect((await reader.next()).id).toBe(String(entries[1].seq));
+    } finally {
+      await reader.cancel();
+    }
+  });
+
+  it("400s a malformed Last-Event-ID", async () => {
+    const sessionId = await seedSession(app);
+    const res = await get(app, `/v1/sessions/${sessionId}/stream`, { "Last-Event-ID": "abc" });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("404s a foreign session before any byte streams", async () => {
+    const sessionId = await seedSession(scoped, asTenant("tenant-a"));
+    const res = await get(scoped, `/v1/sessions/${sessionId}/stream`, asTenant("tenant-b"));
+    expect(res.status).toBe(404);
+  });
+
+  it("keeps a quiet stream alive with heartbeat comments", async () => {
+    // No entries at all: nothing will ever be emitted but the heartbeat.
+    const sessionId = await seedSession(heartbeatApp);
+    const res = await get(heartbeatApp, `/v1/sessions/${sessionId}/stream`);
+    const reader = sseReader(res);
+    try {
+      let frame = "";
+      while (!frame.includes(": ping")) frame = await reader.nextFrame();
+      expect(frame).toContain(": ping");
+    } finally {
+      await reader.cancel();
+    }
   });
 });


### PR DESCRIPTION
## Summary

`GET /v1/sessions/:id/stream` — the entries read, delivered incrementally. This is the **truth lane** of the ratified two-lane wire protocol; the lossy delta fast lane (`DeltaSink`) stays deferred to P5 and will ride in later as additive event types on this same stream.

- **Same objects as `GET /entries`.** Each SSE event is `id: <seq>` + `data: <entry JSON>` — unnamed, so a plain `EventSource.onmessage` sees everything and `data.type` discriminates. One client code path for reconnect and live rendering.
- **Resume is SSE-native.** `id: seq` means an auto-reconnecting EventSource sends `Last-Event-ID`; the route honors it over `?after=`. A malformed header 400s.
- **Poll, not NOTIFY (ratified).** The tail re-polls the entries cursor every `FUNKY_STREAM_POLL_MS` (default 1s). A pg LISTEN/NOTIFY Notifier would change latency inside this loop, never the wire — it can land later, shared with the worker's idle poll, without touching this contract.
- **Heartbeat.** A quiet stream emits a `: ping` comment every `FUNKY_STREAM_HEARTBEAT_MS` (default 15s) so idle proxies don't sever it.
- **No server-side end.** Sessions don't terminate; the client hangs up and the abort stops the loop. Ownership is checked before any byte streams — a foreign session 404s exactly like a nonexistent one.
- Pacing threads through `AppDeps.stream` from config, so tests run at ~10ms poll.

## Test plan

- [x] `vitest run` in `apps/api`: **41/41** (5 new stream tests + config pacing test) over real PGlite through HTTP:
  - replay of committed entries with `id` = seq, payload equal to `GET /entries`
  - live tail — a control entry committed *while the stream is open* arrives (cancel is the one entry writer these worker-less tests have)
  - `?after=` resume, and `Last-Event-ID` precedence over it
  - malformed `Last-Event-ID` → 400 envelope
  - foreign-namespace session → 404 before any byte streams
  - heartbeat comment on a quiet stream
- [x] `tsc --noEmit` clean, prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)