### PR TITLE
Add the agent config update endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ export TOKEN=<your FUNKY_AUTH_TOKEN>
 export H="Authorization: Bearer $TOKEN"
 export J="content-type: application/json"
 
-# 1. an agent config: the model and the system prompt (write-once)
+# 1. an agent config: the model and the system prompt
 AID=$(curl -s localhost:3000/v1/agent-configs -H "$H" -H "$J" -d '{
   "inference": { "provider": "anthropic", "model": "claude-sonnet-5", "maxTokens": 2048 },
   "systemPrompt": "You are an autonomous agent in a fresh Linux sandbox."
@@ -50,6 +50,11 @@ curl -N -H "$H" localhost:3000/v1/sessions/$SID/stream &
 curl -s localhost:3000/v1/sessions/$SID/messages -H "$H" -H "$J" \
   -d '{"content":"Run uname -a in your sandbox and tell me what you see."}'
 ```
+
+Agent configs can be updated with `POST /v1/agent-configs/$AID`. Send only the fields to
+replace; omitted fields are preserved. Responses include a monotonic `version`: include the
+current value in an update for optimistic concurrency (a stale value returns 409), or omit it
+for an unconditional last-write-wins update.
 
 The message answers `202 {"kind":"started", ...}` — accepted, not done. A worker claims the
 run, provisions an E2B sandbox the moment a tool actually executes (an inference-only turn

--- a/apps/api/src/http.ts
+++ b/apps/api/src/http.ts
@@ -5,11 +5,15 @@
 import type { Context } from "hono";
 
 export type ErrorType =
-  "invalid_request_error" | "authentication_error" | "not_found_error" | "api_error";
+  | "invalid_request_error"
+  | "authentication_error"
+  | "not_found_error"
+  | "conflict_error"
+  | "api_error";
 
 export function errorResponse(
   c: Context,
-  status: 400 | 401 | 404 | 500,
+  status: 400 | 401 | 404 | 409 | 500,
   type: ErrorType,
   message: string,
 ) {

--- a/apps/api/src/routes/agent-configs.ts
+++ b/apps/api/src/routes/agent-configs.ts
@@ -1,23 +1,24 @@
 // apps/api/src/routes/agent-configs.ts
-// The agent-config resource — write-once behavior recipes (inference +
-// system prompt), tenant-private like every config. Same shape as
-// env-configs.ts: create, get, list, core schemas as the wire format,
-// the middleware's namespace stamped on create and checked on read.
+// The agent-config resource — versioned behavior recipes (inference +
+// system prompt), tenant-private like every config. Updates follow
+// UpdateAgent semantics: partial replacement and an optional version
+// precondition for optimistic concurrency.
 import { Hono } from "hono";
-import { CreateAgentConfigRequest } from "@funky/core";
-import type { Store } from "@funky/agent";
+import { CreateAgentConfigRequest, UpdateAgentConfigRequest } from "@funky/core";
+import { type Store, VersionConflictError } from "@funky/agent";
 import { errorResponse } from "../http";
 import { ListQuery, page, validate } from "./common";
 
 /** The slice of the harness Store this resource needs. */
 export type AgentConfigStore = Pick<
   Store,
-  "createAgentConfig" | "getAgentConfig" | "listAgentConfigs"
+  "createAgentConfig" | "getAgentConfig" | "listAgentConfigs" | "updateAgentConfig"
 >;
 
 type Env = { Variables: { requestId: string; namespace: string } };
 
 const WireCreateAgentConfig = CreateAgentConfigRequest.omit({ namespace: true });
+const WireUpdateAgentConfig = UpdateAgentConfigRequest.omit({ namespace: true });
 
 export function agentConfigRoutes(store: AgentConfigStore) {
   const r = new Hono<Env>();
@@ -60,6 +61,25 @@ export function agentConfigRoutes(store: AgentConfigStore) {
       return errorResponse(c, 404, "not_found_error", `no agent config ${id}`);
     }
     return c.json(config);
+  });
+
+  r.post("/:id", validate("json", WireUpdateAgentConfig), async (c) => {
+    const id = c.req.param("id");
+    try {
+      const config = await store.updateAgentConfig(id, {
+        ...c.req.valid("json"),
+        namespace: c.get("namespace"),
+      });
+      if (config === undefined) {
+        return errorResponse(c, 404, "not_found_error", `no agent config ${id}`);
+      }
+      return c.json(config);
+    } catch (err) {
+      if (err instanceof VersionConflictError) {
+        return errorResponse(c, 409, "conflict_error", err.message);
+      }
+      throw err;
+    }
   });
 
   return r;

--- a/apps/api/test/agent-configs.test.ts
+++ b/apps/api/test/agent-configs.test.ts
@@ -150,6 +150,105 @@ describe("GET /v1/agent-configs", () => {
   });
 });
 
+describe("POST /v1/agent-configs/:id", () => {
+  it("partially updates the config and increments its version", async () => {
+    const created = await (await post(app, "/v1/agent-configs", RECIPE)).json();
+    const res = await post(app, `/v1/agent-configs/${created.id}`, {
+      systemPrompt: "You are a research analyst.",
+      version: 1,
+    });
+    expect(res.status).toBe(200);
+    const updated = await res.json();
+    expect(updated).toMatchObject({
+      id: created.id,
+      inference: RECIPE.inference,
+      systemPrompt: "You are a research analyst.",
+      namespace: "default",
+      version: 2,
+      createdAt: created.createdAt,
+    });
+    expect(typeof updated.updatedAt).toBe("string");
+
+    const fetched = await get(app, `/v1/agent-configs/${created.id}`);
+    expect(await fetched.json()).toEqual(updated);
+  });
+
+  it("returns 409 for a stale version and leaves the winning update intact", async () => {
+    const created = await (await post(app, "/v1/agent-configs", RECIPE)).json();
+    const winner = await post(app, `/v1/agent-configs/${created.id}`, {
+      systemPrompt: "winner",
+      version: 1,
+    });
+    expect(winner.status).toBe(200);
+
+    const stale = await post(app, `/v1/agent-configs/${created.id}`, {
+      systemPrompt: "stale",
+      version: 1,
+    });
+    expect(stale.status).toBe(409);
+    expect((await stale.json()).error.type).toBe("conflict_error");
+
+    const fetched = await (await get(app, `/v1/agent-configs/${created.id}`)).json();
+    expect(fetched).toMatchObject({ systemPrompt: "winner", version: 2 });
+  });
+
+  it("updates unconditionally when version is omitted", async () => {
+    const created = await (await post(app, "/v1/agent-configs", RECIPE)).json();
+    await post(app, `/v1/agent-configs/${created.id}`, { systemPrompt: "first", version: 1 });
+    const res = await post(app, `/v1/agent-configs/${created.id}`, {
+      inference: { provider: "anthropic", model: "claude-opus-5" },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      inference: { provider: "anthropic", model: "claude-opus-5" },
+      systemPrompt: "first",
+      version: 3,
+    });
+  });
+
+  it("accepts an empty update as a no-op", async () => {
+    const created = await (await post(app, "/v1/agent-configs", RECIPE)).json();
+    const res = await post(app, `/v1/agent-configs/${created.id}`, {});
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(created);
+  });
+
+  it("validates the update body", async () => {
+    const created = await (await post(app, "/v1/agent-configs", RECIPE)).json();
+    for (const body of [{ version: 0 }, { inference: "model-only" }]) {
+      const res = await post(app, `/v1/agent-configs/${created.id}`, body);
+      expect(res.status).toBe(400);
+      expect((await res.json()).error.type).toBe("invalid_request_error");
+    }
+  });
+
+  it("404s unknown and foreign ids without mutating the foreign config", async () => {
+    const asTenant = (tenant: string) => ({ "X-Funky-Namespace": tenant });
+    const unknown = await post(
+      scoped,
+      "/v1/agent-configs/nope",
+      { systemPrompt: "x" },
+      asTenant("update-a"),
+    );
+    expect(unknown.status).toBe(404);
+
+    const created = await (
+      await post(scoped, "/v1/agent-configs", RECIPE, asTenant("update-a"))
+    ).json();
+    const foreign = await post(
+      scoped,
+      `/v1/agent-configs/${created.id}`,
+      { systemPrompt: "x", version: 1 },
+      asTenant("update-b"),
+    );
+    expect(foreign.status).toBe(404);
+    const own = await (
+      await get(scoped, `/v1/agent-configs/${created.id}`, asTenant("update-a"))
+    ).json();
+    expect(own).toMatchObject({ systemPrompt: RECIPE.systemPrompt, version: 1 });
+  });
+});
+
 describe("GET /v1/agent-configs/:id", () => {
   it("404s an unknown id with the error envelope", async () => {
     const res = await get(app, "/v1/agent-configs/nope");


### PR DESCRIPTION
## Summary

- add POST /v1/agent-configs/:id with partial-update semantics
- accept an optional version precondition and return 409 conflict_error for stale writes
- preserve namespace isolation for unknown and foreign config ids
- document unconditional last-write-wins updates when version is omitted

## Stack

- depends on #128

## Verification

- pnpm test
- pnpm typecheck
- pnpm build
- pnpm format:check