### PR TITLE
Refuse a stream poll slower than the heartbeat

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -32,6 +32,13 @@ const EnvSchema = z
   .refine((e) => e.FUNKY_AUTH !== "disabled" || e.FUNKY_NAMESPACE_SOURCE !== "header", {
     path: ["FUNKY_NAMESPACE_SOURCE"],
     message: "FUNKY_NAMESPACE_SOURCE=header requires FUNKY_AUTH=enabled",
+  })
+  // The stream loop checks the heartbeat once per poll, so a poll slower
+  // than the heartbeat would silently stretch the keepalive past its
+  // schedule. Refuse the combination rather than complicate the loop.
+  .refine((e) => e.FUNKY_STREAM_POLL_MS <= e.FUNKY_STREAM_HEARTBEAT_MS, {
+    path: ["FUNKY_STREAM_POLL_MS"],
+    message: "FUNKY_STREAM_POLL_MS must not exceed FUNKY_STREAM_HEARTBEAT_MS",
   });
 
 export type Config = {

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -141,6 +141,9 @@ export function sessionRoutes(store: SessionStore, pacing: StreamPacing) {
           cursor = entry.seq;
           quietSince = Date.now();
         }
+        // Checked once per poll, so the heartbeat can run late by up to one
+        // poll interval — config forbids a poll slower than the heartbeat,
+        // which keeps that slack shorter than the schedule it pads.
         if (Date.now() - quietSince >= pacing.heartbeatMs) {
           await stream.write(": ping\n\n");
           quietSince = Date.now();

--- a/apps/api/test/config.test.ts
+++ b/apps/api/test/config.test.ts
@@ -74,6 +74,16 @@ describe("loadConfig — invalid input", () => {
     expect(() => loadConfig({ ...BASE, FUNKY_AUTH_TOKEN: "short" })).toThrow("process.exit(1)");
   });
 
+  it("exits when the stream poll is slower than the heartbeat", () => {
+    expect(() =>
+      loadConfig({
+        ...BASE,
+        FUNKY_STREAM_POLL_MS: "60000",
+        FUNKY_STREAM_HEARTBEAT_MS: "15000",
+      }),
+    ).toThrow("process.exit(1)");
+  });
+
   it("exits when the header source is combined with disabled auth", () => {
     expect(() =>
       loadConfig({


### PR DESCRIPTION
## Summary

Follow-up to #117, closing the review finding that heartbeats could be delayed past their configured interval — reworked from a loop restructure to a config guard after review discussion.

The stream loop checks the heartbeat once per poll, so the effective heartbeat cadence is `max(pollMs, heartbeatMs)`: with `FUNKY_STREAM_POLL_MS=60000`, a quiet stream would write its first `: ping` after 60s instead of 15s, and an idle proxy could sever the connection the heartbeat exists to protect.

**Fix: make the invalid state unrepresentable at boot.** One zod refine — `FUNKY_STREAM_POLL_MS ≤ FUNKY_STREAM_HEARTBEAT_MS` — in config.ts's existing fail-fast style, plus a comment on the loop naming the invariant. The stream loop itself is untouched from #117.

Chosen over teaching the loop two independent deadlines: no deployable configuration hits this today (defaults are 1s/15s), and the roadmap answer to polling cost is pg NOTIFY inside the loop, not a slower poll. If slow-poll + fast-heartbeat is ever genuinely wanted, that's the moment the loop earns the complexity, with a real configuration to test against.

## Test plan

- [x] New config test: `FUNKY_STREAM_POLL_MS=60000` with the default heartbeat exits at boot.
- [x] api suite 42/42, `tsc --noEmit` clean, prettier clean. Net diff vs main: +20 lines across 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)