### PR TITLE
Persist immutable agent config versions

### DIFF
--- a/apps/api/test/agent-configs.test.ts
+++ b/apps/api/test/agent-configs.test.ts
@@ -11,13 +11,14 @@ import { createPgStore, type StoreDb } from "@funky/adapters";
 import { buildApp } from "../src/app";
 import { get, post } from "./helpers";
 
-const ddl = readFileSync(
-  new URL(
-    "../../../packages/adapters/migrations/20260820000000_init/migration.sql",
-    import.meta.url,
-  ),
-  "utf8",
-);
+const ddl = ["20260820000000_init", "20260827000000_agent_config_versions"]
+  .map((name) =>
+    readFileSync(
+      new URL(`../../../packages/adapters/migrations/${name}/migration.sql`, import.meta.url),
+      "utf8",
+    ),
+  )
+  .join("\n");
 
 const RECIPE = {
   inference: { provider: "anthropic", model: "claude-sonnet-5", maxTokens: 8192 },
@@ -50,8 +51,10 @@ describe("POST /v1/agent-configs", () => {
     expect(body.inference).toEqual(RECIPE.inference);
     expect(body.systemPrompt).toBe(RECIPE.systemPrompt);
     expect(body.namespace).toBe("default");
+    expect(body.version).toBe(1);
     expect(typeof body.id).toBe("string");
     expect(typeof body.createdAt).toBe("string");
+    expect(body.updatedAt).toBe(body.createdAt);
 
     const fetched = await get(app, `/v1/agent-configs/${body.id}`);
     expect(fetched.status).toBe(200);

--- a/apps/api/test/agent-configs.test.ts
+++ b/apps/api/test/agent-configs.test.ts
@@ -3,22 +3,13 @@
 // header source validation) is covered there and in app.test.ts; here
 // we pin this resource's wiring, materialization, and its own
 // fetch-then-check scoping.
-import { readFileSync } from "node:fs";
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createPgStore, type StoreDb } from "@funky/adapters";
+import { storeDdl } from "../../../packages/adapters/test/store-ddl";
 import { buildApp } from "../src/app";
 import { get, post } from "./helpers";
-
-const ddl = ["20260820000000_init", "20260827000000_agent_config_versions"]
-  .map((name) =>
-    readFileSync(
-      new URL(`../../../packages/adapters/migrations/${name}/migration.sql`, import.meta.url),
-      "utf8",
-    ),
-  )
-  .join("\n");
 
 const RECIPE = {
   inference: { provider: "anthropic", model: "claude-sonnet-5", maxTokens: 8192 },
@@ -31,7 +22,7 @@ let scoped: ReturnType<typeof buildApp>; // namespaceSource "header" over the SA
 
 beforeAll(async () => {
   client = new PGlite();
-  await client.exec(ddl);
+  await client.exec(storeDdl);
   const store = createPgStore(drizzle({ client }) as unknown as StoreDb);
   const base = { store, authToken: null, ping: async () => ({}) };
   const stream = { pollMs: 1000, heartbeatMs: 15_000 };

--- a/apps/api/test/env-configs.test.ts
+++ b/apps/api/test/env-configs.test.ts
@@ -1,22 +1,13 @@
 // Route tests over the REAL store — PGlite + the pg adapter, the same
 // binding the driver suites use — so materialization (defaults resolved
 // at create) is asserted end to end, never mocked.
-import { readFileSync } from "node:fs";
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createPgStore, type StoreDb } from "@funky/adapters";
+import { storeDdl } from "../../../packages/adapters/test/store-ddl";
 import { buildApp } from "../src/app";
 import { get, post } from "./helpers";
-
-const ddl = ["20260820000000_init", "20260827000000_agent_config_versions"]
-  .map((name) =>
-    readFileSync(
-      new URL(`../../../packages/adapters/migrations/${name}/migration.sql`, import.meta.url),
-      "utf8",
-    ),
-  )
-  .join("\n");
 
 let client: PGlite;
 let app: ReturnType<typeof buildApp>;
@@ -24,7 +15,7 @@ let scoped: ReturnType<typeof buildApp>; // namespaceSource "header" over the SA
 
 beforeAll(async () => {
   client = new PGlite();
-  await client.exec(ddl);
+  await client.exec(storeDdl);
   const store = createPgStore(drizzle({ client }) as unknown as StoreDb);
   const base = { store, authToken: null, ping: async () => ({}) };
   const stream = { pollMs: 1000, heartbeatMs: 15_000 };

--- a/apps/api/test/env-configs.test.ts
+++ b/apps/api/test/env-configs.test.ts
@@ -9,13 +9,14 @@ import { createPgStore, type StoreDb } from "@funky/adapters";
 import { buildApp } from "../src/app";
 import { get, post } from "./helpers";
 
-const ddl = readFileSync(
-  new URL(
-    "../../../packages/adapters/migrations/20260820000000_init/migration.sql",
-    import.meta.url,
-  ),
-  "utf8",
-);
+const ddl = ["20260820000000_init", "20260827000000_agent_config_versions"]
+  .map((name) =>
+    readFileSync(
+      new URL(`../../../packages/adapters/migrations/${name}/migration.sql`, import.meta.url),
+      "utf8",
+    ),
+  )
+  .join("\n");
 
 let client: PGlite;
 let app: ReturnType<typeof buildApp>;

--- a/apps/api/test/sessions.test.ts
+++ b/apps/api/test/sessions.test.ts
@@ -10,13 +10,14 @@ import { createPgStore, type StoreDb } from "@funky/adapters";
 import { buildApp } from "../src/app";
 import { get, post } from "./helpers";
 
-const ddl = readFileSync(
-  new URL(
-    "../../../packages/adapters/migrations/20260820000000_init/migration.sql",
-    import.meta.url,
-  ),
-  "utf8",
-);
+const ddl = ["20260820000000_init", "20260827000000_agent_config_versions"]
+  .map((name) =>
+    readFileSync(
+      new URL(`../../../packages/adapters/migrations/${name}/migration.sql`, import.meta.url),
+      "utf8",
+    ),
+  )
+  .join("\n");
 
 let client: PGlite;
 let app: ReturnType<typeof buildApp>;
@@ -82,6 +83,7 @@ describe("POST /v1/sessions", () => {
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.agentConfigId).toBe(configs.agentConfigId);
+    expect(body.agentConfigVersion).toBe(1);
     expect(body.envConfigId).toBe(configs.envConfigId);
     expect(body.namespace).toBe("default");
     expect(typeof body.id).toBe("string");

--- a/apps/api/test/sessions.test.ts
+++ b/apps/api/test/sessions.test.ts
@@ -2,22 +2,13 @@
 // worker is deliberately absent: what these pin is the intake half
 // (create, started/queued branching, cancel-as-control-entry) and the
 // inspection reads, all through HTTP, plus the ownership boundary.
-import { readFileSync } from "node:fs";
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createPgStore, type StoreDb } from "@funky/adapters";
+import { storeDdl } from "../../../packages/adapters/test/store-ddl";
 import { buildApp } from "../src/app";
 import { get, post } from "./helpers";
-
-const ddl = ["20260820000000_init", "20260827000000_agent_config_versions"]
-  .map((name) =>
-    readFileSync(
-      new URL(`../../../packages/adapters/migrations/${name}/migration.sql`, import.meta.url),
-      "utf8",
-    ),
-  )
-  .join("\n");
 
 let client: PGlite;
 let app: ReturnType<typeof buildApp>;
@@ -31,7 +22,7 @@ const PACING = { pollMs: 10, heartbeatMs: 60_000 };
 
 beforeAll(async () => {
   client = new PGlite();
-  await client.exec(ddl);
+  await client.exec(storeDdl);
   const store = createPgStore(drizzle({ client }) as unknown as StoreDb);
   const base = { store, authToken: null, ping: async () => ({}) };
   app = buildApp({ ...base, namespaceSource: "static", stream: PACING });
@@ -79,7 +70,7 @@ async function seedSession(
 describe("POST /v1/sessions", () => {
   it("creates and returns the materialized session, 201", async () => {
     const configs = await seedConfigs(app);
-    const res = await post(app, "/v1/sessions", configs);
+    const res = await post(app, "/v1/sessions", { ...configs, agentConfigVersion: 1 });
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.agentConfigId).toBe(configs.agentConfigId);
@@ -92,6 +83,13 @@ describe("POST /v1/sessions", () => {
   it("400s a dangling config reference", async () => {
     const { envConfigId } = await seedConfigs(app);
     const res = await post(app, "/v1/sessions", { agentConfigId: "nope", envConfigId });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("400s an unknown agent config version", async () => {
+    const configs = await seedConfigs(app);
+    const res = await post(app, "/v1/sessions", { ...configs, agentConfigVersion: 2 });
     expect(res.status).toBe(400);
     expect((await res.json()).error.type).toBe("invalid_request_error");
   });

--- a/apps/worker/test/e2e.test.ts
+++ b/apps/worker/test/e2e.test.ts
@@ -36,13 +36,14 @@ if (!url || !anthropicKey || !e2bKey) {
     it("skipped — set E2E_DATABASE_URL, ANTHROPIC_API_KEY and E2B_API_KEY to run", () => {});
   });
 } else {
-  const ddl = readFileSync(
-    new URL(
-      "../../../packages/adapters/migrations/20260820000000_init/migration.sql",
-      import.meta.url,
-    ),
-    "utf8",
-  );
+  const ddl = ["20260820000000_init", "20260827000000_agent_config_versions"]
+    .map((name) =>
+      readFileSync(
+        new URL(`../../../packages/adapters/migrations/${name}/migration.sql`, import.meta.url),
+        "utf8",
+      ),
+    )
+    .join("\n");
   const mainPath = fileURLToPath(new URL("../src/main.ts", import.meta.url));
   const apiMainPath = fileURLToPath(new URL("../../api/src/main.ts", import.meta.url));
   const pool = new Pool({ connectionString: url, max: 5 });

--- a/apps/worker/test/e2e.test.ts
+++ b/apps/worker/test/e2e.test.ts
@@ -19,13 +19,13 @@
 // every test SIGKILLs its own workers before the next begins.
 
 import { type ChildProcess, fork } from "node:child_process";
-import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { AgentMessage, SessionEntry, SessionId } from "@funky/core";
 import { createE2bProvider, createPgStore, type StoreDb } from "@funky/adapters";
+import { storeDdl } from "../../../packages/adapters/test/store-ddl";
 
 const url = process.env.E2E_DATABASE_URL;
 const anthropicKey = process.env.ANTHROPIC_API_KEY;
@@ -36,14 +36,6 @@ if (!url || !anthropicKey || !e2bKey) {
     it("skipped — set E2E_DATABASE_URL, ANTHROPIC_API_KEY and E2B_API_KEY to run", () => {});
   });
 } else {
-  const ddl = ["20260820000000_init", "20260827000000_agent_config_versions"]
-    .map((name) =>
-      readFileSync(
-        new URL(`../../../packages/adapters/migrations/${name}/migration.sql`, import.meta.url),
-        "utf8",
-      ),
-    )
-    .join("\n");
   const mainPath = fileURLToPath(new URL("../src/main.ts", import.meta.url));
   const apiMainPath = fileURLToPath(new URL("../../api/src/main.ts", import.meta.url));
   const pool = new Pool({ connectionString: url, max: 5 });
@@ -59,7 +51,7 @@ if (!url || !anthropicKey || !e2bKey) {
 
   beforeAll(async () => {
     await pool.query("DROP SCHEMA public CASCADE; CREATE SCHEMA public;");
-    await pool.query(ddl);
+    await pool.query(storeDdl);
   });
 
   afterAll(async () => {

--- a/packages/adapters/migrations/20260827000000_agent_config_versions/migration.sql
+++ b/packages/adapters/migrations/20260827000000_agent_config_versions/migration.sql
@@ -1,0 +1,41 @@
+-- Agent configs now follow UpdateAgent-style optimistic concurrency. Existing
+-- configs become version 1 and start with updated_at equal to created_at.
+ALTER TABLE agent_configs ADD COLUMN version integer;
+ALTER TABLE agent_configs ADD COLUMN updated_at timestamptz;
+
+UPDATE agent_configs SET version = 1 WHERE version IS NULL;
+UPDATE agent_configs SET updated_at = created_at WHERE updated_at IS NULL;
+
+ALTER TABLE agent_configs ALTER COLUMN version SET NOT NULL;
+ALTER TABLE agent_configs ALTER COLUMN updated_at SET NOT NULL;
+
+-- Each mutation appends one immutable snapshot. Backfill the pre-versioning
+-- state as version 1 before sessions begin referencing concrete versions.
+CREATE TABLE agent_config_versions (
+  agent_config_id text NOT NULL REFERENCES agent_configs(id),
+  version integer NOT NULL,
+  inference jsonb NOT NULL,
+  system_prompt text NOT NULL,
+  metadata jsonb,
+  updated_at timestamptz NOT NULL,
+  PRIMARY KEY (agent_config_id, version)
+);
+
+INSERT INTO agent_config_versions (
+  agent_config_id,
+  version,
+  inference,
+  system_prompt,
+  metadata,
+  updated_at
+)
+SELECT id, version, inference, system_prompt, metadata, updated_at
+FROM agent_configs;
+
+ALTER TABLE sessions ADD COLUMN agent_config_version integer;
+UPDATE sessions SET agent_config_version = 1 WHERE agent_config_version IS NULL;
+ALTER TABLE sessions ALTER COLUMN agent_config_version SET NOT NULL;
+ALTER TABLE sessions
+  ADD CONSTRAINT sessions_agent_config_version_fk
+  FOREIGN KEY (agent_config_id, agent_config_version)
+  REFERENCES agent_config_versions (agent_config_id, version);

--- a/packages/adapters/migrations/20260827000000_agent_config_versions/migration.sql
+++ b/packages/adapters/migrations/20260827000000_agent_config_versions/migration.sql
@@ -1,16 +1,5 @@
--- Agent configs now follow UpdateAgent-style optimistic concurrency. Existing
--- configs become version 1 and start with updated_at equal to created_at.
-ALTER TABLE agent_configs ADD COLUMN version integer;
-ALTER TABLE agent_configs ADD COLUMN updated_at timestamptz;
-
-UPDATE agent_configs SET version = 1 WHERE version IS NULL;
-UPDATE agent_configs SET updated_at = created_at WHERE updated_at IS NULL;
-
-ALTER TABLE agent_configs ALTER COLUMN version SET NOT NULL;
-ALTER TABLE agent_configs ALTER COLUMN updated_at SET NOT NULL;
-
 -- Each mutation appends one immutable snapshot. Backfill the pre-versioning
--- state as version 1 before sessions begin referencing concrete versions.
+-- state as version 1 before moving its payload out of the identity row.
 CREATE TABLE agent_config_versions (
   agent_config_id text NOT NULL REFERENCES agent_configs(id),
   version integer NOT NULL,
@@ -29,13 +18,23 @@ INSERT INTO agent_config_versions (
   metadata,
   updated_at
 )
-SELECT id, version, inference, system_prompt, metadata, updated_at
+SELECT id, 1, inference, system_prompt, metadata, created_at
 FROM agent_configs;
 
-ALTER TABLE sessions ADD COLUMN agent_config_version integer;
-UPDATE sessions SET agent_config_version = 1 WHERE agent_config_version IS NULL;
-ALTER TABLE sessions ALTER COLUMN agent_config_version SET NOT NULL;
+-- The identity row keeps only stable fields and a pointer used for atomic
+-- optimistic-concurrency updates. Versioned payload has one source of truth.
+ALTER TABLE agent_configs ADD COLUMN current_version integer NOT NULL DEFAULT 1;
+ALTER TABLE agent_configs
+  ALTER COLUMN current_version DROP DEFAULT,
+  DROP COLUMN inference,
+  DROP COLUMN system_prompt,
+  DROP COLUMN metadata;
+
+ALTER TABLE sessions
+  ADD COLUMN agent_config_version integer NOT NULL DEFAULT 1;
+ALTER TABLE sessions ALTER COLUMN agent_config_version DROP DEFAULT;
 ALTER TABLE sessions
   ADD CONSTRAINT sessions_agent_config_version_fk
   FOREIGN KEY (agent_config_id, agent_config_version)
   REFERENCES agent_config_versions (agent_config_id, version);
+ALTER TABLE sessions DROP CONSTRAINT sessions_agent_config_id_fkey;

--- a/packages/adapters/src/store/pg.ts
+++ b/packages/adapters/src/store/pg.ts
@@ -39,6 +39,7 @@ import {
   PendingInput,
   Session,
   SessionEntry,
+  UpdateAgentConfigRequest,
   UserMessage,
   WorkItem,
 } from "@funky/core";
@@ -47,9 +48,11 @@ import {
   FencedError,
   type ListConfigsRequest,
   type Store,
+  VersionConflictError,
 } from "@funky/agent";
 import {
   agentConfigs,
+  agentConfigVersions,
   envConfigs,
   pendingInputs,
   sessionEntries,
@@ -81,7 +84,27 @@ const toAgentConfig = (row: typeof agentConfigs.$inferSelect): AgentConfig =>
     systemPrompt: row.systemPrompt,
     namespace: row.namespace,
     ...unwrapped(row.metadata),
+    version: row.version,
     createdAt: iso(row.createdAt),
+    updatedAt: iso(row.updatedAt),
+  });
+
+type AgentConfigVersionRow = typeof agentConfigVersions.$inferSelect & {
+  id: string;
+  namespace: string;
+  createdAt: Date;
+};
+
+const toAgentConfigVersion = (row: AgentConfigVersionRow): AgentConfig =>
+  AgentConfig.parse({
+    id: row.id,
+    inference: row.inference,
+    systemPrompt: row.systemPrompt,
+    namespace: row.namespace,
+    ...unwrapped(row.metadata),
+    version: row.version,
+    createdAt: iso(row.createdAt),
+    updatedAt: iso(row.updatedAt),
   });
 
 const toEnvConfig = (row: typeof envConfigs.$inferSelect): EnvConfig =>
@@ -155,13 +178,27 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
     async createAgentConfig(req) {
       const parsed = CreateAgentConfigRequest.parse(req);
       const id = randomUUID();
-      await db.insert(agentConfigs).values({
-        id,
-        inference: parsed.inference,
-        systemPrompt: parsed.systemPrompt,
-        namespace: parsed.namespace ?? DEFAULT_NAMESPACE,
-        metadata: wrap(parsed.metadata),
-        createdAt: now(),
+      const timestamp = now();
+      await db.transaction(async (tx) => {
+        const metadata = wrap(parsed.metadata);
+        await tx.insert(agentConfigs).values({
+          id,
+          inference: parsed.inference,
+          systemPrompt: parsed.systemPrompt,
+          namespace: parsed.namespace ?? DEFAULT_NAMESPACE,
+          metadata,
+          version: 1,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        });
+        await tx.insert(agentConfigVersions).values({
+          agentConfigId: id,
+          version: 1,
+          inference: parsed.inference,
+          systemPrompt: parsed.systemPrompt,
+          metadata,
+          updatedAt: timestamp,
+        });
       });
       return id;
     },
@@ -169,6 +206,84 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
     async getAgentConfig(id) {
       const [row] = await db.select().from(agentConfigs).where(eq(agentConfigs.id, id));
       return row === undefined ? undefined : toAgentConfig(row);
+    },
+
+    async getAgentConfigVersion(id, version) {
+      const [row] = await db
+        .select({
+          agentConfigId: agentConfigVersions.agentConfigId,
+          version: agentConfigVersions.version,
+          inference: agentConfigVersions.inference,
+          systemPrompt: agentConfigVersions.systemPrompt,
+          metadata: agentConfigVersions.metadata,
+          updatedAt: agentConfigVersions.updatedAt,
+          id: agentConfigs.id,
+          namespace: agentConfigs.namespace,
+          createdAt: agentConfigs.createdAt,
+        })
+        .from(agentConfigVersions)
+        .innerJoin(agentConfigs, eq(agentConfigVersions.agentConfigId, agentConfigs.id))
+        .where(
+          and(eq(agentConfigVersions.agentConfigId, id), eq(agentConfigVersions.version, version)),
+        );
+      return row === undefined ? undefined : toAgentConfigVersion(row);
+    },
+
+    async updateAgentConfig(id, req) {
+      const parsed = UpdateAgentConfigRequest.parse(req);
+      const namespace = parsed.namespace ?? DEFAULT_NAMESPACE;
+      const target = and(
+        eq(agentConfigs.id, id),
+        eq(agentConfigs.namespace, namespace),
+        parsed.version === undefined ? undefined : eq(agentConfigs.version, parsed.version),
+      );
+      const hasMutation =
+        parsed.inference !== undefined ||
+        parsed.systemPrompt !== undefined ||
+        parsed.metadata !== undefined;
+
+      return db.transaction(async (tx) => {
+        if (hasMutation) {
+          const timestamp = now();
+          const [row] = await tx
+            .update(agentConfigs)
+            .set({
+              ...(parsed.inference === undefined ? {} : { inference: parsed.inference }),
+              ...(parsed.systemPrompt === undefined ? {} : { systemPrompt: parsed.systemPrompt }),
+              ...(parsed.metadata === undefined ? {} : { metadata: wrap(parsed.metadata) }),
+              version: sql`${agentConfigs.version} + 1`,
+              updatedAt: timestamp,
+            })
+            .where(target)
+            .returning();
+          if (row !== undefined) {
+            await tx.insert(agentConfigVersions).values({
+              agentConfigId: row.id,
+              version: row.version,
+              inference: row.inference,
+              systemPrompt: row.systemPrompt,
+              metadata: row.metadata,
+              updatedAt: timestamp,
+            });
+            return toAgentConfig(row);
+          }
+        } else {
+          const [row] = await tx.select().from(agentConfigs).where(target);
+          if (row !== undefined) return toAgentConfig(row);
+        }
+
+        // No updated row means unknown/foreign, or a failed version precondition.
+        // Resolve under the same namespace so a foreign id never leaks existence.
+        const [current] = await tx
+          .select({ version: agentConfigs.version })
+          .from(agentConfigs)
+          .where(and(eq(agentConfigs.id, id), eq(agentConfigs.namespace, namespace)));
+        if (current === undefined) return undefined;
+        if (parsed.version !== undefined) {
+          throw new VersionConflictError(parsed.version, current.version);
+        }
+        throw new Error(`agent config ${id} was not updated`);
+      });
     },
 
     async listAgentConfigs(req: ListConfigsRequest) {
@@ -218,13 +333,14 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
     async createSession(req) {
       const parsed = CreateSessionRequest.parse(req);
       const namespace = parsed.namespace ?? DEFAULT_NAMESPACE;
-      // Configs are write-once and never deleted, so this pre-check cannot
-      // go stale; the FK constraints remain as the structural backstop.
+      // Config ids and namespaces are immutable and configs are never deleted,
+      // so this existence/ownership pre-check cannot go stale; the FK
+      // constraints remain as the structural backstop.
       // The checks are namespace-scoped: a session and its configs always
       // share one namespace, and a foreign config is "unknown" —
       // indistinguishable from nonexistent, so nothing leaks.
       const [agent] = await db
-        .select({ id: agentConfigs.id })
+        .select({ id: agentConfigs.id, version: agentConfigs.version })
         .from(agentConfigs)
         .where(
           and(eq(agentConfigs.id, parsed.agentConfigId), eq(agentConfigs.namespace, namespace)),
@@ -239,6 +355,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       await db.insert(sessions).values({
         id,
         agentConfigId: parsed.agentConfigId,
+        agentConfigVersion: agent.version,
         envConfigId: parsed.envConfigId,
         namespace,
         metadata: wrap(parsed.metadata),
@@ -253,6 +370,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       return Session.parse({
         id: row.id,
         agentConfigId: row.agentConfigId,
+        agentConfigVersion: row.agentConfigVersion,
         envConfigId: row.envConfigId,
         namespace: row.namespace,
         ...(row.sandboxId ? { sandboxId: row.sandboxId } : {}),

--- a/packages/adapters/src/store/pg.ts
+++ b/packages/adapters/src/store/pg.ts
@@ -75,27 +75,29 @@ const wrap = (v: JsonValue | undefined): WrappedJson | null => (v === undefined 
 const unwrapped = (w: WrappedJson | null): { metadata?: JsonValue } =>
   w === null ? {} : { metadata: w.v };
 
-// Row → domain, shared by each config's get and list so the two can
-// never disagree about how a stored row reads back.
-const toAgentConfig = (row: typeof agentConfigs.$inferSelect): AgentConfig =>
-  AgentConfig.parse({
-    id: row.id,
-    inference: row.inference,
-    systemPrompt: row.systemPrompt,
-    namespace: row.namespace,
-    ...unwrapped(row.metadata),
-    version: row.version,
-    createdAt: iso(row.createdAt),
-    updatedAt: iso(row.updatedAt),
-  });
-
-type AgentConfigVersionRow = typeof agentConfigVersions.$inferSelect & {
+type AgentConfigRow = Omit<typeof agentConfigVersions.$inferSelect, "agentConfigId"> & {
   id: string;
   namespace: string;
   createdAt: Date;
 };
 
-const toAgentConfigVersion = (row: AgentConfigVersionRow): AgentConfig =>
+const agentConfigColumns = {
+  version: agentConfigVersions.version,
+  inference: agentConfigVersions.inference,
+  systemPrompt: agentConfigVersions.systemPrompt,
+  metadata: agentConfigVersions.metadata,
+  updatedAt: agentConfigVersions.updatedAt,
+  id: agentConfigs.id,
+  namespace: agentConfigs.namespace,
+  createdAt: agentConfigs.createdAt,
+};
+
+const currentAgentVersion = and(
+  eq(agentConfigVersions.agentConfigId, agentConfigs.id),
+  eq(agentConfigVersions.version, agentConfigs.currentVersion),
+);
+
+const toAgentConfig = (row: AgentConfigRow): AgentConfig =>
   AgentConfig.parse({
     id: row.id,
     inference: row.inference,
@@ -180,23 +182,18 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       const id = randomUUID();
       const timestamp = now();
       await db.transaction(async (tx) => {
-        const metadata = wrap(parsed.metadata);
         await tx.insert(agentConfigs).values({
           id,
-          inference: parsed.inference,
-          systemPrompt: parsed.systemPrompt,
           namespace: parsed.namespace ?? DEFAULT_NAMESPACE,
-          metadata,
-          version: 1,
+          currentVersion: 1,
           createdAt: timestamp,
-          updatedAt: timestamp,
         });
         await tx.insert(agentConfigVersions).values({
           agentConfigId: id,
           version: 1,
           inference: parsed.inference,
           systemPrompt: parsed.systemPrompt,
-          metadata,
+          metadata: wrap(parsed.metadata),
           updatedAt: timestamp,
         });
       });
@@ -204,29 +201,23 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
     },
 
     async getAgentConfig(id) {
-      const [row] = await db.select().from(agentConfigs).where(eq(agentConfigs.id, id));
+      const [row] = await db
+        .select(agentConfigColumns)
+        .from(agentConfigs)
+        .innerJoin(agentConfigVersions, currentAgentVersion)
+        .where(eq(agentConfigs.id, id));
       return row === undefined ? undefined : toAgentConfig(row);
     },
 
     async getAgentConfigVersion(id, version) {
       const [row] = await db
-        .select({
-          agentConfigId: agentConfigVersions.agentConfigId,
-          version: agentConfigVersions.version,
-          inference: agentConfigVersions.inference,
-          systemPrompt: agentConfigVersions.systemPrompt,
-          metadata: agentConfigVersions.metadata,
-          updatedAt: agentConfigVersions.updatedAt,
-          id: agentConfigs.id,
-          namespace: agentConfigs.namespace,
-          createdAt: agentConfigs.createdAt,
-        })
+        .select(agentConfigColumns)
         .from(agentConfigVersions)
         .innerJoin(agentConfigs, eq(agentConfigVersions.agentConfigId, agentConfigs.id))
         .where(
           and(eq(agentConfigVersions.agentConfigId, id), eq(agentConfigVersions.version, version)),
         );
-      return row === undefined ? undefined : toAgentConfigVersion(row);
+      return row === undefined ? undefined : toAgentConfig(row);
     },
 
     async updateAgentConfig(id, req) {
@@ -235,7 +226,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       const target = and(
         eq(agentConfigs.id, id),
         eq(agentConfigs.namespace, namespace),
-        parsed.version === undefined ? undefined : eq(agentConfigs.version, parsed.version),
+        parsed.version === undefined ? undefined : eq(agentConfigs.currentVersion, parsed.version),
       );
       const hasMutation =
         parsed.inference !== undefined ||
@@ -244,38 +235,69 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
 
       return db.transaction(async (tx) => {
         if (hasMutation) {
-          const timestamp = now();
-          const [row] = await tx
+          // Incrementing the identity's pointer locks this config row. That
+          // serializes unconditional writers and provides the optional CAS;
+          // the new snapshot is inserted before the transaction commits.
+          const [identity] = await tx
             .update(agentConfigs)
             .set({
-              ...(parsed.inference === undefined ? {} : { inference: parsed.inference }),
-              ...(parsed.systemPrompt === undefined ? {} : { systemPrompt: parsed.systemPrompt }),
-              ...(parsed.metadata === undefined ? {} : { metadata: wrap(parsed.metadata) }),
-              version: sql`${agentConfigs.version} + 1`,
-              updatedAt: timestamp,
+              currentVersion: sql`${agentConfigs.currentVersion} + 1`,
             })
             .where(target)
-            .returning();
-          if (row !== undefined) {
-            await tx.insert(agentConfigVersions).values({
-              agentConfigId: row.id,
-              version: row.version,
-              inference: row.inference,
-              systemPrompt: row.systemPrompt,
-              metadata: row.metadata,
-              updatedAt: timestamp,
+            .returning({
+              id: agentConfigs.id,
+              namespace: agentConfigs.namespace,
+              nextVersion: agentConfigs.currentVersion,
+              createdAt: agentConfigs.createdAt,
             });
-            return toAgentConfig(row);
+          if (identity !== undefined) {
+            const [previous] = await tx
+              .select({
+                inference: agentConfigVersions.inference,
+                systemPrompt: agentConfigVersions.systemPrompt,
+                metadata: agentConfigVersions.metadata,
+              })
+              .from(agentConfigVersions)
+              .where(
+                and(
+                  eq(agentConfigVersions.agentConfigId, identity.id),
+                  eq(agentConfigVersions.version, identity.nextVersion - 1),
+                ),
+              );
+            if (previous === undefined) {
+              throw new Error(
+                `agent config ${identity.id} has no version ${identity.nextVersion - 1}`,
+              );
+            }
+
+            const version = {
+              version: identity.nextVersion,
+              inference: parsed.inference ?? previous.inference,
+              systemPrompt: parsed.systemPrompt ?? previous.systemPrompt,
+              metadata: parsed.metadata === undefined ? previous.metadata : wrap(parsed.metadata),
+              updatedAt: now(),
+            };
+            await tx.insert(agentConfigVersions).values({ agentConfigId: identity.id, ...version });
+            return toAgentConfig({
+              id: identity.id,
+              namespace: identity.namespace,
+              createdAt: identity.createdAt,
+              ...version,
+            });
           }
         } else {
-          const [row] = await tx.select().from(agentConfigs).where(target);
+          const [row] = await tx
+            .select(agentConfigColumns)
+            .from(agentConfigs)
+            .innerJoin(agentConfigVersions, currentAgentVersion)
+            .where(target);
           if (row !== undefined) return toAgentConfig(row);
         }
 
         // No updated row means unknown/foreign, or a failed version precondition.
         // Resolve under the same namespace so a foreign id never leaks existence.
         const [current] = await tx
-          .select({ version: agentConfigs.version })
+          .select({ version: agentConfigs.currentVersion })
           .from(agentConfigs)
           .where(and(eq(agentConfigs.id, id), eq(agentConfigs.namespace, namespace)));
         if (current === undefined) return undefined;
@@ -290,8 +312,9 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       const scope = eq(agentConfigs.namespace, req.namespace);
       const page = await olderThanCursor(agentConfigs, scope, req.after);
       const rows = await db
-        .select()
+        .select(agentConfigColumns)
         .from(agentConfigs)
+        .innerJoin(agentConfigVersions, currentAgentVersion)
         .where(and(scope, page))
         .orderBy(desc(agentConfigs.createdAt), desc(agentConfigs.id))
         .limit(req.limit);
@@ -333,15 +356,23 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
     async createSession(req) {
       const parsed = CreateSessionRequest.parse(req);
       const namespace = parsed.namespace ?? DEFAULT_NAMESPACE;
+      const requestedAgentVersion =
+        parsed.agentConfigVersion === undefined
+          ? currentAgentVersion
+          : and(
+              eq(agentConfigVersions.agentConfigId, agentConfigs.id),
+              eq(agentConfigVersions.version, parsed.agentConfigVersion),
+            );
       // Config ids and namespaces are immutable and configs are never deleted,
-      // so this existence/ownership pre-check cannot go stale; the FK
-      // constraints remain as the structural backstop.
+      // so this existence/ownership check cannot go stale. Version snapshots
+      // are immutable, and the FK constraints remain as the backstop.
       // The checks are namespace-scoped: a session and its configs always
       // share one namespace, and a foreign config is "unknown" —
       // indistinguishable from nonexistent, so nothing leaks.
       const [agent] = await db
-        .select({ id: agentConfigs.id, version: agentConfigs.version })
+        .select({ version: agentConfigVersions.version })
         .from(agentConfigs)
+        .innerJoin(agentConfigVersions, requestedAgentVersion)
         .where(
           and(eq(agentConfigs.id, parsed.agentConfigId), eq(agentConfigs.namespace, namespace)),
         );

--- a/packages/adapters/src/store/schema.ts
+++ b/packages/adapters/src/store/schema.ts
@@ -38,20 +38,15 @@ export type WrappedJson = { v: JsonValue };
 
 export const agentConfigs = pgTable("agent_configs", {
   id: text("id").primaryKey(),
-  inference: jsonb("inference").$type<InferenceConfig>().notNull(),
-  systemPrompt: text("system_prompt").notNull(),
   // The tenancy boundary (core/store.ts) — the adapter materializes the
   // default; no SQL DEFAULT, so the resolution lives in exactly one place.
   namespace: text("namespace").notNull(),
-  metadata: jsonb("metadata").$type<WrappedJson>(),
-  version: integer("version").notNull(),
+  // Pointer to the latest immutable snapshot.
+  currentVersion: integer("current_version").notNull(),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
-  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
 });
 
-// Immutable snapshots of every agent config version. Namespace and the
-// identity's created_at remain on agent_configs; version reads join the parent
-// for those stable fields. updated_at is when this version became current.
+// Immutable snapshots of every agent config version.
 export const agentConfigVersions = pgTable(
   "agent_config_versions",
   {
@@ -81,9 +76,7 @@ export const sessions = pgTable(
   "sessions",
   {
     id: text("id").primaryKey(),
-    agentConfigId: text("agent_config_id")
-      .notNull()
-      .references(() => agentConfigs.id),
+    agentConfigId: text("agent_config_id").notNull(),
     // Resolved from the agent's latest version at session creation. The
     // composite FK below makes every session's behavior snapshot durable.
     agentConfigVersion: integer("agent_config_version").notNull(),

--- a/packages/adapters/src/store/schema.ts
+++ b/packages/adapters/src/store/schema.ts
@@ -14,6 +14,7 @@
 import { sql } from "drizzle-orm";
 import {
   bigserial,
+  foreignKey,
   index,
   integer,
   jsonb,
@@ -43,8 +44,28 @@ export const agentConfigs = pgTable("agent_configs", {
   // default; no SQL DEFAULT, so the resolution lives in exactly one place.
   namespace: text("namespace").notNull(),
   metadata: jsonb("metadata").$type<WrappedJson>(),
+  version: integer("version").notNull(),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
 });
+
+// Immutable snapshots of every agent config version. Namespace and the
+// identity's created_at remain on agent_configs; version reads join the parent
+// for those stable fields. updated_at is when this version became current.
+export const agentConfigVersions = pgTable(
+  "agent_config_versions",
+  {
+    agentConfigId: text("agent_config_id")
+      .notNull()
+      .references(() => agentConfigs.id),
+    version: integer("version").notNull(),
+    inference: jsonb("inference").$type<InferenceConfig>().notNull(),
+    systemPrompt: text("system_prompt").notNull(),
+    metadata: jsonb("metadata").$type<WrappedJson>(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.agentConfigId, t.version] })],
+);
 
 export const envConfigs = pgTable("env_configs", {
   id: text("id").primaryKey(),
@@ -56,20 +77,32 @@ export const envConfigs = pgTable("env_configs", {
   createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
 });
 
-export const sessions = pgTable("sessions", {
-  id: text("id").primaryKey(),
-  agentConfigId: text("agent_config_id")
-    .notNull()
-    .references(() => agentConfigs.id),
-  envConfigId: text("env_config_id")
-    .notNull()
-    .references(() => envConfigs.id),
-  namespace: text("namespace").notNull(),
-  // The session's one workspace; null until bindSandbox registers it.
-  sandboxId: text("sandbox_id"),
-  metadata: jsonb("metadata").$type<WrappedJson>(),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
-});
+export const sessions = pgTable(
+  "sessions",
+  {
+    id: text("id").primaryKey(),
+    agentConfigId: text("agent_config_id")
+      .notNull()
+      .references(() => agentConfigs.id),
+    // Resolved from the agent's latest version at session creation. The
+    // composite FK below makes every session's behavior snapshot durable.
+    agentConfigVersion: integer("agent_config_version").notNull(),
+    envConfigId: text("env_config_id")
+      .notNull()
+      .references(() => envConfigs.id),
+    namespace: text("namespace").notNull(),
+    // The session's one workspace; null until bindSandbox registers it.
+    sandboxId: text("sandbox_id"),
+    metadata: jsonb("metadata").$type<WrappedJson>(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+  },
+  (t) => [
+    foreignKey({
+      columns: [t.agentConfigId, t.agentConfigVersion],
+      foreignColumns: [agentConfigVersions.agentConfigId, agentConfigVersions.version],
+    }),
+  ],
+);
 
 export const sessionEntries = pgTable(
   "session_entries",

--- a/packages/adapters/test/crash-resume.test.ts
+++ b/packages/adapters/test/crash-resume.test.ts
@@ -50,10 +50,11 @@ import {
   user,
 } from "./fixtures/crash-script";
 
-const ddl = readFileSync(
-  new URL("../migrations/20260820000000_init/migration.sql", import.meta.url),
-  "utf8",
-);
+const ddl = ["20260820000000_init", "20260827000000_agent_config_versions"]
+  .map((name) =>
+    readFileSync(new URL(`../migrations/${name}/migration.sql`, import.meta.url), "utf8"),
+  )
+  .join("\n");
 const driverPath = fileURLToPath(new URL("./fixtures/crash-driver.ts", import.meta.url));
 const packageRoot = fileURLToPath(new URL("..", import.meta.url));
 

--- a/packages/adapters/test/crash-resume.test.ts
+++ b/packages/adapters/test/crash-resume.test.ts
@@ -30,7 +30,6 @@
 
 import { type ChildProcess, fork } from "node:child_process";
 import { once } from "node:events";
-import { readFileSync } from "node:fs";
 import { cp, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -49,12 +48,7 @@ import {
   PROMPTS,
   user,
 } from "./fixtures/crash-script";
-
-const ddl = ["20260820000000_init", "20260827000000_agent_config_versions"]
-  .map((name) =>
-    readFileSync(new URL(`../migrations/${name}/migration.sql`, import.meta.url), "utf8"),
-  )
-  .join("\n");
+import { storeDdl } from "./store-ddl";
 const driverPath = fileURLToPath(new URL("./fixtures/crash-driver.ts", import.meta.url));
 const packageRoot = fileURLToPath(new URL("..", import.meta.url));
 
@@ -284,7 +278,7 @@ beforeAll(async () => {
   templateFresh = join(workRoot, "template-fresh");
   {
     const client = new PGlite(templateFresh);
-    await client.exec(ddl);
+    await client.exec(storeDdl);
     const store = createPgStore(drizzle({ client }) as unknown as StoreDb);
     const agentConfigId = await store.createAgentConfig({
       inference: inferenceConfig,

--- a/packages/adapters/test/driver.test.ts
+++ b/packages/adapters/test/driver.test.ts
@@ -25,10 +25,11 @@ import {
 } from "@funky/agent";
 import { createPgStore, type StoreDb } from "../src";
 
-const ddl = readFileSync(
-  new URL("../migrations/20260820000000_init/migration.sql", import.meta.url),
-  "utf8",
-);
+const ddl = ["20260820000000_init", "20260827000000_agent_config_versions"]
+  .map((name) =>
+    readFileSync(new URL(`../migrations/${name}/migration.sql`, import.meta.url), "utf8"),
+  )
+  .join("\n");
 
 let client: PGlite;
 let store: Store;

--- a/packages/adapters/test/driver.test.ts
+++ b/packages/adapters/test/driver.test.ts
@@ -6,7 +6,6 @@
 // real echo tool, and the store's injected clock stand in for the
 // world; tests drive steps one at a time, so almost nothing here waits.
 
-import { readFileSync } from "node:fs";
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -24,12 +23,7 @@ import {
   toToolSpec,
 } from "@funky/agent";
 import { createPgStore, type StoreDb } from "../src";
-
-const ddl = ["20260820000000_init", "20260827000000_agent_config_versions"]
-  .map((name) =>
-    readFileSync(new URL(`../migrations/${name}/migration.sql`, import.meta.url), "utf8"),
-  )
-  .join("\n");
+import { storeDdl } from "./store-ddl";
 
 let client: PGlite;
 let store: Store;
@@ -37,7 +31,7 @@ let clock: { advance: (ms: number) => void };
 
 beforeAll(async () => {
   client = new PGlite();
-  await client.exec(ddl);
+  await client.exec(storeDdl);
 });
 
 afterAll(async () => {

--- a/packages/adapters/test/migrations.test.ts
+++ b/packages/adapters/test/migrations.test.ts
@@ -19,7 +19,7 @@ describe("store migrations", () => {
     client = undefined;
   });
 
-  it("backfills version and updated_at for existing agent configs", async () => {
+  it("moves existing agent config payload into version 1", async () => {
     client = new PGlite();
     await client.exec(init);
     await client.query(
@@ -44,22 +44,32 @@ describe("store migrations", () => {
     await client.exec(agentConfigVersions);
 
     const result = await client.query<{
-      version: number;
+      current_version: number;
       created_at: Date;
-      updated_at: Date;
-    }>("SELECT version, created_at, updated_at FROM agent_configs WHERE id = 'existing'");
+    }>("SELECT current_version, created_at FROM agent_configs WHERE id = 'existing'");
     expect(result.rows).toHaveLength(1);
-    expect(result.rows[0]?.version).toBe(1);
-    expect(result.rows[0]?.updated_at).toEqual(result.rows[0]?.created_at);
+    expect(result.rows[0]?.current_version).toBe(1);
 
     const versions = await client.query<{
       agent_config_id: string;
       version: number;
       system_prompt: string;
-    }>("SELECT agent_config_id, version, system_prompt FROM agent_config_versions");
-    expect(versions.rows).toEqual([
-      { agent_config_id: "existing", version: 1, system_prompt: "s" },
-    ]);
+      updated_at: Date;
+    }>("SELECT agent_config_id, version, system_prompt, updated_at FROM agent_config_versions");
+    expect(versions.rows[0]).toMatchObject({
+      agent_config_id: "existing",
+      version: 1,
+      system_prompt: "s",
+    });
+    expect(versions.rows[0]?.updated_at).toEqual(result.rows[0]?.created_at);
+
+    const payloadColumns = await client.query<{ column_name: string }>(
+      `SELECT column_name
+       FROM information_schema.columns
+       WHERE table_name = 'agent_configs'
+         AND column_name IN ('inference', 'system_prompt', 'metadata', 'updated_at')`,
+    );
+    expect(payloadColumns.rows).toEqual([]);
     const sessions = await client.query<{ agent_config_version: number }>(
       "SELECT agent_config_version FROM sessions WHERE id = 'session'",
     );

--- a/packages/adapters/test/migrations.test.ts
+++ b/packages/adapters/test/migrations.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from "node:fs";
+import { PGlite } from "@electric-sql/pglite";
+import { afterEach, describe, expect, it } from "vitest";
+
+const init = readFileSync(
+  new URL("../migrations/20260820000000_init/migration.sql", import.meta.url),
+  "utf8",
+);
+const agentConfigVersions = readFileSync(
+  new URL("../migrations/20260827000000_agent_config_versions/migration.sql", import.meta.url),
+  "utf8",
+);
+
+describe("store migrations", () => {
+  let client: PGlite | undefined;
+
+  afterEach(async () => {
+    await client?.close();
+    client = undefined;
+  });
+
+  it("backfills version and updated_at for existing agent configs", async () => {
+    client = new PGlite();
+    await client.exec(init);
+    await client.query(
+      `INSERT INTO agent_configs
+        (id, inference, system_prompt, namespace, metadata, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      ["existing", { provider: "fake", model: "m" }, "s", "default", null, "2026-08-20T12:00:00Z"],
+    );
+    await client.query(
+      `INSERT INTO env_configs
+        (id, network, packages, namespace, metadata, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      ["env", { type: "unrestricted" }, {}, "default", null, "2026-08-20T12:00:00Z"],
+    );
+    await client.query(
+      `INSERT INTO sessions
+        (id, agent_config_id, env_config_id, namespace, metadata, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      ["session", "existing", "env", "default", null, "2026-08-20T12:00:00Z"],
+    );
+
+    await client.exec(agentConfigVersions);
+
+    const result = await client.query<{
+      version: number;
+      created_at: Date;
+      updated_at: Date;
+    }>("SELECT version, created_at, updated_at FROM agent_configs WHERE id = 'existing'");
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]?.version).toBe(1);
+    expect(result.rows[0]?.updated_at).toEqual(result.rows[0]?.created_at);
+
+    const versions = await client.query<{
+      agent_config_id: string;
+      version: number;
+      system_prompt: string;
+    }>("SELECT agent_config_id, version, system_prompt FROM agent_config_versions");
+    expect(versions.rows).toEqual([
+      { agent_config_id: "existing", version: 1, system_prompt: "s" },
+    ]);
+    const sessions = await client.query<{ agent_config_version: number }>(
+      "SELECT agent_config_version FROM sessions WHERE id = 'session'",
+    );
+    expect(sessions.rows[0]?.agent_config_version).toBe(1);
+  });
+});

--- a/packages/adapters/test/pg-postgres.test.ts
+++ b/packages/adapters/test/pg-postgres.test.ts
@@ -17,10 +17,11 @@ if (!url) {
     it("skipped — set STORE_TEST_DATABASE_URL to run", () => {});
   });
 } else {
-  const ddl = readFileSync(
-    new URL("../migrations/20260820000000_init/migration.sql", import.meta.url),
-    "utf8",
-  );
+  const ddl = ["20260820000000_init", "20260827000000_agent_config_versions"]
+    .map((name) =>
+      readFileSync(new URL(`../migrations/${name}/migration.sql`, import.meta.url), "utf8"),
+    )
+    .join("\n");
   const pool = new Pool({ connectionString: url });
 
   beforeAll(async () => {

--- a/packages/adapters/test/pg-postgres.test.ts
+++ b/packages/adapters/test/pg-postgres.test.ts
@@ -3,11 +3,11 @@
 // races) that PGlite serializes away. Runs only when
 // STORE_TEST_DATABASE_URL is set; the database is wiped per run.
 
-import { readFileSync } from "node:fs";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { createPgStore, type StoreDb } from "../src";
+import { storeDdl } from "./store-ddl";
 import { describeStoreConformance } from "./store-conformance";
 
 const url = process.env.STORE_TEST_DATABASE_URL;
@@ -17,16 +17,11 @@ if (!url) {
     it("skipped — set STORE_TEST_DATABASE_URL to run", () => {});
   });
 } else {
-  const ddl = ["20260820000000_init", "20260827000000_agent_config_versions"]
-    .map((name) =>
-      readFileSync(new URL(`../migrations/${name}/migration.sql`, import.meta.url), "utf8"),
-    )
-    .join("\n");
   const pool = new Pool({ connectionString: url });
 
   beforeAll(async () => {
     await pool.query("DROP SCHEMA public CASCADE; CREATE SCHEMA public;");
-    await pool.query(ddl);
+    await pool.query(storeDdl);
   });
 
   afterAll(async () => {

--- a/packages/adapters/test/pg.test.ts
+++ b/packages/adapters/test/pg.test.ts
@@ -4,24 +4,18 @@
 // concurrent queries, so the contention cases only prove true parallelism
 // there.
 
-import { readFileSync } from "node:fs";
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll } from "vitest";
 import { createPgStore, type StoreDb } from "../src";
+import { storeDdl } from "./store-ddl";
 import { describeStoreConformance } from "./store-conformance";
-
-const ddl = ["20260820000000_init", "20260827000000_agent_config_versions"]
-  .map((name) =>
-    readFileSync(new URL(`../migrations/${name}/migration.sql`, import.meta.url), "utf8"),
-  )
-  .join("\n");
 
 let client: PGlite;
 
 beforeAll(async () => {
   client = new PGlite();
-  await client.exec(ddl);
+  await client.exec(storeDdl);
 });
 
 afterAll(async () => {

--- a/packages/adapters/test/pg.test.ts
+++ b/packages/adapters/test/pg.test.ts
@@ -11,10 +11,11 @@ import { afterAll, beforeAll } from "vitest";
 import { createPgStore, type StoreDb } from "../src";
 import { describeStoreConformance } from "./store-conformance";
 
-const ddl = readFileSync(
-  new URL("../migrations/20260820000000_init/migration.sql", import.meta.url),
-  "utf8",
-);
+const ddl = ["20260820000000_init", "20260827000000_agent_config_versions"]
+  .map((name) =>
+    readFileSync(new URL(`../migrations/${name}/migration.sql`, import.meta.url), "utf8"),
+  )
+  .join("\n");
 
 let client: PGlite;
 

--- a/packages/adapters/test/store-conformance.ts
+++ b/packages/adapters/test/store-conformance.ts
@@ -7,7 +7,12 @@
 // advancing time, never by sleeping.
 
 import { beforeEach, describe, expect, it } from "vitest";
-import { type AssistantMessage, DEFAULT_NAMESPACE, type UserMessage } from "@funky/core";
+import {
+  type AssistantMessage,
+  type CreateAgentConfigRequest,
+  DEFAULT_NAMESPACE,
+  type UserMessage,
+} from "@funky/core";
 import {
   type CommitStepRequest,
   FencedError,
@@ -44,10 +49,17 @@ export function describeStoreConformance(
       ({ store, clock } = await makeHarness());
     });
 
-    async function newSession(): Promise<string> {
-      const agentConfigId = await store.createAgentConfig({
-        inference: { provider: "fake", model: "scripted" },
+    async function newAgent(overrides: Partial<CreateAgentConfigRequest> = {}): Promise<string> {
+      return store.createAgentConfig({
+        inference: { provider: "fake", model: "m" },
         systemPrompt: "s",
+        ...overrides,
+      });
+    }
+
+    async function newSession(): Promise<string> {
+      const agentConfigId = await newAgent({
+        inference: { provider: "fake", model: "scripted" },
       });
       const envConfigId = await store.createEnvConfig({});
       return store.createSession({ agentConfigId, envConfigId });
@@ -82,10 +94,7 @@ export function describeStoreConformance(
       });
 
       it("stores absence as absence — no metadata or sampling keys materialize", async () => {
-        const id = await store.createAgentConfig({
-          inference: { provider: "fake", model: "m" },
-          systemPrompt: "s",
-        });
+        const id = await newAgent();
         const config = await store.getAgentConfig(id);
         expect(config).toBeDefined();
         expect("metadata" in config!).toBe(false);
@@ -94,11 +103,7 @@ export function describeStoreConformance(
       });
 
       it("keeps JSON null metadata distinct from absent metadata", async () => {
-        const id = await store.createAgentConfig({
-          inference: { provider: "fake", model: "m" },
-          systemPrompt: "s",
-          metadata: null,
-        });
+        const id = await newAgent({ metadata: null });
         const config = await store.getAgentConfig(id);
         expect(config).toBeDefined();
         expect("metadata" in config!).toBe(true);
@@ -116,7 +121,7 @@ export function describeStoreConformance(
       });
 
       it("partially updates an agent config, preserving omitted fields and its identity", async () => {
-        const id = await store.createAgentConfig({
+        const id = await newAgent({
           inference: { provider: "anthropic", model: "old-model", maxTokens: 1024 },
           systemPrompt: "old prompt",
           metadata: { team: "growth" },
@@ -143,10 +148,7 @@ export function describeStoreConformance(
       });
 
       it("updates unconditionally when version is omitted", async () => {
-        const id = await store.createAgentConfig({
-          inference: { provider: "fake", model: "m" },
-          systemPrompt: "s",
-        });
+        const id = await newAgent();
         const first = await store.updateAgentConfig(id, { systemPrompt: "one" });
         const second = await store.updateAgentConfig(id, {
           inference: { provider: "fake", model: "m2" },
@@ -155,21 +157,31 @@ export function describeStoreConformance(
         expect(second).toMatchObject({ version: 3, systemPrompt: "one" });
       });
 
-      it("treats an update with no mutable fields as a version-checked no-op", async () => {
-        const id = await store.createAgentConfig({
-          inference: { provider: "fake", model: "m" },
-          systemPrompt: "s",
+      it("serializes concurrent unconditional partial updates", async () => {
+        const id = await newAgent();
+
+        const updates = await Promise.all([
+          store.updateAgentConfig(id, { systemPrompt: "new prompt" }),
+          store.updateAgentConfig(id, { inference: { provider: "fake", model: "m2" } }),
+        ]);
+
+        expect(updates.map((config) => config?.version).sort()).toEqual([2, 3]);
+        expect(await store.getAgentConfig(id)).toMatchObject({
+          inference: { provider: "fake", model: "m2" },
+          systemPrompt: "new prompt",
+          version: 3,
         });
+      });
+
+      it("treats an update with no mutable fields as a version-checked no-op", async () => {
+        const id = await newAgent();
         const before = await store.getAgentConfig(id);
         expect(await store.updateAgentConfig(id, { version: 1 })).toEqual(before);
         expect(await store.updateAgentConfig(id, {})).toEqual(before);
       });
 
       it("rejects a stale expected version without changing the config", async () => {
-        const id = await store.createAgentConfig({
-          inference: { provider: "fake", model: "m" },
-          systemPrompt: "s",
-        });
+        const id = await newAgent();
         await store.updateAgentConfig(id, { systemPrompt: "winner", version: 1 });
 
         await expect(
@@ -183,7 +195,7 @@ export function describeStoreConformance(
       });
 
       it("keeps every prior agent version as an immutable snapshot", async () => {
-        const id = await store.createAgentConfig({
+        const id = await newAgent({
           inference: { provider: "fake", model: "m1" },
           systemPrompt: "v1",
           metadata: { revision: 1 },
@@ -209,10 +221,7 @@ export function describeStoreConformance(
       });
 
       it("lets exactly one concurrent update satisfy the same version", async () => {
-        const id = await store.createAgentConfig({
-          inference: { provider: "fake", model: "m" },
-          systemPrompt: "s",
-        });
+        const id = await newAgent();
         const results = await Promise.allSettled([
           store.updateAgentConfig(id, { systemPrompt: "a", version: 1 }),
           store.updateAgentConfig(id, { systemPrompt: "b", version: 1 }),
@@ -224,11 +233,7 @@ export function describeStoreConformance(
       });
 
       it("treats an unknown or foreign update target as absent", async () => {
-        const id = await store.createAgentConfig({
-          inference: { provider: "fake", model: "m" },
-          systemPrompt: "s",
-          namespace: "tenant-a",
-        });
+        const id = await newAgent({ namespace: "tenant-a" });
         await expect(
           store.updateAgentConfig("nope", { systemPrompt: "x", namespace: "tenant-a" }),
         ).resolves.toBeUndefined();
@@ -239,10 +244,7 @@ export function describeStoreConformance(
       });
 
       it("rejects an invalid update request at the boundary", async () => {
-        const id = await store.createAgentConfig({
-          inference: { provider: "fake", model: "m" },
-          systemPrompt: "s",
-        });
+        const id = await newAgent();
         await expect(
           // biome-ignore lint/suspicious/noExplicitAny: deliberately malformed
           store.updateAgentConfig(id, { version: 0 } as any),
@@ -278,9 +280,8 @@ export function describeStoreConformance(
         const ids: string[] = [];
         for (let i = 0; i < n; i++) {
           ids.push(
-            await store.createAgentConfig({
+            await newAgent({
               inference: { provider: "fake", model: `m${i}` },
-              systemPrompt: "s",
               ...(namespace === undefined ? {} : { namespace }),
             }),
           );
@@ -392,7 +393,7 @@ export function describeStoreConformance(
       });
 
       it("pins the latest agent version when the session is created", async () => {
-        const agentConfigId = await store.createAgentConfig({
+        const agentConfigId = await newAgent({
           inference: { provider: "fake", model: "m1" },
           systemPrompt: "v1",
         });
@@ -407,6 +408,20 @@ export function describeStoreConformance(
           (await store.getAgentConfigVersion(agentConfigId, session!.agentConfigVersion))
             ?.systemPrompt,
         ).toBe("v2");
+      });
+
+      it("pins an explicitly requested agent version", async () => {
+        const agentConfigId = await newAgent({ systemPrompt: "v1" });
+        const envConfigId = await store.createEnvConfig({});
+        await store.updateAgentConfig(agentConfigId, { systemPrompt: "v2", version: 1 });
+
+        const sessionId = await store.createSession({
+          agentConfigId,
+          agentConfigVersion: 1,
+          envConfigId,
+        });
+
+        expect((await store.getSession(sessionId))?.agentConfigVersion).toBe(1);
       });
 
       it("bindSandbox: first writer wins, losers learn the winner", async () => {
@@ -436,26 +451,24 @@ export function describeStoreConformance(
         await expect(store.bindSandbox("nope", "sbx_a")).rejects.toThrow("unknown session");
       });
 
-      it("rejects a session naming an unknown agent config", async () => {
+      it("rejects a session naming an unknown agent config or version", async () => {
         const envConfigId = await store.createEnvConfig({});
         await expect(store.createSession({ agentConfigId: "nope", envConfigId })).rejects.toThrow();
+        const agentConfigId = await newAgent();
+        await expect(
+          store.createSession({ agentConfigId, agentConfigVersion: 2, envConfigId }),
+        ).rejects.toThrow();
       });
 
       it("rejects a session naming an unknown env config", async () => {
-        const agentConfigId = await store.createAgentConfig({
-          inference: { provider: "fake", model: "m" },
-          systemPrompt: "s",
-        });
+        const agentConfigId = await newAgent();
         await expect(store.createSession({ agentConfigId, envConfigId: "nope" })).rejects.toThrow();
       });
     });
 
     describe("namespace", () => {
       it("materializes DEFAULT_NAMESPACE when absent, on all three ownable rows", async () => {
-        const agentConfigId = await store.createAgentConfig({
-          inference: { provider: "fake", model: "m" },
-          systemPrompt: "s",
-        });
+        const agentConfigId = await newAgent();
         const envConfigId = await store.createEnvConfig({});
         const sessionId = await store.createSession({ agentConfigId, envConfigId });
         expect((await store.getAgentConfig(agentConfigId))?.namespace).toBe(DEFAULT_NAMESPACE);
@@ -464,11 +477,7 @@ export function describeStoreConformance(
       });
 
       it("stores an explicit namespace verbatim", async () => {
-        const agentConfigId = await store.createAgentConfig({
-          inference: { provider: "fake", model: "m" },
-          systemPrompt: "s",
-          namespace: "tenant-a",
-        });
+        const agentConfigId = await newAgent({ namespace: "tenant-a" });
         const envConfigId = await store.createEnvConfig({ namespace: "tenant-a" });
         const sessionId = await store.createSession({
           agentConfigId,
@@ -481,11 +490,7 @@ export function describeStoreConformance(
       });
 
       it("a foreign-namespace config is unknown — sessions and their configs share one namespace", async () => {
-        const agentA = await store.createAgentConfig({
-          inference: { provider: "fake", model: "m" },
-          systemPrompt: "s",
-          namespace: "tenant-a",
-        });
+        const agentA = await newAgent({ namespace: "tenant-a" });
         const envA = await store.createEnvConfig({ namespace: "tenant-a" });
         const envB = await store.createEnvConfig({ namespace: "tenant-b" });
 

--- a/packages/adapters/test/store-conformance.ts
+++ b/packages/adapters/test/store-conformance.ts
@@ -8,7 +8,12 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import { type AssistantMessage, DEFAULT_NAMESPACE, type UserMessage } from "@funky/core";
-import { type CommitStepRequest, FencedError, type Store } from "@funky/agent";
+import {
+  type CommitStepRequest,
+  FencedError,
+  type Store,
+  VersionConflictError,
+} from "@funky/agent";
 
 export interface StoreHarness {
   store: Store;
@@ -72,6 +77,8 @@ export function describeStoreConformance(
           metadata: { team: "growth" },
         });
         expect(config?.createdAt).toMatch(/T.*Z$/);
+        expect(config?.version).toBe(1);
+        expect(await store.getAgentConfigVersion(id, 1)).toEqual(config);
       });
 
       it("stores absence as absence — no metadata or sampling keys materialize", async () => {
@@ -105,6 +112,140 @@ export function describeStoreConformance(
             inference: "claude-sonnet-5" as any,
             systemPrompt: "s",
           }),
+        ).rejects.toThrow();
+      });
+
+      it("partially updates an agent config, preserving omitted fields and its identity", async () => {
+        const id = await store.createAgentConfig({
+          inference: { provider: "anthropic", model: "old-model", maxTokens: 1024 },
+          systemPrompt: "old prompt",
+          metadata: { team: "growth" },
+        });
+        const before = await store.getAgentConfig(id);
+        clock.advance(1_000);
+
+        const updated = await store.updateAgentConfig(id, {
+          systemPrompt: "new prompt",
+          version: 1,
+        });
+
+        expect(updated).toMatchObject({
+          id,
+          inference: { provider: "anthropic", model: "old-model", maxTokens: 1024 },
+          systemPrompt: "new prompt",
+          metadata: { team: "growth" },
+          namespace: DEFAULT_NAMESPACE,
+          version: 2,
+          createdAt: before?.createdAt,
+        });
+        expect(Date.parse(updated!.updatedAt)).toBeGreaterThan(Date.parse(before!.updatedAt));
+        expect(await store.getAgentConfig(id)).toEqual(updated);
+      });
+
+      it("updates unconditionally when version is omitted", async () => {
+        const id = await store.createAgentConfig({
+          inference: { provider: "fake", model: "m" },
+          systemPrompt: "s",
+        });
+        const first = await store.updateAgentConfig(id, { systemPrompt: "one" });
+        const second = await store.updateAgentConfig(id, {
+          inference: { provider: "fake", model: "m2" },
+        });
+        expect(first?.version).toBe(2);
+        expect(second).toMatchObject({ version: 3, systemPrompt: "one" });
+      });
+
+      it("treats an update with no mutable fields as a version-checked no-op", async () => {
+        const id = await store.createAgentConfig({
+          inference: { provider: "fake", model: "m" },
+          systemPrompt: "s",
+        });
+        const before = await store.getAgentConfig(id);
+        expect(await store.updateAgentConfig(id, { version: 1 })).toEqual(before);
+        expect(await store.updateAgentConfig(id, {})).toEqual(before);
+      });
+
+      it("rejects a stale expected version without changing the config", async () => {
+        const id = await store.createAgentConfig({
+          inference: { provider: "fake", model: "m" },
+          systemPrompt: "s",
+        });
+        await store.updateAgentConfig(id, { systemPrompt: "winner", version: 1 });
+
+        await expect(
+          store.updateAgentConfig(id, { systemPrompt: "stale", version: 1 }),
+        ).rejects.toMatchObject({
+          name: "VersionConflictError",
+          expectedVersion: 1,
+          actualVersion: 2,
+        });
+        expect((await store.getAgentConfig(id))?.systemPrompt).toBe("winner");
+      });
+
+      it("keeps every prior agent version as an immutable snapshot", async () => {
+        const id = await store.createAgentConfig({
+          inference: { provider: "fake", model: "m1" },
+          systemPrompt: "v1",
+          metadata: { revision: 1 },
+        });
+        const v1 = await store.getAgentConfigVersion(id, 1);
+        await store.updateAgentConfig(id, {
+          inference: { provider: "fake", model: "m2" },
+          systemPrompt: "v2",
+          version: 1,
+        });
+        await store.updateAgentConfig(id, { metadata: { revision: 3 }, version: 2 });
+
+        expect(await store.getAgentConfigVersion(id, 1)).toEqual(v1);
+        expect(await store.getAgentConfigVersion(id, 2)).toMatchObject({
+          inference: { provider: "fake", model: "m2" },
+          systemPrompt: "v2",
+          metadata: { revision: 1 },
+          version: 2,
+        });
+        expect(await store.getAgentConfigVersion(id, 3)).toEqual(await store.getAgentConfig(id));
+        expect(await store.getAgentConfigVersion(id, 4)).toBeUndefined();
+        expect(await store.getAgentConfigVersion("nope", 1)).toBeUndefined();
+      });
+
+      it("lets exactly one concurrent update satisfy the same version", async () => {
+        const id = await store.createAgentConfig({
+          inference: { provider: "fake", model: "m" },
+          systemPrompt: "s",
+        });
+        const results = await Promise.allSettled([
+          store.updateAgentConfig(id, { systemPrompt: "a", version: 1 }),
+          store.updateAgentConfig(id, { systemPrompt: "b", version: 1 }),
+        ]);
+        expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+        const rejected = results.find((result) => result.status === "rejected");
+        expect(rejected).toMatchObject({ reason: expect.any(VersionConflictError) });
+        expect((await store.getAgentConfig(id))?.version).toBe(2);
+      });
+
+      it("treats an unknown or foreign update target as absent", async () => {
+        const id = await store.createAgentConfig({
+          inference: { provider: "fake", model: "m" },
+          systemPrompt: "s",
+          namespace: "tenant-a",
+        });
+        await expect(
+          store.updateAgentConfig("nope", { systemPrompt: "x", namespace: "tenant-a" }),
+        ).resolves.toBeUndefined();
+        await expect(
+          store.updateAgentConfig(id, { systemPrompt: "x", namespace: "tenant-b" }),
+        ).resolves.toBeUndefined();
+        expect((await store.getAgentConfig(id))?.systemPrompt).toBe("s");
+      });
+
+      it("rejects an invalid update request at the boundary", async () => {
+        const id = await store.createAgentConfig({
+          inference: { provider: "fake", model: "m" },
+          systemPrompt: "s",
+        });
+        await expect(
+          // biome-ignore lint/suspicious/noExplicitAny: deliberately malformed
+          store.updateAgentConfig(id, { version: 0 } as any),
         ).rejects.toThrow();
       });
 
@@ -246,7 +387,26 @@ export function describeStoreConformance(
         const session = await store.getSession(sessionId);
         expect(session?.id).toBe(sessionId);
         expect(session?.agentConfigId).toBeDefined();
+        expect(session?.agentConfigVersion).toBe(1);
         expect(session?.envConfigId).toBeDefined();
+      });
+
+      it("pins the latest agent version when the session is created", async () => {
+        const agentConfigId = await store.createAgentConfig({
+          inference: { provider: "fake", model: "m1" },
+          systemPrompt: "v1",
+        });
+        const envConfigId = await store.createEnvConfig({});
+        await store.updateAgentConfig(agentConfigId, { systemPrompt: "v2", version: 1 });
+        const sessionId = await store.createSession({ agentConfigId, envConfigId });
+        await store.updateAgentConfig(agentConfigId, { systemPrompt: "v3", version: 2 });
+
+        const session = await store.getSession(sessionId);
+        expect(session?.agentConfigVersion).toBe(2);
+        expect(
+          (await store.getAgentConfigVersion(agentConfigId, session!.agentConfigVersion))
+            ?.systemPrompt,
+        ).toBe("v2");
       });
 
       it("bindSandbox: first writer wins, losers learn the winner", async () => {

--- a/packages/adapters/test/store-ddl.ts
+++ b/packages/adapters/test/store-ddl.ts
@@ -1,0 +1,7 @@
+import { readFileSync } from "node:fs";
+
+export const storeDdl = ["20260820000000_init", "20260827000000_agent_config_versions"]
+  .map((name) =>
+    readFileSync(new URL(`../migrations/${name}/migration.sql`, import.meta.url), "utf8"),
+  )
+  .join("\n");

--- a/packages/agent/src/driver/loop.ts
+++ b/packages/agent/src/driver/loop.ts
@@ -173,7 +173,10 @@ export async function runStep(
     if (item.type === "inference") {
       const session = await store.getSession(item.sessionId);
       if (!session) throw new Error(`driver: claimed item for unknown session ${item.sessionId}`);
-      const config = await store.getAgentConfig(session.agentConfigId);
+      const config = await store.getAgentConfigVersion(
+        session.agentConfigId,
+        session.agentConfigVersion,
+      );
       if (!config) throw new Error(`driver: session ${item.sessionId} has no agent config`);
       // Drain-at-inference-prep is what makes these inputs steering: they
       // shape this context, ride in this commit before the step's output,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -26,7 +26,7 @@ export type {
   SandboxInfo,
   SandboxProvider,
 } from "./ports/sandbox-provider";
-export { FencedError } from "./ports/store";
+export { FencedError, VersionConflictError } from "./ports/store";
 export type {
   Claim,
   CommitStepRequest,

--- a/packages/agent/src/ports/store.ts
+++ b/packages/agent/src/ports/store.ts
@@ -13,6 +13,7 @@ import type {
   Session,
   SessionEntry,
   SessionId,
+  UpdateAgentConfigRequest,
   UserMessage,
   WorkItem,
 } from "@funky/core";
@@ -45,10 +46,20 @@ import type { RunEndStatus } from "../engine/next-action";
  * implement it; the conformance suite keeps that honest.
  */
 export interface Store {
-  // --- configs — write-once, so every get is infinitely cacheable ---
+  // --- configs ---
 
   createAgentConfig(req: CreateAgentConfigRequest): Promise<ConfigId>;
   getAgentConfig(id: ConfigId): Promise<AgentConfig | undefined>;
+  /** An immutable historical snapshot; undefined for an unknown id/version. */
+  getAgentConfigVersion(id: ConfigId, version: number): Promise<AgentConfig | undefined>;
+  /**
+   * Partially update one namespace's agent config. Omitted fields are
+   * preserved. A supplied version is an optimistic-concurrency precondition;
+   * mismatch throws VersionConflictError, while an unknown or foreign id is
+   * undefined. Every successful mutation increments the stored version; a
+   * request containing only the precondition is a read-like no-op.
+   */
+  updateAgentConfig(id: ConfigId, req: UpdateAgentConfigRequest): Promise<AgentConfig | undefined>;
   /** One namespace's agent configs, newest first — see ListConfigsRequest. */
   listAgentConfigs(req: ListConfigsRequest): Promise<AgentConfig[]>;
   createEnvConfig(req: CreateEnvConfigRequest): Promise<ConfigId>;
@@ -58,10 +69,11 @@ export interface Store {
 
   // --- sessions ---
 
-  /** Rejects unknown config ids — a session never dangles — and the
-   *  checks are namespace-scoped: a config in a different namespace IS
-   *  unknown (indistinguishable from nonexistent, so nothing leaks). A
-   *  session and its configs therefore always share one namespace. */
+  /** Resolves and pins the agent's latest version. Rejects unknown config
+   *  ids — a session never dangles — and the checks are namespace-scoped: a
+   *  config in a different namespace IS unknown (indistinguishable from
+   *  nonexistent, so nothing leaks). A session and its configs therefore
+   *  always share one namespace. */
   createSession(req: CreateSessionRequest): Promise<SessionId>;
   getSession(id: SessionId): Promise<Session | undefined>;
   /** Register the session's one sandbox: a compare-and-set on the
@@ -158,8 +170,8 @@ export interface Store {
  * of the last row of the page before. It is resolved inside the
  * namespace, so a foreign cursor throws "unknown cursor" exactly like a
  * nonexistent one and nothing leaks. Keyset, not offset, and ordered by
- * (createdAt, id) so ties in the clock still order totally: config rows
- * are write-once and never deleted, so a page boundary never moves — a
+ * (createdAt, id) so ties in the clock still order totally: those ordering
+ * keys are immutable and configs are never deleted, so a page boundary never moves — a
  * concurrent create lands ahead of the first page, which the caller
  * already has, and can neither duplicate nor skip a row mid-walk.
  */
@@ -182,6 +194,19 @@ export class FencedError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "FencedError";
+  }
+}
+
+/** Thrown when an agent-config update's expected version is stale. */
+export class VersionConflictError extends Error {
+  constructor(
+    readonly expectedVersion: number,
+    readonly actualVersion: number,
+  ) {
+    super(
+      `agent config version ${actualVersion} does not match expected version ${expectedVersion}`,
+    );
+    this.name = "VersionConflictError";
   }
 }
 

--- a/packages/agent/src/ports/store.ts
+++ b/packages/agent/src/ports/store.ts
@@ -69,11 +69,9 @@ export interface Store {
 
   // --- sessions ---
 
-  /** Resolves and pins the agent's latest version. Rejects unknown config
-   *  ids — a session never dangles — and the checks are namespace-scoped: a
-   *  config in a different namespace IS unknown (indistinguishable from
-   *  nonexistent, so nothing leaks). A session and its configs therefore
-   *  always share one namespace. */
+  /** Pins the requested agent version, or the latest when omitted. Rejects
+   *  unknown configs or versions, with namespace-scoped checks so foreign ids
+   *  remain indistinguishable from nonexistent ones. */
   createSession(req: CreateSessionRequest): Promise<SessionId>;
   getSession(id: SessionId): Promise<Session | undefined>;
   /** Register the session's one sandbox: a compare-and-set on the
@@ -170,10 +168,9 @@ export interface Store {
  * of the last row of the page before. It is resolved inside the
  * namespace, so a foreign cursor throws "unknown cursor" exactly like a
  * nonexistent one and nothing leaks. Keyset, not offset, and ordered by
- * (createdAt, id) so ties in the clock still order totally: those ordering
- * keys are immutable and configs are never deleted, so a page boundary never moves — a
- * concurrent create lands ahead of the first page, which the caller
- * already has, and can neither duplicate nor skip a row mid-walk.
+ * immutable (createdAt, id), so updates cannot move a page boundary. A
+ * concurrent create lands ahead of the first page and cannot duplicate or
+ * skip a row mid-walk.
  */
 export interface ListConfigsRequest {
   namespace: string;

--- a/packages/agent/test/ensure-sandbox.test.ts
+++ b/packages/agent/test/ensure-sandbox.test.ts
@@ -44,6 +44,7 @@ function fakeStore(opts?: { sandboxId?: string; winner?: string }) {
   const session: Session = {
     id: "s1",
     agentConfigId: "a1",
+    agentConfigVersion: 1,
     envConfigId: "e1",
     namespace: "default",
     createdAt: "2026-08-18T00:00:00.000Z",

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -14,10 +14,11 @@ import { InferenceConfig } from "./inference";
  * boundary from the log's control entries — no import edge.
  *
  * Request shapes (Create*Request, after InferenceRequest and
- * StreamRequest) become stored rows verbatim, plus the store-minted
- * envelope (id, createdAt). Two rules keep every row one-shaped:
+ * StreamRequest) become stored rows verbatim, plus store-minted envelope
+ * fields (id/createdAt, and version/updatedAt on mutable agent configs).
+ * Two rules keep every row one-shaped:
  * - Rows store decisions, not rules: a default that is RESOLVED at
- *   creation time is materialized into the write-once row (network →
+ *   creation time is materialized into the stored row (network →
  *   unrestricted), so a later change of the platform default can never
  *   reinterpret an old row. Where absence itself is the fact (no
  *   sampling override, no metadata), absence is stored as absence.
@@ -52,10 +53,10 @@ export const DEFAULT_NAMESPACE = "default";
 
 // --- configs ---
 
-// Config rows are write-once: the port exposes no update or delete, so
-// immutability is an API impossibility, not a discipline. Sessions
-// reference config ids — the resolved config is always read through the
-// id, never copied forward.
+// Agent configs are mutable, with a monotonic version used for optional
+// optimistic concurrency. Env configs remain immutable sandbox recipes.
+// Sessions pin the latest concrete agent version at creation, so later agent
+// updates cannot change the behavior of an existing session.
 
 export const CreateAgentConfigRequest = z.object({
   inference: InferenceConfig,
@@ -65,10 +66,23 @@ export const CreateAgentConfigRequest = z.object({
 });
 export type CreateAgentConfigRequest = z.infer<typeof CreateAgentConfigRequest>;
 
+// UpdateAgent-style partial replacement: omission preserves a field. `version`
+// is a precondition, not stored payload — omit it for last-write-wins.
+export const UpdateAgentConfigRequest = z.object({
+  inference: InferenceConfig.optional(),
+  systemPrompt: z.string().optional(),
+  namespace: z.string().min(1).optional(),
+  metadata: JsonValue.optional(),
+  version: z.number().int().min(1).optional(),
+});
+export type UpdateAgentConfigRequest = z.infer<typeof UpdateAgentConfigRequest>;
+
 export const AgentConfig = CreateAgentConfigRequest.extend({
   id: z.string(),
   namespace: z.string().min(1), // materialized: absence resolved to DEFAULT_NAMESPACE
+  version: z.number().int().min(1),
   createdAt: z.iso.datetime(),
+  updatedAt: z.iso.datetime(),
 });
 export type AgentConfig = z.infer<typeof AgentConfig>;
 
@@ -110,6 +124,8 @@ export type CreateSessionRequest = z.infer<typeof CreateSessionRequest>;
 export const Session = CreateSessionRequest.extend({
   id: z.string(),
   namespace: z.string().min(1), // materialized: absence resolved to DEFAULT_NAMESPACE
+  // Materialized from the agent config's latest version at session create.
+  agentConfigVersion: z.number().int().min(1),
   // The session's one workspace, registered by the driver's first
   // execute_tools claim (Store.bindSandbox); absent until then.
   sandboxId: z.string().optional(),

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -112,6 +112,8 @@ export type EnvConfig = z.infer<typeof EnvConfig>;
 
 export const CreateSessionRequest = z.object({
   agentConfigId: z.string(),
+  // Omit to pin the latest version at creation time.
+  agentConfigVersion: z.number().int().min(1).optional(),
   envConfigId: z.string(),
   // Explicit, not derived from the configs: deriving would let a leaked
   // foreign config id pull a session into the wrong namespace. The store
@@ -124,7 +126,7 @@ export type CreateSessionRequest = z.infer<typeof CreateSessionRequest>;
 export const Session = CreateSessionRequest.extend({
   id: z.string(),
   namespace: z.string().min(1), // materialized: absence resolved to DEFAULT_NAMESPACE
-  // Materialized from the agent config's latest version at session create.
+  // Materialized from the request or the agent config's latest version.
   agentConfigVersion: z.number().int().min(1),
   // The session's one workspace, registered by the driver's first
   // execute_tools claim (Store.bindSandbox); absent until then.

--- a/packages/core/test/store.test.ts
+++ b/packages/core/test/store.test.ts
@@ -8,6 +8,7 @@ import {
   IntakeResult,
   PendingInput,
   Session,
+  UpdateAgentConfigRequest,
   WorkItem,
 } from "../src/store";
 
@@ -27,7 +28,9 @@ describe("configs", () => {
       systemPrompt: "You are helpful.",
       namespace: "tenant-a",
       metadata: { team: "growth" },
+      version: 3,
       createdAt: "2026-08-11T12:00:00Z",
+      updatedAt: "2026-08-12T12:00:00Z",
     };
     expect(roundTrip(AgentConfig, config)).toEqual(config);
   });
@@ -46,7 +49,9 @@ describe("configs", () => {
       inference: { provider: "fake", model: "scripted" },
       systemPrompt: "s",
       namespace: "default",
+      version: 1,
       createdAt: "2026-08-11T12:00:00Z",
+      updatedAt: "2026-08-11T12:00:00Z",
     };
     expect(roundTrip(AgentConfig, config)).toEqual(config);
   });
@@ -67,6 +72,18 @@ describe("configs", () => {
       systemPrompt: "s",
     });
     expect(result.success).toBe(false);
+  });
+
+  it("accepts a partial update and an optional positive version precondition", () => {
+    expect(UpdateAgentConfigRequest.safeParse({ systemPrompt: "new", version: 2 }).success).toBe(
+      true,
+    );
+    expect(UpdateAgentConfigRequest.safeParse({}).success).toBe(true);
+  });
+
+  it("rejects an invalid update version or inference config", () => {
+    expect(UpdateAgentConfigRequest.safeParse({ version: 0 }).success).toBe(false);
+    expect(UpdateAgentConfigRequest.safeParse({ inference: "model-only" }).success).toBe(false);
   });
 });
 
@@ -113,6 +130,7 @@ describe("sessions", () => {
     const session = {
       id: "s1",
       agentConfigId: "ac1",
+      agentConfigVersion: 2,
       envConfigId: "ec1",
       namespace: "default",
       createdAt: "2026-08-11T12:00:00Z",
@@ -124,6 +142,7 @@ describe("sessions", () => {
     const result = Session.safeParse({
       id: "s1",
       agentConfigId: "ac1",
+      agentConfigVersion: 1,
       envConfigId: "ec1",
       createdAt: "2026-08-11T12:00:00Z",
     });

--- a/packages/core/test/store.test.ts
+++ b/packages/core/test/store.test.ts
@@ -158,6 +158,23 @@ describe("sessions", () => {
     const result = CreateSessionRequest.safeParse({ agentConfigId: "ac1" });
     expect(result.success).toBe(false);
   });
+
+  it("accepts an optional positive agent config version", () => {
+    expect(
+      CreateSessionRequest.safeParse({
+        agentConfigId: "ac1",
+        agentConfigVersion: 2,
+        envConfigId: "ec1",
+      }).success,
+    ).toBe(true);
+    expect(
+      CreateSessionRequest.safeParse({
+        agentConfigId: "ac1",
+        agentConfigVersion: 0,
+        envConfigId: "ec1",
+      }).success,
+    ).toBe(false);
+  });
 });
 
 describe("work items", () => {


### PR DESCRIPTION
## Summary

- add an immutable agent_config_versions snapshot for every created or updated agent config
- make config updates and version appends one transaction with optional optimistic concurrency
- pin each session to the latest agent version at creation and have workers read that pinned snapshot
- migrate existing agents and sessions to version 1 with backfill coverage

## Verification

- pnpm test
- pnpm typecheck
- pnpm build
- pnpm format:check