### PR TITLE
Add the config list routes: GET /v1/agent-configs and /v1/env-configs

### DIFF
--- a/apps/api/src/routes/agent-configs.ts
+++ b/apps/api/src/routes/agent-configs.ts
@@ -1,16 +1,19 @@
 // apps/api/src/routes/agent-configs.ts
 // The agent-config resource — write-once behavior recipes (inference +
 // system prompt), tenant-private like every config. Same shape as
-// env-configs.ts: two verbs, core schemas as the wire format, the
-// middleware's namespace stamped on create and checked on read.
+// env-configs.ts: create, get, list, core schemas as the wire format,
+// the middleware's namespace stamped on create and checked on read.
 import { Hono } from "hono";
 import { CreateAgentConfigRequest } from "@funky/core";
 import type { Store } from "@funky/agent";
 import { errorResponse } from "../http";
-import { validate } from "./common";
+import { ListQuery, page, validate } from "./common";
 
 /** The slice of the harness Store this resource needs. */
-export type AgentConfigStore = Pick<Store, "createAgentConfig" | "getAgentConfig">;
+export type AgentConfigStore = Pick<
+  Store,
+  "createAgentConfig" | "getAgentConfig" | "listAgentConfigs"
+>;
 
 type Env = { Variables: { requestId: string; namespace: string } };
 
@@ -27,6 +30,27 @@ export function agentConfigRoutes(store: AgentConfigStore) {
     const config = await store.getAgentConfig(id);
     if (!config) throw new Error(`agent config ${id} missing after create`);
     return c.json(config, 201);
+  });
+
+  // list → one page of this namespace's rows, newest first. The store
+  // is asked for limit + 1: the extra row is hasMore (see page()).
+  r.get("/", validate("query", ListQuery), async (c) => {
+    const { limit, after } = c.req.valid("query");
+    try {
+      const rows = await store.listAgentConfigs({
+        namespace: c.get("namespace"),
+        limit: limit + 1,
+        after,
+      });
+      return c.json(page(rows, limit));
+    } catch (err) {
+      // A cursor the store can't resolve — foreign or made-up, the same
+      // "unknown" either way — is the client's mistake, so 400 not 500.
+      if (err instanceof Error && err.message.startsWith("unknown cursor")) {
+        return errorResponse(c, 400, "invalid_request_error", err.message);
+      }
+      throw err;
+    }
   });
 
   r.get("/:id", async (c) => {

--- a/apps/api/src/routes/common.ts
+++ b/apps/api/src/routes/common.ts
@@ -1,8 +1,10 @@
 // apps/api/src/routes/common.ts
 // The validate wrapper shared by every resource's route file: core zod
-// schemas in, the error envelope out.
+// schemas in, the error envelope out. Plus the collection reads' one
+// pagination shape — the query the client sends and the envelope it
+// gets back, written once so no two resources page differently.
 import { zValidator } from "@hono/zod-validator";
-import type { ZodType } from "zod";
+import { type ZodType, z } from "zod";
 import { errorResponse } from "../http";
 
 export const validate = <T extends ZodType>(target: "json" | "query", schema: T) =>
@@ -14,3 +16,36 @@ export const validate = <T extends ZodType>(target: "json" | "query", schema: T)
       return errorResponse(c, 400, "invalid_request_error", msg);
     }
   });
+
+/** Page size when the caller doesn't ask, and the ceiling when it does. */
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+/**
+ * A list route's query. `limit` is bounded here rather than clamped
+ * silently: an over-large page is a client mistake worth a 400, not a
+ * request we quietly answer with something else. `after` is the id of
+ * the previous page's last row — the cursor `page()` hands back.
+ */
+export const ListQuery = z.object({
+  limit: z.coerce.number().int().min(1).max(MAX_LIMIT).default(DEFAULT_LIMIT),
+  after: z.string().min(1).optional(),
+});
+export type ListQuery = z.infer<typeof ListQuery>;
+
+/**
+ * The list envelope. Routes over-fetch by one row — `rows` is a page of
+ * `limit + 1` — and that extra row IS `hasMore`: no count query, no
+ * second round trip, and the client never has to guess from a short
+ * page. `lastId` is what to send as the next `after`; it is absent on an
+ * empty page, because absence has one spelling (core/store.ts).
+ */
+export function page<T extends { id: string }>(rows: T[], limit: number) {
+  const data = rows.slice(0, limit);
+  const last = data[data.length - 1];
+  return {
+    data,
+    hasMore: rows.length > limit,
+    ...(last === undefined ? {} : { lastId: last.id }),
+  };
+}

--- a/apps/api/src/routes/env-configs.ts
+++ b/apps/api/src/routes/env-configs.ts
@@ -4,22 +4,25 @@
 // ARE the wire format, so there is no HTTP-side translation layer.
 //
 // Write-once is structural, not policy: the Store port exposes no
-// update, archive, delete, or list for config rows, so the resource has
-// exactly two verbs. Sessions reference config ids; a row that could
-// change under a running session would reinterpret its history.
+// update, archive, or delete for config rows, so create is the only
+// verb that writes — the other two routes read. Sessions reference
+// config ids; a row that could change under a running session would
+// reinterpret its history.
 //
 // Namespace discipline: the wire schema OMITS namespace — a client can
 // never choose one. The auth middleware decided it (c.get("namespace"));
 // create stamps it, and get answers 404 for a foreign row, so a foreign
-// id is indistinguishable from a nonexistent one.
+// id is indistinguishable from a nonexistent one. The list is the one
+// read the api can't scope that way — there is no id to check
+// afterwards — so it passes the namespace INTO the store instead.
 import { Hono } from "hono";
 import { CreateEnvConfigRequest } from "@funky/core";
 import type { Store } from "@funky/agent";
 import { errorResponse } from "../http";
-import { validate } from "./common";
+import { ListQuery, page, validate } from "./common";
 
 /** The slice of the harness Store this resource needs. */
-export type EnvConfigStore = Pick<Store, "createEnvConfig" | "getEnvConfig">;
+export type EnvConfigStore = Pick<Store, "createEnvConfig" | "getEnvConfig" | "listEnvConfigs">;
 
 type Env = { Variables: { requestId: string; namespace: string } };
 
@@ -39,6 +42,28 @@ export function envConfigRoutes(store: EnvConfigStore) {
     const config = await store.getEnvConfig(id);
     if (!config) throw new Error(`env config ${id} missing after create`);
     return c.json(config, 201);
+  });
+
+  // list → one page of this namespace's rows, newest first. The store
+  // is asked for limit + 1: the extra row is hasMore (see page()).
+  r.get("/", validate("query", ListQuery), async (c) => {
+    const { limit, after } = c.req.valid("query");
+    try {
+      const rows = await store.listEnvConfigs({
+        namespace: c.get("namespace"),
+        limit: limit + 1,
+        after,
+      });
+      return c.json(page(rows, limit));
+    } catch (err) {
+      // The store resolves the cursor inside the namespace; a foreign
+      // one is "unknown" exactly like a made-up one. Either way the
+      // client sent it, so it is a 400, not a 500.
+      if (err instanceof Error && err.message.startsWith("unknown cursor")) {
+        return errorResponse(c, 400, "invalid_request_error", err.message);
+      }
+      throw err;
+    }
   });
 
   r.get("/:id", async (c) => {

--- a/apps/api/test/agent-configs.test.ts
+++ b/apps/api/test/agent-configs.test.ts
@@ -73,6 +73,89 @@ describe("POST /v1/agent-configs", () => {
   });
 });
 
+describe("GET /v1/agent-configs", () => {
+  // Every list test gets its own tenant, so the page it reads contains
+  // exactly the rows it created — the store's namespace scoping IS the
+  // isolation. Order is asserted against the list itself, never against
+  // creation order: the store's clock is real wall time here, so rows
+  // created back to back can share a timestamp. That the order is
+  // newest-first is pinned in the store conformance suite, which owns
+  // an injected clock.
+  const asTenant = (tenant: string) => ({ "X-Funky-Namespace": tenant });
+
+  async function seed(tenant: string, n: number): Promise<string[]> {
+    const ids: string[] = [];
+    for (let i = 0; i < n; i++) {
+      const res = await post(scoped, "/v1/agent-configs", RECIPE, asTenant(tenant));
+      expect(res.status).toBe(201);
+      ids.push((await res.json()).id);
+    }
+    return ids;
+  }
+
+  it("returns the namespace's rows in one page, whole rows, hasMore false", async () => {
+    const ids = await seed("list-one", 3);
+    const res = await get(scoped, "/v1/agent-configs", asTenant("list-one"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.map((c: { id: string }) => c.id).sort()).toEqual([...ids].sort());
+    expect(body.hasMore).toBe(false);
+    expect(body.lastId).toBe(body.data[2].id);
+    // A listed row is the same row a get returns.
+    const one = await get(scoped, `/v1/agent-configs/${ids[0]}`, asTenant("list-one"));
+    expect(body.data).toContainEqual(await one.json());
+  });
+
+  it("pages with limit and after: the walk equals the whole list", async () => {
+    await seed("list-page", 3);
+    const whole = await (await get(scoped, "/v1/agent-configs", asTenant("list-page"))).json();
+
+    const first = await (
+      await get(scoped, "/v1/agent-configs?limit=2", asTenant("list-page"))
+    ).json();
+    expect(first.data).toHaveLength(2);
+    expect(first.hasMore).toBe(true); // the over-fetched row, not a guess
+    expect(first.lastId).toBe(first.data[1].id);
+
+    const second = await (
+      await get(scoped, `/v1/agent-configs?limit=2&after=${first.lastId}`, asTenant("list-page"))
+    ).json();
+    expect(second.data).toHaveLength(1);
+    expect(second.hasMore).toBe(false);
+
+    expect([...first.data, ...second.data]).toEqual(whole.data);
+  });
+
+  it("answers an empty namespace with an empty page and no cursor", async () => {
+    const body = await (await get(scoped, "/v1/agent-configs", asTenant("list-empty"))).json();
+    expect(body).toEqual({ data: [], hasMore: false });
+  });
+
+  it("never crosses the namespace boundary", async () => {
+    const mine = await seed("list-mine", 2);
+    await seed("list-theirs", 1);
+    const body = await (await get(scoped, "/v1/agent-configs", asTenant("list-mine"))).json();
+    expect(body.data.map((c: { id: string }) => c.id).sort()).toEqual([...mine].sort());
+  });
+
+  it("400s a limit outside the bounds and a non-numeric one", async () => {
+    for (const q of ["limit=0", "limit=101", "limit=abc", "limit=1.5"]) {
+      const res = await get(scoped, `/v1/agent-configs?${q}`, asTenant("list-one"));
+      expect(res.status).toBe(400);
+      expect((await res.json()).error.type).toBe("invalid_request_error");
+    }
+  });
+
+  it("400s a cursor the store can't resolve — foreign like made-up", async () => {
+    const [foreign] = await seed("list-cursor-b", 1);
+    for (const after of ["nope", foreign]) {
+      const res = await get(scoped, `/v1/agent-configs?after=${after}`, asTenant("list-cursor-a"));
+      expect(res.status).toBe(400);
+      expect((await res.json()).error.type).toBe("invalid_request_error");
+    }
+  });
+});
+
 describe("GET /v1/agent-configs/:id", () => {
   it("404s an unknown id with the error envelope", async () => {
     const res = await get(app, "/v1/agent-configs/nope");

--- a/apps/api/test/env-configs.test.ts
+++ b/apps/api/test/env-configs.test.ts
@@ -72,6 +72,45 @@ describe("POST /v1/env-configs", () => {
   });
 });
 
+describe("GET /v1/env-configs", () => {
+  // The pagination machinery itself (limit bounds, over-fetched
+  // hasMore, the page walk) is pinned in agent-configs.test.ts, which
+  // shares it; here we pin this resource's own wiring.
+  const asTenant = (tenant: string) => ({ "X-Funky-Namespace": tenant });
+
+  it("lists env configs only — the two config kinds are separate collections", async () => {
+    const created = await (
+      await post(scoped, "/v1/env-configs", { packages: { npm: ["zod@4"] } }, asTenant("list-env"))
+    ).json();
+    await post(
+      scoped,
+      "/v1/agent-configs",
+      { inference: { provider: "fake", model: "m" }, systemPrompt: "s" },
+      asTenant("list-env"),
+    );
+
+    const res = await get(scoped, "/v1/env-configs", asTenant("list-env"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: [created], hasMore: false, lastId: created.id });
+  });
+
+  it("is wired on the static namespace source too", async () => {
+    const created = await (await post(app, "/v1/env-configs", {})).json();
+    const body = await (await get(app, "/v1/env-configs?limit=100")).json();
+    expect(body.data).toContainEqual(created);
+    // The default page is bounded whether or not the caller asks.
+    const capped = await (await get(app, "/v1/env-configs?limit=1")).json();
+    expect(capped.data).toHaveLength(1);
+  });
+
+  it("400s a cursor from another namespace", async () => {
+    const foreign = await (await post(scoped, "/v1/env-configs", {}, asTenant("env-cur-b"))).json();
+    const res = await get(scoped, `/v1/env-configs?after=${foreign.id}`, asTenant("env-cur-a"));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.type).toBe("invalid_request_error");
+  });
+});
+
 describe("GET /v1/env-configs/:id", () => {
   it("404s an unknown id with the error envelope", async () => {
     const res = await get(app, "/v1/env-configs/nope");


### PR DESCRIPTION
Re-opens #126 against `main`. That PR was stacked on #125's branch and got merged 54 seconds after it, before GitHub retargeted the base — so it landed on `list-configs-store` instead of `main`. The commit is unchanged, cherry-picked onto `main`; `main` already has the port half from #125, so this is the api half on its own. Once this merges, `list-configs-store` and `list-configs-api` can be deleted.

---

The two config resources could create a row and get it back by id, but a client that lost an id had no route home and a console had nothing to render. Both gain a collection read on the Store port's list methods (#125).

## One page shape, written once

Two resources that page differently is a bug waiting to happen, so the query schema and the envelope live in `routes/common.ts`:

```
GET /v1/agent-configs?limit=20&after=<id>
{ "data": [ …rows… ], "hasMore": true, "lastId": "…" }
```

- The rows are the same objects `GET /:id` returns — the core schemas are still the wire format, no translation layer.
- `limit` defaults to 20 and is **bounded** at 100 by the query schema rather than clamped silently: an over-large page is a client mistake worth a 400, not a request we quietly answer with something else.
- `lastId` is the next `after`; absent on an empty page, since absence has one spelling.
- `hasMore` is neither a guess nor a count query — the route asks the store for `limit + 1` rows and the extra row **is** the answer. `page()` slices it off before the data goes out.

## The one place namespace discipline shifts

Create stamps the middleware's namespace and get 404s a foreign row, so a foreign id is indistinguishable from a nonexistent one. A list has no id to check afterwards, so it passes the namespace *into* the store and the query scopes it. A cursor from another tenant is resolved inside that scope and comes back `unknown cursor`, exactly like a made-up one — the route turns that into a 400, because the client sent it (the same `unknown …` → 400 mapping `POST /v1/sessions` already does for config refs).

## Testing

Re-verified on top of `main` after the cherry-pick: `pnpm test` green (321 passed; api 42 → 51), typecheck and `format:check` clean. The route tests run over the real store (PGlite + the pg adapter), each list test in its own tenant so the page it reads contains exactly the rows it created: the envelope, the page walk equalling the whole list, an empty namespace, the namespace boundary, `limit` bounds (`0`, `101`, `abc`, `1.5`), and the foreign cursor. Ordering is asserted against the list itself, never creation order — the store's clock is real wall time here, so back-to-back rows can share a timestamp; *newest-first* is pinned in the conformance suite, which owns an injected clock.

Docs unchanged: the README quickstart isn't an endpoint reference, and its layout table already reads "configs, sessions, intake, cancel, inspection, the SSE stream".

🤖 Generated with [Claude Code](https://claude.com/claude-code)