### PR TITLE
Add the config list reads to the Store port

### DIFF
--- a/packages/adapters/src/store/pg.ts
+++ b/packages/adapters/src/store/pg.ts
@@ -24,7 +24,7 @@
 // comparisons use it — never SQL now().
 
 import { randomUUID } from "node:crypto";
-import { and, asc, eq, gt, inArray, isNull, lte, ne, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNull, lte, ne, or, type SQL, sql } from "drizzle-orm";
 import type { PgAsyncDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 import {
   AgentConfig,
@@ -42,7 +42,12 @@ import {
   UserMessage,
   WorkItem,
 } from "@funky/core";
-import { type CommitStepRequest, FencedError, type Store } from "@funky/agent";
+import {
+  type CommitStepRequest,
+  FencedError,
+  type ListConfigsRequest,
+  type Store,
+} from "@funky/agent";
 import {
   agentConfigs,
   envConfigs,
@@ -67,6 +72,28 @@ const wrap = (v: JsonValue | undefined): WrappedJson | null => (v === undefined 
 const unwrapped = (w: WrappedJson | null): { metadata?: JsonValue } =>
   w === null ? {} : { metadata: w.v };
 
+// Row → domain, shared by each config's get and list so the two can
+// never disagree about how a stored row reads back.
+const toAgentConfig = (row: typeof agentConfigs.$inferSelect): AgentConfig =>
+  AgentConfig.parse({
+    id: row.id,
+    inference: row.inference,
+    systemPrompt: row.systemPrompt,
+    namespace: row.namespace,
+    ...unwrapped(row.metadata),
+    createdAt: iso(row.createdAt),
+  });
+
+const toEnvConfig = (row: typeof envConfigs.$inferSelect): EnvConfig =>
+  EnvConfig.parse({
+    id: row.id,
+    network: row.network,
+    packages: row.packages,
+    namespace: row.namespace,
+    ...unwrapped(row.metadata),
+    createdAt: iso(row.createdAt),
+  });
+
 export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
   const now = opts.now ?? (() => new Date());
 
@@ -77,6 +104,28 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       .where(eq(sessions.id, sessionId))
       .for("update");
     if (rows.length === 0) throw new Error(`unknown session: ${sessionId}`);
+  }
+
+  /**
+   * The config lists' page predicate: everything strictly older than the
+   * cursor row in (created_at, id) order — a row-value comparison, so the
+   * tie-break is one comparison, not a hand-unrolled OR. The cursor is
+   * looked up under the caller's `scope`, which makes a foreign id
+   * unknown exactly like a nonexistent one. undefined = start at the
+   * newest (and drizzle's and() drops it).
+   */
+  async function olderThanCursor(
+    table: typeof agentConfigs | typeof envConfigs,
+    scope: SQL,
+    after: string | undefined,
+  ): Promise<SQL | undefined> {
+    if (after === undefined) return undefined;
+    const [cursor] = await db
+      .select({ createdAt: table.createdAt })
+      .from(table)
+      .where(and(scope, eq(table.id, after)));
+    if (!cursor) throw new Error(`unknown cursor: ${after}`);
+    return sql`(${table.createdAt}, ${table.id}) < (${iso(cursor.createdAt)}::timestamptz, ${after})`;
   }
 
   /** Mint envelopes and append; caller must hold the session lock. */
@@ -119,15 +168,19 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
 
     async getAgentConfig(id) {
       const [row] = await db.select().from(agentConfigs).where(eq(agentConfigs.id, id));
-      if (!row) return undefined;
-      return AgentConfig.parse({
-        id: row.id,
-        inference: row.inference,
-        systemPrompt: row.systemPrompt,
-        namespace: row.namespace,
-        ...unwrapped(row.metadata),
-        createdAt: iso(row.createdAt),
-      });
+      return row === undefined ? undefined : toAgentConfig(row);
+    },
+
+    async listAgentConfigs(req: ListConfigsRequest) {
+      const scope = eq(agentConfigs.namespace, req.namespace);
+      const page = await olderThanCursor(agentConfigs, scope, req.after);
+      const rows = await db
+        .select()
+        .from(agentConfigs)
+        .where(and(scope, page))
+        .orderBy(desc(agentConfigs.createdAt), desc(agentConfigs.id))
+        .limit(req.limit);
+      return rows.map(toAgentConfig);
     },
 
     async createEnvConfig(req) {
@@ -147,15 +200,19 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
 
     async getEnvConfig(id) {
       const [row] = await db.select().from(envConfigs).where(eq(envConfigs.id, id));
-      if (!row) return undefined;
-      return EnvConfig.parse({
-        id: row.id,
-        network: row.network,
-        packages: row.packages,
-        namespace: row.namespace,
-        ...unwrapped(row.metadata),
-        createdAt: iso(row.createdAt),
-      });
+      return row === undefined ? undefined : toEnvConfig(row);
+    },
+
+    async listEnvConfigs(req: ListConfigsRequest) {
+      const scope = eq(envConfigs.namespace, req.namespace);
+      const page = await olderThanCursor(envConfigs, scope, req.after);
+      const rows = await db
+        .select()
+        .from(envConfigs)
+        .where(and(scope, page))
+        .orderBy(desc(envConfigs.createdAt), desc(envConfigs.id))
+        .limit(req.limit);
+      return rows.map(toEnvConfig);
     },
 
     async createSession(req) {

--- a/packages/adapters/test/store-conformance.ts
+++ b/packages/adapters/test/store-conformance.ts
@@ -131,6 +131,115 @@ export function describeStoreConformance(
       });
     });
 
+    describe("listing configs", () => {
+      /** n configs, each a tick newer than the last, oldest id first. */
+      async function agentConfigs(n: number, namespace?: string): Promise<string[]> {
+        const ids: string[] = [];
+        for (let i = 0; i < n; i++) {
+          ids.push(
+            await store.createAgentConfig({
+              inference: { provider: "fake", model: `m${i}` },
+              systemPrompt: "s",
+              ...(namespace === undefined ? {} : { namespace }),
+            }),
+          );
+          clock.advance(1_000);
+        }
+        return ids;
+      }
+
+      /** Walk the whole list one small page at a time. */
+      async function walk(namespace: string, limit: number): Promise<string[]> {
+        const ids: string[] = [];
+        let after: string | undefined;
+        for (let guard = 0; guard < 20; guard++) {
+          const page = await store.listAgentConfigs({ namespace, limit, after });
+          expect(page.length).toBeLessThanOrEqual(limit);
+          if (page.length === 0) return ids;
+          ids.push(...page.map((c) => c.id));
+          after = page[page.length - 1]?.id;
+        }
+        throw new Error("walk did not terminate");
+      }
+
+      it("lists a namespace's configs newest first, whole rows", async () => {
+        const [oldest, middle, newest] = await agentConfigs(3);
+        const configs = await store.listAgentConfigs({ namespace: DEFAULT_NAMESPACE, limit: 10 });
+        expect(configs.map((c) => c.id)).toEqual([newest, middle, oldest]);
+        // The same shape a get returns — one row mapping, not two.
+        expect(configs[0]).toEqual(await store.getAgentConfig(newest!));
+      });
+
+      it("bounds the page at limit and resumes strictly after the cursor", async () => {
+        const [oldest, middle, newest] = await agentConfigs(3);
+        const first = await store.listAgentConfigs({ namespace: DEFAULT_NAMESPACE, limit: 2 });
+        expect(first.map((c) => c.id)).toEqual([newest, middle]);
+        const second = await store.listAgentConfigs({
+          namespace: DEFAULT_NAMESPACE,
+          limit: 2,
+          after: middle,
+        });
+        expect(second.map((c) => c.id)).toEqual([oldest]);
+        expect(
+          await store.listAgentConfigs({ namespace: DEFAULT_NAMESPACE, limit: 2, after: oldest }),
+        ).toEqual([]);
+      });
+
+      it("pages an unadvanced clock without dropping or duplicating a row", async () => {
+        // No clock advance: created_at ties are likely, so this pins the
+        // (createdAt, id) key's total order — walking in pages must equal
+        // the whole list exactly.
+        for (let i = 0; i < 5; i++) {
+          await store.createEnvConfig({});
+        }
+        const whole = await store.listEnvConfigs({ namespace: DEFAULT_NAMESPACE, limit: 10 });
+        expect(whole).toHaveLength(5);
+
+        const walked: string[] = [];
+        let after: string | undefined;
+        for (let guard = 0; guard < 20; guard++) {
+          const page = await store.listEnvConfigs({
+            namespace: DEFAULT_NAMESPACE,
+            limit: 2,
+            after,
+          });
+          if (page.length === 0) break;
+          walked.push(...page.map((c) => c.id));
+          after = page[page.length - 1]?.id;
+        }
+        expect(walked).toEqual(whole.map((c) => c.id));
+      });
+
+      it("scopes the list to one namespace — a page walk never crosses the boundary", async () => {
+        const a = await agentConfigs(3, "tenant-a");
+        const b = await agentConfigs(2, "tenant-b");
+        expect(await walk("tenant-a", 2)).toEqual([...a].reverse());
+        expect(await walk("tenant-b", 2)).toEqual([...b].reverse());
+        expect(await store.listAgentConfigs({ namespace: "tenant-c", limit: 10 })).toEqual([]);
+      });
+
+      it("rejects a cursor it cannot resolve — a foreign one like a nonexistent one", async () => {
+        const [foreign] = await agentConfigs(1, "tenant-b");
+        await expect(
+          store.listAgentConfigs({ namespace: "tenant-a", limit: 10, after: "nope" }),
+        ).rejects.toThrow("unknown cursor");
+        await expect(
+          store.listAgentConfigs({ namespace: "tenant-a", limit: 10, after: foreign }),
+        ).rejects.toThrow("unknown cursor");
+      });
+
+      it("lists the two config kinds independently", async () => {
+        await agentConfigs(2);
+        const envId = await store.createEnvConfig({});
+        const envs = await store.listEnvConfigs({ namespace: DEFAULT_NAMESPACE, limit: 10 });
+        expect(envs.map((c) => c.id)).toEqual([envId]);
+        expect(envs[0]).toEqual(await store.getEnvConfig(envId));
+        expect(
+          await store.listAgentConfigs({ namespace: DEFAULT_NAMESPACE, limit: 10 }),
+        ).toHaveLength(2);
+      });
+    });
+
     describe("sessions", () => {
       it("round-trips a session", async () => {
         const sessionId = await newSession();

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -27,4 +27,10 @@ export type {
   SandboxProvider,
 } from "./ports/sandbox-provider";
 export { FencedError } from "./ports/store";
-export type { Claim, CommitStepRequest, LeaseToken, Store } from "./ports/store";
+export type {
+  Claim,
+  CommitStepRequest,
+  LeaseToken,
+  ListConfigsRequest,
+  Store,
+} from "./ports/store";

--- a/packages/agent/src/ports/README.md
+++ b/packages/agent/src/ports/README.md
@@ -8,7 +8,7 @@ what they are.
 | port                | one line                                                |
 | ------------------- | ------------------------------------------------------- |
 | `InferenceProvider` | one request in, one live stream of increments out       |
-| `Store`             | the single source of truth: 15 methods, two write paths |
+| `Store`             | the single source of truth: 17 methods, two write paths |
 
 Why the ports live here and not elsewhere:
 

--- a/packages/agent/src/ports/store.ts
+++ b/packages/agent/src/ports/store.ts
@@ -49,8 +49,12 @@ export interface Store {
 
   createAgentConfig(req: CreateAgentConfigRequest): Promise<ConfigId>;
   getAgentConfig(id: ConfigId): Promise<AgentConfig | undefined>;
+  /** One namespace's agent configs, newest first — see ListConfigsRequest. */
+  listAgentConfigs(req: ListConfigsRequest): Promise<AgentConfig[]>;
   createEnvConfig(req: CreateEnvConfigRequest): Promise<ConfigId>;
   getEnvConfig(id: ConfigId): Promise<EnvConfig | undefined>;
+  /** One namespace's env configs, newest first — see ListConfigsRequest. */
+  listEnvConfigs(req: ListConfigsRequest): Promise<EnvConfig[]>;
 
   // --- sessions ---
 
@@ -134,6 +138,37 @@ export interface Store {
   commitStep(req: CommitStepRequest): Promise<void>;
 
   // P4 adds reaper operations (lease expiry, interrupted-result synthesis).
+}
+
+/**
+ * The config list reads' argument, shared by both because the two config
+ * tables page identically.
+ *
+ * `namespace` is required, and it is the one read whose tenancy the
+ * store enforces rather than the api: a list has no id to fetch and
+ * check afterwards, so the scope has to be inside the query.
+ *
+ * `limit` is required too — the port has no unbounded list, so no
+ * caller can forget to bound one. The store returns at most that many
+ * rows; a caller wanting to know whether more exist asks for one more
+ * than it will show.
+ *
+ * `after` is a position cursor with the same meaning as readEntries'
+ * seq — "what comes next" — in this list's newest-first order: the id
+ * of the last row of the page before. It is resolved inside the
+ * namespace, so a foreign cursor throws "unknown cursor" exactly like a
+ * nonexistent one and nothing leaks. Keyset, not offset, and ordered by
+ * (createdAt, id) so ties in the clock still order totally: config rows
+ * are write-once and never deleted, so a page boundary never moves — a
+ * concurrent create lands ahead of the first page, which the caller
+ * already has, and can neither duplicate nor skip a row mid-walk.
+ */
+export interface ListConfigsRequest {
+  namespace: string;
+  /** At most this many rows. */
+  limit: number;
+  /** Id of the previous page's last row; absent starts at the newest. */
+  after?: ConfigId;
 }
 
 /**


### PR DESCRIPTION
**Stacked PR 1 of 2.** This one is the port + adapter; the api routes (#126) land on top of it (`list-configs-api`, opened next, based on this branch).

The api can create and get a config but never enumerate them: a client that loses an id has no way back to the row, and a console has no way to show a tenant what it has. Two methods close that — `listAgentConfigs` and `listEnvConfigs`.

## The shape

Both take one `ListConfigsRequest`, because the two config tables page identically. Three decisions in it:

- **`namespace` is required.** It is the one read whose tenancy the store enforces rather than the api: a list has no id to fetch and check afterwards, so the scope has to be inside the query.
- **`limit` is required.** The port has no unbounded list, so no caller can forget to bound one. A caller that wants to know whether more rows exist asks for one more than it will show.
- **`after` is a position cursor** — `readEntries`' "what comes next", in this list's newest-first order — resolved inside the namespace, so a foreign cursor throws `unknown cursor` exactly like a nonexistent one and nothing leaks.

## Why keyset and why `(created_at, id)`

Config rows are write-once and never deleted, so a page boundary never moves: a concurrent create lands ahead of page one, which the caller already has, and can neither duplicate nor skip a row mid-walk. Offset paging would give the same property here, but keyset costs nothing extra and doesn't degrade on deep pages.

The `id` in the key is load-bearing, not decoration. The adapter's clock is injected, and five creates under an unadvanced one land on a *single* timestamp (verified — 1 distinct value out of 5), so `created_at` alone would stall a walk at the first tie. The conformance suite pins exactly that case: paging with a tied clock must equal the whole list, row for row.

In the pg adapter the cursor is a row-value comparison — `(created_at, id) < (?, ?)` — one predicate rather than a hand-unrolled OR, and each config's row-to-domain mapping is now shared by its `get` and its `list` so the two cannot drift.

## Not in this PR

No migration and no new index. The list needs no schema change, and the config tables are small and cold (an inspection path, not the claim loop). Seven test files pin the init DDL by path, so adding an index would fork the fixture for a non-hot query — worth doing when there's a second reason to migrate.

## Testing

`pnpm test` green (321 passed). The new coverage is in the store conformance suite, so it runs against **every** adapter and binding — PGlite here, real Postgres in CI: newest-first order, the limit bound, resuming strictly after a cursor, the tied-clock walk, namespace scoping in both directions, and the unresolvable-cursor rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)