### PR TITLE
Add namespace-scoped agent config references

### DIFF
--- a/apps/api/src/routes/agent-configs.ts
+++ b/apps/api/src/routes/agent-configs.ts
@@ -22,17 +22,11 @@ export type AgentConfigStore = Pick<
 
 type Env = { Variables: { requestId: string; namespace: string } };
 
-const WireCreateAgentConfig = CreateAgentConfigRequest.omit({ namespace: true });
-const WireUpdateAgentConfig = UpdateAgentConfigRequest;
-
 export function agentConfigRoutes(store: AgentConfigStore) {
   const r = new Hono<Env>();
 
-  r.post("/", validate("json", WireCreateAgentConfig), async (c) => {
-    const ref = await store.createAgentConfig({
-      ...c.req.valid("json"),
-      namespace: c.get("namespace"),
-    });
+  r.post("/", validate("json", CreateAgentConfigRequest), async (c) => {
+    const ref = await store.createAgentConfig(c.req.valid("json"));
     const config = await store.getAgentConfig(ref);
     if (!config) throw new Error(`agent config ${ref.id} missing after create`);
     return c.json(config, 201);
@@ -68,7 +62,7 @@ export function agentConfigRoutes(store: AgentConfigStore) {
     return c.json(config);
   });
 
-  r.post("/:id", validate("json", WireUpdateAgentConfig), async (c) => {
+  r.post("/:id", validate("json", UpdateAgentConfigRequest), async (c) => {
     const id = c.req.param("id");
     try {
       const config = await store.updateAgentConfig(

--- a/apps/api/src/routes/agent-configs.ts
+++ b/apps/api/src/routes/agent-configs.ts
@@ -23,18 +23,18 @@ export type AgentConfigStore = Pick<
 type Env = { Variables: { requestId: string; namespace: string } };
 
 const WireCreateAgentConfig = CreateAgentConfigRequest.omit({ namespace: true });
-const WireUpdateAgentConfig = UpdateAgentConfigRequest.omit({ namespace: true });
+const WireUpdateAgentConfig = UpdateAgentConfigRequest;
 
 export function agentConfigRoutes(store: AgentConfigStore) {
   const r = new Hono<Env>();
 
   r.post("/", validate("json", WireCreateAgentConfig), async (c) => {
-    const id = await store.createAgentConfig({
+    const ref = await store.createAgentConfig({
       ...c.req.valid("json"),
       namespace: c.get("namespace"),
     });
-    const config = await store.getAgentConfig(id);
-    if (!config) throw new Error(`agent config ${id} missing after create`);
+    const config = await store.getAgentConfig(ref);
+    if (!config) throw new Error(`agent config ${ref.id} missing after create`);
     return c.json(config, 201);
   });
 
@@ -61,8 +61,8 @@ export function agentConfigRoutes(store: AgentConfigStore) {
 
   r.get("/:id", async (c) => {
     const id = c.req.param("id");
-    const config = await store.getAgentConfig(id);
-    if (!config || config.namespace !== c.get("namespace")) {
+    const config = await store.getAgentConfig({ namespace: c.get("namespace"), id });
+    if (!config) {
       return errorResponse(c, 404, "not_found_error", `no agent config ${id}`);
     }
     return c.json(config);
@@ -71,10 +71,10 @@ export function agentConfigRoutes(store: AgentConfigStore) {
   r.post("/:id", validate("json", WireUpdateAgentConfig), async (c) => {
     const id = c.req.param("id");
     try {
-      const config = await store.updateAgentConfig(id, {
-        ...c.req.valid("json"),
-        namespace: c.get("namespace"),
-      });
+      const config = await store.updateAgentConfig(
+        { namespace: c.get("namespace"), id },
+        c.req.valid("json"),
+      );
       if (config === undefined) {
         return errorResponse(c, 404, "not_found_error", `no agent config ${id}`);
       }
@@ -99,7 +99,7 @@ export function agentConfigRoutes(store: AgentConfigStore) {
   // archivedAt, because the state it asks for is already the state.
   r.post("/:id/archive", async (c) => {
     const id = c.req.param("id");
-    const config = await store.archiveAgentConfig(id, { namespace: c.get("namespace") });
+    const config = await store.archiveAgentConfig({ namespace: c.get("namespace"), id });
     if (config === undefined) {
       return errorResponse(c, 404, "not_found_error", `no agent config ${id}`);
     }

--- a/apps/api/test/agent-configs.test.ts
+++ b/apps/api/test/agent-configs.test.ts
@@ -2,7 +2,7 @@
 // pattern as env-configs.test.ts. The middleware machinery (auth,
 // header source validation) is covered there and in app.test.ts; here
 // we pin this resource's wiring, materialization, and its own
-// fetch-then-check scoping.
+// namespace-scoped Store references.
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";

--- a/apps/api/test/agent-configs.test.ts
+++ b/apps/api/test/agent-configs.test.ts
@@ -12,9 +12,12 @@ import { buildApp } from "../src/app";
 import { get, post } from "./helpers";
 
 const RECIPE = {
+  namespace: "default",
   inference: { provider: "anthropic", model: "claude-sonnet-5", maxTokens: 8192 },
   systemPrompt: "You are a data analyst.",
 };
+
+const recipeFor = (namespace: string) => ({ ...RECIPE, namespace });
 
 let client: PGlite;
 let app: ReturnType<typeof buildApp>;
@@ -52,8 +55,23 @@ describe("POST /v1/agent-configs", () => {
     expect(await fetched.json()).toEqual(body);
   });
 
+  it("uses the namespace supplied in the request", async () => {
+    const res = await post(app, "/v1/agent-configs", recipeFor("caller-namespace"));
+    expect(res.status).toBe(201);
+    expect((await res.json()).namespace).toBe("caller-namespace");
+  });
+
+  it("requires a namespace", async () => {
+    const res = await post(app, "/v1/agent-configs", {
+      inference: RECIPE.inference,
+      systemPrompt: RECIPE.systemPrompt,
+    });
+    expect(res.status).toBe(400);
+  });
+
   it("rejects a bare-string inference config, 400", async () => {
     const res = await post(app, "/v1/agent-configs", {
+      namespace: "default",
       inference: "claude-sonnet-5",
       systemPrompt: "s",
     });
@@ -62,7 +80,10 @@ describe("POST /v1/agent-configs", () => {
   });
 
   it("rejects a missing system prompt, 400", async () => {
-    const res = await post(app, "/v1/agent-configs", { inference: RECIPE.inference });
+    const res = await post(app, "/v1/agent-configs", {
+      namespace: "default",
+      inference: RECIPE.inference,
+    });
     expect(res.status).toBe(400);
   });
 });
@@ -80,7 +101,7 @@ describe("GET /v1/agent-configs", () => {
   async function seed(tenant: string, n: number): Promise<string[]> {
     const ids: string[] = [];
     for (let i = 0; i < n; i++) {
-      const res = await post(scoped, "/v1/agent-configs", RECIPE, asTenant(tenant));
+      const res = await post(scoped, "/v1/agent-configs", recipeFor(tenant), asTenant(tenant));
       expect(res.status).toBe(201);
       ids.push((await res.json()).id);
     }
@@ -233,7 +254,7 @@ describe("POST /v1/agent-configs/:id", () => {
     expect(unknown.status).toBe(404);
 
     const created = await (
-      await post(scoped, "/v1/agent-configs", RECIPE, asTenant("update-a"))
+      await post(scoped, "/v1/agent-configs", recipeFor("update-a"), asTenant("update-a"))
     ).json();
     const foreign = await post(
       scoped,
@@ -291,7 +312,7 @@ describe("POST /v1/agent-configs/:id/archive", () => {
     ).toBe(404);
 
     const created = await (
-      await post(scoped, "/v1/agent-configs", RECIPE, asTenant("arch-a"))
+      await post(scoped, "/v1/agent-configs", recipeFor("arch-a"), asTenant("arch-a"))
     ).json();
     const foreign = await post(
       scoped,
@@ -319,7 +340,7 @@ describe("GET /v1/agent-configs/:id", () => {
   it("scopes by namespace: a foreign row 404s exactly like a nonexistent one", async () => {
     const asTenant = (tenant: string) => ({ "X-Funky-Namespace": tenant });
     const created = await (
-      await post(scoped, "/v1/agent-configs", RECIPE, asTenant("tenant-a"))
+      await post(scoped, "/v1/agent-configs", recipeFor("tenant-a"), asTenant("tenant-a"))
     ).json();
     expect(created.namespace).toBe("tenant-a");
 

--- a/apps/api/test/env-configs.test.ts
+++ b/apps/api/test/env-configs.test.ts
@@ -77,7 +77,11 @@ describe("GET /v1/env-configs", () => {
     await post(
       scoped,
       "/v1/agent-configs",
-      { inference: { provider: "fake", model: "m" }, systemPrompt: "s" },
+      {
+        namespace: "list-env",
+        inference: { provider: "fake", model: "m" },
+        systemPrompt: "s",
+      },
       asTenant("list-env"),
     );
 

--- a/apps/api/test/sessions.test.ts
+++ b/apps/api/test/sessions.test.ts
@@ -45,11 +45,12 @@ async function seedConfigs(
   on: ReturnType<typeof buildApp>,
   headers: Record<string, string> = {},
 ): Promise<{ agentConfigId: string; envConfigId: string }> {
+  const namespace = headers["X-Funky-Namespace"] ?? "default";
   const agent = await (
     await post(
       on,
       "/v1/agent-configs",
-      { inference: { provider: "fake", model: "m" }, systemPrompt: "s" },
+      { namespace, inference: { provider: "fake", model: "m" }, systemPrompt: "s" },
       headers,
     )
   ).json();

--- a/apps/worker/test/e2e.test.ts
+++ b/apps/worker/test/e2e.test.ts
@@ -23,7 +23,12 @@ import { fileURLToPath } from "node:url";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { AgentMessage, SessionEntry, SessionId } from "@funky/core";
+import {
+  DEFAULT_NAMESPACE,
+  type AgentMessage,
+  type SessionEntry,
+  type SessionId,
+} from "@funky/core";
 import { createE2bProvider, createPgStore, type StoreDb } from "@funky/adapters";
 import { storeDdl } from "../../../packages/adapters/test/store-ddl";
 
@@ -99,7 +104,8 @@ if (!url || !anthropicKey || !e2bKey) {
   }
 
   async function seedSession(task: string): Promise<SessionId> {
-    const agentConfigId = await store.createAgentConfig({
+    const agentConfigRef = await store.createAgentConfig({
+      namespace: DEFAULT_NAMESPACE,
       inference: {
         provider: "anthropic",
         model: "claude-haiku-4-5-20251001",
@@ -111,7 +117,10 @@ if (!url || !anthropicKey || !e2bKey) {
         "the execution was interrupted, issue that call again.",
     });
     const envConfigId = await store.createEnvConfig({});
-    const sessionId = await store.createSession({ agentConfigId, envConfigId });
+    const sessionId = await store.createSession({
+      agentConfigId: agentConfigRef.id,
+      envConfigId,
+    });
     sessions.push(sessionId);
     const result = await store.intake(sessionId, {
       role: "user",

--- a/apps/worker/test/e2e.test.ts
+++ b/apps/worker/test/e2e.test.ts
@@ -360,6 +360,7 @@ if (!url || !anthropicKey || !e2bKey) {
 
           // Seed exclusively over HTTP — the api is the only writer here.
           const agent = await apiJson("POST", "/v1/agent-configs", {
+            namespace: DEFAULT_NAMESPACE,
             inference: {
               provider: "anthropic",
               model: "claude-haiku-4-5-20251001",

--- a/packages/adapters/src/store/pg.ts
+++ b/packages/adapters/src/store/pg.ts
@@ -32,8 +32,9 @@ import { and, asc, desc, eq, gt, inArray, isNull, lte, ne, or, type SQL, sql } f
 import type { PgAsyncDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 import {
   AgentConfig,
+  AgentConfigRef,
+  AgentConfigVersionRef,
   AgentMessage,
-  ArchiveAgentConfigRequest,
   CreateAgentConfigRequest,
   CreateEnvConfigRequest,
   CreateSessionRequest,
@@ -41,6 +42,7 @@ import {
   EnvConfig,
   IntakeResult,
   type JsonValue,
+  ListAgentConfigsRequest,
   PendingInput,
   Session,
   SessionEntry,
@@ -194,7 +196,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       await db.transaction(async (tx) => {
         await tx.insert(agentConfigs).values({
           id,
-          namespace: parsed.namespace ?? DEFAULT_NAMESPACE,
+          namespace: parsed.namespace,
           currentVersion: 1,
           createdAt: timestamp,
         });
@@ -207,32 +209,33 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
           updatedAt: timestamp,
         });
       });
-      return id;
+      return AgentConfigRef.parse({ namespace: parsed.namespace, id });
     },
 
-    async getAgentConfig(id) {
+    async getAgentConfig(ref) {
+      const version =
+        "version" in ref && ref.version !== undefined
+          ? AgentConfigVersionRef.parse(ref).version
+          : undefined;
+      const parsed = AgentConfigRef.parse(ref);
+      const requestedVersion =
+        version !== undefined
+          ? and(
+              eq(agentConfigVersions.agentConfigId, agentConfigs.id),
+              eq(agentConfigVersions.version, version),
+            )
+          : currentAgentVersion;
       const [row] = await db
         .select(agentConfigColumns)
         .from(agentConfigs)
-        .innerJoin(agentConfigVersions, currentAgentVersion)
-        .where(eq(agentConfigs.id, id));
+        .innerJoin(agentConfigVersions, requestedVersion)
+        .where(and(eq(agentConfigs.id, parsed.id), eq(agentConfigs.namespace, parsed.namespace)));
       return row === undefined ? undefined : toAgentConfig(row);
     },
 
-    async getAgentConfigVersion(id, version) {
-      const [row] = await db
-        .select(agentConfigColumns)
-        .from(agentConfigVersions)
-        .innerJoin(agentConfigs, eq(agentConfigVersions.agentConfigId, agentConfigs.id))
-        .where(
-          and(eq(agentConfigVersions.agentConfigId, id), eq(agentConfigVersions.version, version)),
-        );
-      return row === undefined ? undefined : toAgentConfig(row);
-    },
-
-    async updateAgentConfig(id, req) {
+    async updateAgentConfig(ref, req) {
+      const { id, namespace } = AgentConfigRef.parse(ref);
       const parsed = UpdateAgentConfigRequest.parse(req);
-      const namespace = parsed.namespace ?? DEFAULT_NAMESPACE;
       const scope = and(eq(agentConfigs.id, id), eq(agentConfigs.namespace, namespace));
       const target = and(
         scope,
@@ -327,9 +330,8 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       });
     },
 
-    async archiveAgentConfig(id, req) {
-      const parsed = ArchiveAgentConfigRequest.parse(req);
-      const namespace = parsed.namespace ?? DEFAULT_NAMESPACE;
+    async archiveAgentConfig(ref) {
+      const { id, namespace } = AgentConfigRef.parse(ref);
       const scope = and(eq(agentConfigs.id, id), eq(agentConfigs.namespace, namespace));
       return db.transaction(async (tx) => {
         // Idempotent by predicate rather than by read-then-write: only an
@@ -350,16 +352,17 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       });
     },
 
-    async listAgentConfigs(req: ListConfigsRequest) {
-      const scope = eq(agentConfigs.namespace, req.namespace);
-      const page = await olderThanCursor(agentConfigs, scope, req.after);
+    async listAgentConfigs(req) {
+      const parsed = ListAgentConfigsRequest.parse(req);
+      const scope = eq(agentConfigs.namespace, parsed.namespace);
+      const page = await olderThanCursor(agentConfigs, scope, parsed.after);
       const rows = await db
         .select(agentConfigColumns)
         .from(agentConfigs)
         .innerJoin(agentConfigVersions, currentAgentVersion)
         .where(and(scope, page))
         .orderBy(desc(agentConfigs.createdAt), desc(agentConfigs.id))
-        .limit(req.limit);
+        .limit(parsed.limit);
       return rows.map(toAgentConfig);
     },
 

--- a/packages/adapters/test/crash-resume.test.ts
+++ b/packages/adapters/test/crash-resume.test.ts
@@ -37,6 +37,7 @@ import { fileURLToPath } from "node:url";
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { DEFAULT_NAMESPACE } from "@funky/core";
 import { runStep, type StepDeps, type Store, toToolSpec } from "@funky/agent";
 import { createPgStore, type StoreDb } from "../src";
 import {
@@ -280,12 +281,13 @@ beforeAll(async () => {
     const client = new PGlite(templateFresh);
     await client.exec(storeDdl);
     const store = createPgStore(drizzle({ client }) as unknown as StoreDb);
-    const agentConfigId = await store.createAgentConfig({
+    const agentConfigRef = await store.createAgentConfig({
+      namespace: DEFAULT_NAMESPACE,
       inference: inferenceConfig,
       systemPrompt: "be brief",
     });
     const envConfigId = await store.createEnvConfig({});
-    sessionId = await store.createSession({ agentConfigId, envConfigId });
+    sessionId = await store.createSession({ agentConfigId: agentConfigRef.id, envConfigId });
     const result = await store.intake(sessionId, user(PROMPTS[0]));
     if (result.kind !== "started") throw new Error("seed intake did not start a run");
     await client.close();

--- a/packages/adapters/test/driver.test.ts
+++ b/packages/adapters/test/driver.test.ts
@@ -10,7 +10,13 @@ import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
-import type { ProviderEvent, SessionEntry, Usage, UserMessage } from "@funky/core";
+import {
+  DEFAULT_NAMESPACE,
+  type ProviderEvent,
+  type SessionEntry,
+  type Usage,
+  type UserMessage,
+} from "@funky/core";
 import {
   type Claim,
   FencedError,
@@ -126,12 +132,13 @@ const inferenceConfig = {
 };
 
 async function newSession(): Promise<string> {
-  const agentConfigId = await store.createAgentConfig({
+  const agentConfigRef = await store.createAgentConfig({
+    namespace: DEFAULT_NAMESPACE,
     inference: inferenceConfig,
     systemPrompt: "be brief",
   });
   const envConfigId = await store.createEnvConfig({});
-  return store.createSession({ agentConfigId, envConfigId });
+  return store.createSession({ agentConfigId: agentConfigRef.id, envConfigId });
 }
 
 /** Claim the session's ready item — the tests' stand-in for the loop shell. */

--- a/packages/adapters/test/store-conformance.ts
+++ b/packages/adapters/test/store-conformance.ts
@@ -8,6 +8,7 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  type AgentConfigRef,
   type AssistantMessage,
   type CreateAgentConfigRequest,
   DEFAULT_NAMESPACE,
@@ -50,8 +51,11 @@ export function describeStoreConformance(
       ({ store, clock } = await makeHarness());
     });
 
-    async function newAgent(overrides: Partial<CreateAgentConfigRequest> = {}): Promise<string> {
+    async function newAgent(
+      overrides: Partial<CreateAgentConfigRequest> = {},
+    ): Promise<AgentConfigRef> {
       return store.createAgentConfig({
+        namespace: DEFAULT_NAMESPACE,
         inference: { provider: "fake", model: "m" },
         systemPrompt: "s",
         ...overrides,
@@ -59,11 +63,11 @@ export function describeStoreConformance(
     }
 
     async function newSession(): Promise<string> {
-      const agentConfigId = await newAgent({
+      const agentConfigRef = await newAgent({
         inference: { provider: "fake", model: "scripted" },
       });
       const envConfigId = await store.createEnvConfig({});
-      return store.createSession({ agentConfigId, envConfigId });
+      return store.createSession({ agentConfigId: agentConfigRef.id, envConfigId });
     }
 
     /** intake must have started a run; returns the claimed item + token. */
@@ -77,26 +81,28 @@ export function describeStoreConformance(
 
     describe("configs", () => {
       it("round-trips an agent config through create and get", async () => {
-        const id = await store.createAgentConfig({
+        const ref = await store.createAgentConfig({
+          namespace: DEFAULT_NAMESPACE,
           inference: { provider: "anthropic", model: "claude-sonnet-5", maxTokens: 8192 },
           systemPrompt: "You are helpful.",
           metadata: { team: "growth" },
         });
-        const config = await store.getAgentConfig(id);
+        const config = await store.getAgentConfig(ref);
         expect(config).toMatchObject({
-          id,
+          id: ref.id,
+          namespace: ref.namespace,
           inference: { provider: "anthropic", model: "claude-sonnet-5", maxTokens: 8192 },
           systemPrompt: "You are helpful.",
           metadata: { team: "growth" },
         });
         expect(config?.createdAt).toMatch(/T.*Z$/);
         expect(config?.version).toBe(1);
-        expect(await store.getAgentConfigVersion(id, 1)).toEqual(config);
+        expect(await store.getAgentConfig({ ...ref, version: 1 })).toEqual(config);
       });
 
       it("stores absence as absence — no metadata or sampling keys materialize", async () => {
-        const id = await newAgent();
-        const config = await store.getAgentConfig(id);
+        const ref = await newAgent();
+        const config = await store.getAgentConfig(ref);
         expect(config).toBeDefined();
         expect("metadata" in config!).toBe(false);
         expect("maxTokens" in config!.inference).toBe(false);
@@ -104,8 +110,8 @@ export function describeStoreConformance(
       });
 
       it("keeps JSON null metadata distinct from absent metadata", async () => {
-        const id = await newAgent({ metadata: null });
-        const config = await store.getAgentConfig(id);
+        const ref = await newAgent({ metadata: null });
+        const config = await store.getAgentConfig(ref);
         expect(config).toBeDefined();
         expect("metadata" in config!).toBe(true);
         expect(config!.metadata).toBeNull();
@@ -114,6 +120,7 @@ export function describeStoreConformance(
       it("rejects an invalid create request at the boundary", async () => {
         await expect(
           store.createAgentConfig({
+            namespace: DEFAULT_NAMESPACE,
             // biome-ignore lint/suspicious/noExplicitAny: deliberately malformed
             inference: "claude-sonnet-5" as any,
             systemPrompt: "s",
@@ -122,21 +129,21 @@ export function describeStoreConformance(
       });
 
       it("partially updates an agent config, preserving omitted fields and its identity", async () => {
-        const id = await newAgent({
+        const ref = await newAgent({
           inference: { provider: "anthropic", model: "old-model", maxTokens: 1024 },
           systemPrompt: "old prompt",
           metadata: { team: "growth" },
         });
-        const before = await store.getAgentConfig(id);
+        const before = await store.getAgentConfig(ref);
         clock.advance(1_000);
 
-        const updated = await store.updateAgentConfig(id, {
+        const updated = await store.updateAgentConfig(ref, {
           systemPrompt: "new prompt",
           version: 1,
         });
 
         expect(updated).toMatchObject({
-          id,
+          id: ref.id,
           inference: { provider: "anthropic", model: "old-model", maxTokens: 1024 },
           systemPrompt: "new prompt",
           metadata: { team: "growth" },
@@ -145,13 +152,13 @@ export function describeStoreConformance(
           createdAt: before?.createdAt,
         });
         expect(Date.parse(updated!.updatedAt)).toBeGreaterThan(Date.parse(before!.updatedAt));
-        expect(await store.getAgentConfig(id)).toEqual(updated);
+        expect(await store.getAgentConfig(ref)).toEqual(updated);
       });
 
       it("updates unconditionally when version is omitted", async () => {
-        const id = await newAgent();
-        const first = await store.updateAgentConfig(id, { systemPrompt: "one" });
-        const second = await store.updateAgentConfig(id, {
+        const ref = await newAgent();
+        const first = await store.updateAgentConfig(ref, { systemPrompt: "one" });
+        const second = await store.updateAgentConfig(ref, {
           inference: { provider: "fake", model: "m2" },
         });
         expect(first?.version).toBe(2);
@@ -159,15 +166,15 @@ export function describeStoreConformance(
       });
 
       it("serializes concurrent unconditional partial updates", async () => {
-        const id = await newAgent();
+        const ref = await newAgent();
 
         const updates = await Promise.all([
-          store.updateAgentConfig(id, { systemPrompt: "new prompt" }),
-          store.updateAgentConfig(id, { inference: { provider: "fake", model: "m2" } }),
+          store.updateAgentConfig(ref, { systemPrompt: "new prompt" }),
+          store.updateAgentConfig(ref, { inference: { provider: "fake", model: "m2" } }),
         ]);
 
         expect(updates.map((config) => config?.version).sort()).toEqual([2, 3]);
-        expect(await store.getAgentConfig(id)).toMatchObject({
+        expect(await store.getAgentConfig(ref)).toMatchObject({
           inference: { provider: "fake", model: "m2" },
           systemPrompt: "new prompt",
           version: 3,
@@ -175,80 +182,84 @@ export function describeStoreConformance(
       });
 
       it("treats an update with no mutable fields as a version-checked no-op", async () => {
-        const id = await newAgent();
-        const before = await store.getAgentConfig(id);
-        expect(await store.updateAgentConfig(id, { version: 1 })).toEqual(before);
-        expect(await store.updateAgentConfig(id, {})).toEqual(before);
+        const ref = await newAgent();
+        const before = await store.getAgentConfig(ref);
+        expect(await store.updateAgentConfig(ref, { version: 1 })).toEqual(before);
+        expect(await store.updateAgentConfig(ref, {})).toEqual(before);
       });
 
       it("rejects a stale expected version without changing the config", async () => {
-        const id = await newAgent();
-        await store.updateAgentConfig(id, { systemPrompt: "winner", version: 1 });
+        const ref = await newAgent();
+        await store.updateAgentConfig(ref, { systemPrompt: "winner", version: 1 });
 
         await expect(
-          store.updateAgentConfig(id, { systemPrompt: "stale", version: 1 }),
+          store.updateAgentConfig(ref, { systemPrompt: "stale", version: 1 }),
         ).rejects.toMatchObject({
           name: "VersionConflictError",
           expectedVersion: 1,
           actualVersion: 2,
         });
-        expect((await store.getAgentConfig(id))?.systemPrompt).toBe("winner");
+        expect((await store.getAgentConfig(ref))?.systemPrompt).toBe("winner");
       });
 
       it("keeps every prior agent version as an immutable snapshot", async () => {
-        const id = await newAgent({
+        const ref = await newAgent({
           inference: { provider: "fake", model: "m1" },
           systemPrompt: "v1",
           metadata: { revision: 1 },
         });
-        const v1 = await store.getAgentConfigVersion(id, 1);
-        await store.updateAgentConfig(id, {
+        const v1 = await store.getAgentConfig({ ...ref, version: 1 });
+        await store.updateAgentConfig(ref, {
           inference: { provider: "fake", model: "m2" },
           systemPrompt: "v2",
           version: 1,
         });
-        await store.updateAgentConfig(id, { metadata: { revision: 3 }, version: 2 });
+        await store.updateAgentConfig(ref, { metadata: { revision: 3 }, version: 2 });
 
-        expect(await store.getAgentConfigVersion(id, 1)).toEqual(v1);
-        expect(await store.getAgentConfigVersion(id, 2)).toMatchObject({
+        expect(await store.getAgentConfig({ ...ref, version: 1 })).toEqual(v1);
+        expect(await store.getAgentConfig({ ...ref, version: 2 })).toMatchObject({
           inference: { provider: "fake", model: "m2" },
           systemPrompt: "v2",
           metadata: { revision: 1 },
           version: 2,
         });
-        expect(await store.getAgentConfigVersion(id, 3)).toEqual(await store.getAgentConfig(id));
-        expect(await store.getAgentConfigVersion(id, 4)).toBeUndefined();
-        expect(await store.getAgentConfigVersion("nope", 1)).toBeUndefined();
+        expect(await store.getAgentConfig({ ...ref, version: 3 })).toEqual(
+          await store.getAgentConfig(ref),
+        );
+        expect(await store.getAgentConfig({ ...ref, version: 4 })).toBeUndefined();
+        expect(
+          await store.getAgentConfig({ namespace: DEFAULT_NAMESPACE, id: "nope", version: 1 }),
+        ).toBeUndefined();
       });
 
       it("lets exactly one concurrent update satisfy the same version", async () => {
-        const id = await newAgent();
+        const ref = await newAgent();
         const results = await Promise.allSettled([
-          store.updateAgentConfig(id, { systemPrompt: "a", version: 1 }),
-          store.updateAgentConfig(id, { systemPrompt: "b", version: 1 }),
+          store.updateAgentConfig(ref, { systemPrompt: "a", version: 1 }),
+          store.updateAgentConfig(ref, { systemPrompt: "b", version: 1 }),
         ]);
         expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
         const rejected = results.find((result) => result.status === "rejected");
         expect(rejected).toMatchObject({ reason: expect.any(VersionConflictError) });
-        expect((await store.getAgentConfig(id))?.version).toBe(2);
+        expect((await store.getAgentConfig(ref))?.version).toBe(2);
       });
 
       it("treats an unknown or foreign update target as absent", async () => {
-        const id = await newAgent({ namespace: "tenant-a" });
+        const ref = await newAgent({ namespace: "tenant-a" });
         await expect(
-          store.updateAgentConfig("nope", { systemPrompt: "x", namespace: "tenant-a" }),
+          store.updateAgentConfig({ namespace: "tenant-a", id: "nope" }, { systemPrompt: "x" }),
         ).resolves.toBeUndefined();
         await expect(
-          store.updateAgentConfig(id, { systemPrompt: "x", namespace: "tenant-b" }),
+          store.updateAgentConfig({ namespace: "tenant-b", id: ref.id }, { systemPrompt: "x" }),
         ).resolves.toBeUndefined();
-        expect((await store.getAgentConfig(id))?.systemPrompt).toBe("s");
+        expect((await store.getAgentConfig(ref))?.systemPrompt).toBe("s");
       });
 
       it("rejects an invalid update request at the boundary", async () => {
-        const id = await newAgent();
+        const ref = await newAgent();
         await expect(
           // biome-ignore lint/suspicious/noExplicitAny: deliberately malformed
-          store.updateAgentConfig(id, { version: 0 } as any),
+          store.updateAgentConfig(ref, { version: 0 } as any),
         ).rejects.toThrow();
       });
 
@@ -269,25 +280,35 @@ export function describeStoreConformance(
         expect(config?.packages).toEqual({ pip: ["pandas==2.2.0"] });
       });
 
-      it("returns undefined for an unknown config id", async () => {
-        expect(await store.getAgentConfig("nope")).toBeUndefined();
+      it("returns undefined for unknown or foreign agent config refs", async () => {
+        const ref = await newAgent({ namespace: "tenant-a" });
+        expect(
+          await store.getAgentConfig({ namespace: DEFAULT_NAMESPACE, id: "nope" }),
+        ).toBeUndefined();
+        expect(await store.getAgentConfig({ namespace: "tenant-b", id: ref.id })).toBeUndefined();
+        expect(
+          await store.getAgentConfig({ namespace: "tenant-b", id: ref.id, version: 1 }),
+        ).toBeUndefined();
+      });
+
+      it("returns undefined for an unknown env config id", async () => {
         expect(await store.getEnvConfig("nope")).toBeUndefined();
       });
     });
 
     describe("archiving agent configs", () => {
       it("marks the config archived without touching what it says", async () => {
-        const id = await newAgent({ systemPrompt: "v1" });
-        await store.updateAgentConfig(id, { systemPrompt: "v2" });
-        const before = await store.getAgentConfig(id);
+        const ref = await newAgent({ systemPrompt: "v1" });
+        await store.updateAgentConfig(ref, { systemPrompt: "v2" });
+        const before = await store.getAgentConfig(ref);
         clock.advance(1_000);
 
-        const archived = await store.archiveAgentConfig(id, {});
+        const archived = await store.archiveAgentConfig(ref);
 
         // Archiving retires the config; it does not edit it — same version,
         // same payload, same updatedAt, one new fact.
         expect(archived).toMatchObject({ ...before, archivedAt: expect.any(String) });
-        expect(await store.getAgentConfig(id)).toEqual(archived);
+        expect(await store.getAgentConfig(ref)).toEqual(archived);
       });
 
       it("stores absence as absence — an unarchived config has no archivedAt key", async () => {
@@ -297,18 +318,18 @@ export function describeStoreConformance(
       });
 
       it("is idempotent — the terminal state has no second transition", async () => {
-        const id = await newAgent();
-        const first = await store.archiveAgentConfig(id, {});
+        const ref = await newAgent();
+        const first = await store.archiveAgentConfig(ref);
         clock.advance(1_000);
-        const second = await store.archiveAgentConfig(id, {});
+        const second = await store.archiveAgentConfig(ref);
 
         expect(second).toEqual(first);
         expect(second?.archivedAt).toBe(first?.archivedAt);
       });
 
       it("makes the config read-only: every mutation throws ArchivedError", async () => {
-        const id = await newAgent({ systemPrompt: "final" });
-        await store.archiveAgentConfig(id, {});
+        const ref = await newAgent({ systemPrompt: "final" });
+        await store.archiveAgentConfig(ref);
 
         for (const req of [
           { systemPrompt: "after" },
@@ -316,45 +337,48 @@ export function describeStoreConformance(
           { metadata: { note: "after" } },
           { systemPrompt: "after", version: 1 },
         ]) {
-          await expect(store.updateAgentConfig(id, req)).rejects.toMatchObject({
+          await expect(store.updateAgentConfig(ref, req)).rejects.toMatchObject({
             name: "ArchivedError",
-            configId: id,
+            configId: ref.id,
           });
         }
-        expect(await store.getAgentConfig(id)).toMatchObject({ systemPrompt: "final", version: 1 });
+        expect(await store.getAgentConfig(ref)).toMatchObject({
+          systemPrompt: "final",
+          version: 1,
+        });
       });
 
       it("reports archived before stale — the version is not what the caller can fix", async () => {
-        const id = await newAgent();
-        await store.updateAgentConfig(id, { systemPrompt: "v2" });
-        await store.archiveAgentConfig(id, {});
+        const ref = await newAgent();
+        await store.updateAgentConfig(ref, { systemPrompt: "v2" });
+        await store.archiveAgentConfig(ref);
 
         await expect(
-          store.updateAgentConfig(id, { systemPrompt: "x", version: 1 }),
+          store.updateAgentConfig(ref, { systemPrompt: "x", version: 1 }),
         ).rejects.toBeInstanceOf(ArchivedError);
       });
 
       it("keeps an empty update a read — it mutates nothing, so nothing is forbidden", async () => {
-        const id = await newAgent();
-        const archived = await store.archiveAgentConfig(id, {});
-        expect(await store.updateAgentConfig(id, {})).toEqual(archived);
+        const ref = await newAgent();
+        const archived = await store.archiveAgentConfig(ref);
+        expect(await store.updateAgentConfig(ref, {})).toEqual(archived);
       });
 
       it("stays readable — get, every version, and the list still answer", async () => {
-        const id = await newAgent({ systemPrompt: "v1" });
-        await store.updateAgentConfig(id, { systemPrompt: "v2" });
-        const archived = await store.archiveAgentConfig(id, {});
+        const ref = await newAgent({ systemPrompt: "v1" });
+        await store.updateAgentConfig(ref, { systemPrompt: "v2" });
+        const archived = await store.archiveAgentConfig(ref);
 
-        expect(await store.getAgentConfig(id)).toEqual(archived);
+        expect(await store.getAgentConfig(ref)).toEqual(archived);
         expect(
           (await store.listAgentConfigs({ namespace: DEFAULT_NAMESPACE, limit: 10 })).map(
             (c) => c.id,
           ),
-        ).toContain(id);
+        ).toContain(ref.id);
         // The identity retired, not a snapshot: every version reads back,
         // and each one carries the mark.
         for (const version of [1, 2]) {
-          expect(await store.getAgentConfigVersion(id, version)).toMatchObject({
+          expect(await store.getAgentConfig({ ...ref, version })).toMatchObject({
             version,
             archivedAt: archived?.archivedAt,
           });
@@ -362,31 +386,42 @@ export function describeStoreConformance(
       });
 
       it("refuses a new session naming an archived config, at any version", async () => {
-        const agentConfigId = await newAgent();
-        await store.updateAgentConfig(agentConfigId, { systemPrompt: "v2" });
+        const agentConfigRef = await newAgent();
+        await store.updateAgentConfig(agentConfigRef, { systemPrompt: "v2" });
         const envConfigId = await store.createEnvConfig({});
-        await store.archiveAgentConfig(agentConfigId, {});
+        await store.archiveAgentConfig(agentConfigRef);
 
-        await expect(store.createSession({ agentConfigId, envConfigId })).rejects.toBeInstanceOf(
-          ArchivedError,
-        );
         await expect(
-          store.createSession({ agentConfigId, agentConfigVersion: 1, envConfigId }),
+          store.createSession({ agentConfigId: agentConfigRef.id, envConfigId }),
+        ).rejects.toBeInstanceOf(ArchivedError);
+        await expect(
+          store.createSession({
+            agentConfigId: agentConfigRef.id,
+            agentConfigVersion: 1,
+            envConfigId,
+          }),
         ).rejects.toBeInstanceOf(ArchivedError);
       });
 
       it("lets sessions that already reference it run on", async () => {
-        const agentConfigId = await newAgent({ systemPrompt: "pinned" });
+        const agentConfigRef = await newAgent({ systemPrompt: "pinned" });
         const envConfigId = await store.createEnvConfig({});
-        const sessionId = await store.createSession({ agentConfigId, envConfigId });
-        await store.archiveAgentConfig(agentConfigId, {});
+        const sessionId = await store.createSession({
+          agentConfigId: agentConfigRef.id,
+          envConfigId,
+        });
+        await store.archiveAgentConfig(agentConfigRef);
 
         // The session still resolves the behavior it pinned, and still runs:
         // archiving stops new references, not existing work.
         const session = await store.getSession(sessionId);
         expect(
-          (await store.getAgentConfigVersion(agentConfigId, session!.agentConfigVersion))
-            ?.systemPrompt,
+          (
+            await store.getAgentConfig({
+              ...agentConfigRef,
+              version: session!.agentConfigVersion,
+            })
+          )?.systemPrompt,
         ).toBe("pinned");
         const { itemId, token } = await startAndClaim(sessionId);
         await store.commitStep({
@@ -399,12 +434,12 @@ export function describeStoreConformance(
       });
 
       it("settles a create/archive race one of the two legal ways", async () => {
-        const agentConfigId = await newAgent();
+        const agentConfigRef = await newAgent();
         const envConfigId = await store.createEnvConfig({});
 
         const [created, archived] = await Promise.allSettled([
-          store.createSession({ agentConfigId, envConfigId }),
-          store.archiveAgentConfig(agentConfigId, {}),
+          store.createSession({ agentConfigId: agentConfigRef.id, envConfigId }),
+          store.archiveAgentConfig(agentConfigRef),
         ]);
 
         // The archive always lands: nothing outranks the terminal state.
@@ -418,18 +453,22 @@ export function describeStoreConformance(
           expect(created.reason).toBeInstanceOf(ArchivedError);
         }
         // Whoever won, the door is shut behind them.
-        await expect(store.createSession({ agentConfigId, envConfigId })).rejects.toBeInstanceOf(
-          ArchivedError,
-        );
+        await expect(
+          store.createSession({ agentConfigId: agentConfigRef.id, envConfigId }),
+        ).rejects.toBeInstanceOf(ArchivedError);
       });
 
       it("treats an unknown or foreign archive target as absent", async () => {
-        const id = await newAgent({ namespace: "tenant-a" });
-        expect(await store.archiveAgentConfig("nope", { namespace: "tenant-a" })).toBeUndefined();
-        expect(await store.archiveAgentConfig(id, { namespace: "tenant-b" })).toBeUndefined();
+        const ref = await newAgent({ namespace: "tenant-a" });
+        expect(
+          await store.archiveAgentConfig({ namespace: "tenant-a", id: "nope" }),
+        ).toBeUndefined();
+        expect(
+          await store.archiveAgentConfig({ namespace: "tenant-b", id: ref.id }),
+        ).toBeUndefined();
         // The foreign archive touched nothing.
-        expect(await store.getAgentConfig(id)).toMatchObject({ namespace: "tenant-a" });
-        expect("archivedAt" in (await store.getAgentConfig(id))!).toBe(false);
+        expect(await store.getAgentConfig(ref)).toMatchObject({ namespace: "tenant-a" });
+        expect("archivedAt" in (await store.getAgentConfig(ref))!).toBe(false);
       });
     });
 
@@ -438,12 +477,11 @@ export function describeStoreConformance(
       async function agentConfigs(n: number, namespace?: string): Promise<string[]> {
         const ids: string[] = [];
         for (let i = 0; i < n; i++) {
-          ids.push(
-            await newAgent({
-              inference: { provider: "fake", model: `m${i}` },
-              ...(namespace === undefined ? {} : { namespace }),
-            }),
-          );
+          const ref = await newAgent({
+            inference: { provider: "fake", model: `m${i}` },
+            ...(namespace === undefined ? {} : { namespace }),
+          });
+          ids.push(ref.id);
           clock.advance(1_000);
         }
         return ids;
@@ -468,7 +506,9 @@ export function describeStoreConformance(
         const configs = await store.listAgentConfigs({ namespace: DEFAULT_NAMESPACE, limit: 10 });
         expect(configs.map((c) => c.id)).toEqual([newest, middle, oldest]);
         // The same shape a get returns — one row mapping, not two.
-        expect(configs[0]).toEqual(await store.getAgentConfig(newest!));
+        expect(configs[0]).toEqual(
+          await store.getAgentConfig({ namespace: DEFAULT_NAMESPACE, id: newest! }),
+        );
       });
 
       it("bounds the page at limit and resumes strictly after the cursor", async () => {
@@ -552,30 +592,37 @@ export function describeStoreConformance(
       });
 
       it("pins the latest agent version when the session is created", async () => {
-        const agentConfigId = await newAgent({
+        const agentConfigRef = await newAgent({
           inference: { provider: "fake", model: "m1" },
           systemPrompt: "v1",
         });
         const envConfigId = await store.createEnvConfig({});
-        await store.updateAgentConfig(agentConfigId, { systemPrompt: "v2", version: 1 });
-        const sessionId = await store.createSession({ agentConfigId, envConfigId });
-        await store.updateAgentConfig(agentConfigId, { systemPrompt: "v3", version: 2 });
+        await store.updateAgentConfig(agentConfigRef, { systemPrompt: "v2", version: 1 });
+        const sessionId = await store.createSession({
+          agentConfigId: agentConfigRef.id,
+          envConfigId,
+        });
+        await store.updateAgentConfig(agentConfigRef, { systemPrompt: "v3", version: 2 });
 
         const session = await store.getSession(sessionId);
         expect(session?.agentConfigVersion).toBe(2);
         expect(
-          (await store.getAgentConfigVersion(agentConfigId, session!.agentConfigVersion))
-            ?.systemPrompt,
+          (
+            await store.getAgentConfig({
+              ...agentConfigRef,
+              version: session!.agentConfigVersion,
+            })
+          )?.systemPrompt,
         ).toBe("v2");
       });
 
       it("pins an explicitly requested agent version", async () => {
-        const agentConfigId = await newAgent({ systemPrompt: "v1" });
+        const agentConfigRef = await newAgent({ systemPrompt: "v1" });
         const envConfigId = await store.createEnvConfig({});
-        await store.updateAgentConfig(agentConfigId, { systemPrompt: "v2", version: 1 });
+        await store.updateAgentConfig(agentConfigRef, { systemPrompt: "v2", version: 1 });
 
         const sessionId = await store.createSession({
-          agentConfigId,
+          agentConfigId: agentConfigRef.id,
           agentConfigVersion: 1,
           envConfigId,
         });
@@ -613,37 +660,46 @@ export function describeStoreConformance(
       it("rejects a session naming an unknown agent config or version", async () => {
         const envConfigId = await store.createEnvConfig({});
         await expect(store.createSession({ agentConfigId: "nope", envConfigId })).rejects.toThrow();
-        const agentConfigId = await newAgent();
+        const agentConfigRef = await newAgent();
         await expect(
-          store.createSession({ agentConfigId, agentConfigVersion: 2, envConfigId }),
+          store.createSession({
+            agentConfigId: agentConfigRef.id,
+            agentConfigVersion: 2,
+            envConfigId,
+          }),
         ).rejects.toThrow();
       });
 
       it("rejects a session naming an unknown env config", async () => {
-        const agentConfigId = await newAgent();
-        await expect(store.createSession({ agentConfigId, envConfigId: "nope" })).rejects.toThrow();
+        const agentConfigRef = await newAgent();
+        await expect(
+          store.createSession({ agentConfigId: agentConfigRef.id, envConfigId: "nope" }),
+        ).rejects.toThrow();
       });
     });
 
     describe("namespace", () => {
-      it("materializes DEFAULT_NAMESPACE when absent, on all three ownable rows", async () => {
-        const agentConfigId = await newAgent();
+      it("uses an explicit agent namespace while env configs and sessions default", async () => {
+        const agentConfigRef = await newAgent();
         const envConfigId = await store.createEnvConfig({});
-        const sessionId = await store.createSession({ agentConfigId, envConfigId });
-        expect((await store.getAgentConfig(agentConfigId))?.namespace).toBe(DEFAULT_NAMESPACE);
+        const sessionId = await store.createSession({
+          agentConfigId: agentConfigRef.id,
+          envConfigId,
+        });
+        expect((await store.getAgentConfig(agentConfigRef))?.namespace).toBe(DEFAULT_NAMESPACE);
         expect((await store.getEnvConfig(envConfigId))?.namespace).toBe(DEFAULT_NAMESPACE);
         expect((await store.getSession(sessionId))?.namespace).toBe(DEFAULT_NAMESPACE);
       });
 
       it("stores an explicit namespace verbatim", async () => {
-        const agentConfigId = await newAgent({ namespace: "tenant-a" });
+        const agentConfigRef = await newAgent({ namespace: "tenant-a" });
         const envConfigId = await store.createEnvConfig({ namespace: "tenant-a" });
         const sessionId = await store.createSession({
-          agentConfigId,
+          agentConfigId: agentConfigRef.id,
           envConfigId,
           namespace: "tenant-a",
         });
-        expect((await store.getAgentConfig(agentConfigId))?.namespace).toBe("tenant-a");
+        expect((await store.getAgentConfig(agentConfigRef))?.namespace).toBe("tenant-a");
         expect((await store.getEnvConfig(envConfigId))?.namespace).toBe("tenant-a");
         expect((await store.getSession(sessionId))?.namespace).toBe("tenant-a");
       });
@@ -656,14 +712,26 @@ export function describeStoreConformance(
         // Cross-namespace refs reject exactly like dangling refs — the
         // error is the same "unknown", so existence never leaks.
         await expect(
-          store.createSession({ agentConfigId: agentA, envConfigId: envB, namespace: "tenant-a" }),
+          store.createSession({
+            agentConfigId: agentA.id,
+            envConfigId: envB,
+            namespace: "tenant-a",
+          }),
         ).rejects.toThrow("unknown env config");
         await expect(
-          store.createSession({ agentConfigId: agentA, envConfigId: envA, namespace: "tenant-b" }),
+          store.createSession({
+            agentConfigId: agentA.id,
+            envConfigId: envA,
+            namespace: "tenant-b",
+          }),
         ).rejects.toThrow("unknown agent config");
         // The matched trio is accepted.
         await expect(
-          store.createSession({ agentConfigId: agentA, envConfigId: envA, namespace: "tenant-a" }),
+          store.createSession({
+            agentConfigId: agentA.id,
+            envConfigId: envA,
+            namespace: "tenant-a",
+          }),
         ).resolves.toBeDefined();
       });
     });

--- a/packages/agent/src/driver/loop.ts
+++ b/packages/agent/src/driver/loop.ts
@@ -173,10 +173,11 @@ export async function runStep(
     if (item.type === "inference") {
       const session = await store.getSession(item.sessionId);
       if (!session) throw new Error(`driver: claimed item for unknown session ${item.sessionId}`);
-      const config = await store.getAgentConfigVersion(
-        session.agentConfigId,
-        session.agentConfigVersion,
-      );
+      const config = await store.getAgentConfig({
+        namespace: session.namespace,
+        id: session.agentConfigId,
+        version: session.agentConfigVersion,
+      });
       if (!config) throw new Error(`driver: session ${item.sessionId} has no agent config`);
       // Drain-at-inference-prep is what makes these inputs steering: they
       // shape this context, ride in this commit before the step's output,

--- a/packages/agent/src/ports/store.ts
+++ b/packages/agent/src/ports/store.ts
@@ -1,7 +1,8 @@
 import type {
   AgentConfig,
+  AgentConfigRef,
+  AgentConfigVersionRef,
   AgentMessage,
-  ArchiveAgentConfigRequest,
   ConfigId,
   CreateAgentConfigRequest,
   CreateEnvConfigRequest,
@@ -10,6 +11,7 @@ import type {
   InputId,
   IntakeResult,
   ItemId,
+  ListAgentConfigsRequest,
   PendingInput,
   Session,
   SessionEntry,
@@ -49,10 +51,10 @@ import type { RunEndStatus } from "../engine/next-action";
 export interface Store {
   // --- configs ---
 
-  createAgentConfig(req: CreateAgentConfigRequest): Promise<ConfigId>;
-  getAgentConfig(id: ConfigId): Promise<AgentConfig | undefined>;
-  /** An immutable historical snapshot; undefined for an unknown id/version. */
-  getAgentConfigVersion(id: ConfigId, version: number): Promise<AgentConfig | undefined>;
+  /** Create the first version of an agent config. Namespace must be specified. */
+  createAgentConfig(req: CreateAgentConfigRequest): Promise<AgentConfigRef>;
+  /** Returns the latest config, or the exact version when the ref specifies one. */
+  getAgentConfig(ref: AgentConfigRef | AgentConfigVersionRef): Promise<AgentConfig | undefined>;
   /**
    * Partially update one namespace's agent config. Omitted fields are
    * preserved. A supplied version is an optimistic-concurrency precondition;
@@ -64,7 +66,10 @@ export interface Store {
    * that verdict precedes a stale version's — archived is terminal, so
    * retrying with a fresher version would only fail again.
    */
-  updateAgentConfig(id: ConfigId, req: UpdateAgentConfigRequest): Promise<AgentConfig | undefined>;
+  updateAgentConfig(
+    ref: AgentConfigRef,
+    req: UpdateAgentConfigRequest,
+  ): Promise<AgentConfig | undefined>;
   /**
    * Archive one namespace's agent config — the terminal transition, and
    * the only state change that is not an edit. The row stays readable and
@@ -73,14 +78,12 @@ export interface Store {
    * throws ArchivedError) and future references (createSession rejects
    * it). There is no unarchive, which is what makes this idempotent: a
    * second archive is a no-op returning the first one's archivedAt.
-   * Unknown and foreign ids are undefined, like every other scoped read.
    */
-  archiveAgentConfig(
-    id: ConfigId,
-    req: ArchiveAgentConfigRequest,
-  ): Promise<AgentConfig | undefined>;
-  /** One namespace's agent configs, newest first — see ListConfigsRequest. */
-  listAgentConfigs(req: ListConfigsRequest): Promise<AgentConfig[]>;
+  archiveAgentConfig(ref: AgentConfigRef): Promise<AgentConfig | undefined>;
+  /** One namespace's agent configs, newest first — see ListAgentConfigsRequest. */
+  listAgentConfigs(req: ListAgentConfigsRequest): Promise<AgentConfig[]>;
+
+  /** Create the environment config. Namespace must be specified */
   createEnvConfig(req: CreateEnvConfigRequest): Promise<ConfigId>;
   getEnvConfig(id: ConfigId): Promise<EnvConfig | undefined>;
   /** One namespace's env configs, newest first — see ListConfigsRequest. */
@@ -173,8 +176,8 @@ export interface Store {
 }
 
 /**
- * The config list reads' argument, shared by both because the two config
- * tables page identically.
+ * The env config list read's argument. Agent configs use the equivalent
+ * core ListAgentConfigsRequest vocabulary.
  *
  * `namespace` is required, and it is the one read whose tenancy the
  * store enforces rather than the api: a list has no id to fetch and

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -40,15 +40,15 @@ export type InputId = string;
 // --- namespace ---
 
 // The tenancy boundary, driven by the managed service's trusted gateway
-// (an OSS deployment runs single-tenant and never sets it). Ownership is
-// exactly-one and lives as a fact on the three ownable row types —
-// decided at create, immutable, resolved to DEFAULT_NAMESPACE when
-// absent, like every other materialized default. Work items, entries,
-// and pending inputs derive theirs through sessionId; the worker and
-// the driver never read it. Enforcement is split: the store guarantees
-// a session and its configs share one namespace (a foreign config is
-// "unknown" — indistinguishable from nonexistent, so nothing leaks);
-// scoping reads to a caller's namespace is the api's fetch-then-check.
+// (an OSS deployment runs single-tenant). Ownership is exactly-one and
+// lives as a fact on the three ownable row types — decided at create and
+// immutable. Agent config creation requires that ownership explicitly;
+// env configs and sessions still resolve absence to DEFAULT_NAMESPACE.
+// Work items, entries, and pending inputs derive theirs through sessionId;
+// the worker and the driver never read it. The store guarantees a session
+// and its configs share one namespace, and scopes config references by the
+// namespace they carry; a foreign config is "unknown" — indistinguishable
+// from nonexistent, so nothing leaks.
 export const DEFAULT_NAMESPACE = "default";
 
 // --- configs ---
@@ -64,36 +64,46 @@ export const DEFAULT_NAMESPACE = "default";
 // further update and no new session may reference it. There is no
 // unarchive, so nothing here spells one.
 
+/** A namespace-scoped reference to an agent config. */
+export const AgentConfigRef = z.object({
+  namespace: z.string().min(1),
+  id: z.string().min(1),
+});
+export type AgentConfigRef = z.infer<typeof AgentConfigRef>;
+
+/** A namespace-scoped reference to one immutable agent config version. */
+export const AgentConfigVersionRef = AgentConfigRef.extend({
+  version: z.number().int().min(1),
+});
+export type AgentConfigVersionRef = z.infer<typeof AgentConfigVersionRef>;
+
+/** Lists one namespace's agent configs with keyset pagination. */
+export const ListAgentConfigsRequest = z.object({
+  namespace: z.string().min(1),
+  limit: z.number().int().min(1),
+  after: z.string().min(1).optional(),
+});
+export type ListAgentConfigsRequest = z.infer<typeof ListAgentConfigsRequest>;
+
 export const CreateAgentConfigRequest = z.object({
+  namespace: z.string().min(1),
   inference: InferenceConfig,
   systemPrompt: z.string(),
-  namespace: z.string().min(1).optional(),
   metadata: JsonValue.optional(),
 });
 export type CreateAgentConfigRequest = z.infer<typeof CreateAgentConfigRequest>;
 
-// UpdateAgent-style partial replacement: omission preserves a field. `version`
-// is a precondition, not stored payload — omit it for last-write-wins.
 export const UpdateAgentConfigRequest = z.object({
   inference: InferenceConfig.optional(),
   systemPrompt: z.string().optional(),
-  namespace: z.string().min(1).optional(),
   metadata: JsonValue.optional(),
+  // Optional optimistic-concurrency precondition: version 3 updates only if 3 is current.
   version: z.number().int().min(1).optional(),
 });
 export type UpdateAgentConfigRequest = z.infer<typeof UpdateAgentConfigRequest>;
 
-// ArchiveAgent carries no payload — archiving is a transition, not an
-// edit, and the state it moves to is the only one there is. The scope
-// is all the request can say.
-export const ArchiveAgentConfigRequest = z.object({
-  namespace: z.string().min(1).optional(),
-});
-export type ArchiveAgentConfigRequest = z.infer<typeof ArchiveAgentConfigRequest>;
-
 export const AgentConfig = CreateAgentConfigRequest.extend({
   id: z.string(),
-  namespace: z.string().min(1), // materialized: absence resolved to DEFAULT_NAMESPACE
   version: z.number().int().min(1),
   createdAt: z.iso.datetime(),
   updatedAt: z.iso.datetime(),

--- a/packages/core/test/store.test.ts
+++ b/packages/core/test/store.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
   AgentConfig,
-  ArchiveAgentConfigRequest,
+  AgentConfigRef,
+  AgentConfigVersionRef,
   CreateAgentConfigRequest,
   CreateEnvConfigRequest,
   CreateSessionRequest,
   EnvConfig,
   IntakeResult,
+  ListAgentConfigsRequest,
   PendingInput,
   Session,
   UpdateAgentConfigRequest,
@@ -38,10 +40,41 @@ describe("configs", () => {
 
   it("accepts a create request without metadata or sampling params — absence needs no placeholder", () => {
     const result = CreateAgentConfigRequest.safeParse({
+      namespace: "default",
       inference: { provider: "fake", model: "scripted" },
       systemPrompt: "s",
     });
     expect(result.success).toBe(true);
+  });
+
+  it("requires an explicit namespace when creating an agent config", () => {
+    expect(
+      CreateAgentConfigRequest.safeParse({
+        inference: { provider: "fake", model: "scripted" },
+        systemPrompt: "s",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("validates current and versioned agent config references", () => {
+    expect(AgentConfigRef.safeParse({ namespace: "tenant-a", id: "ac1" }).success).toBe(true);
+    expect(AgentConfigRef.safeParse({ namespace: "tenant-a", id: "" }).success).toBe(false);
+    expect(
+      AgentConfigVersionRef.safeParse({ namespace: "tenant-a", id: "ac1", version: 2 }).success,
+    ).toBe(true);
+    expect(
+      AgentConfigVersionRef.safeParse({ namespace: "tenant-a", id: "ac1", version: 0 }).success,
+    ).toBe(false);
+  });
+
+  it("validates namespaced agent config pagination", () => {
+    expect(
+      ListAgentConfigsRequest.safeParse({ namespace: "tenant-a", limit: 10, after: "ac1" }).success,
+    ).toBe(true);
+    expect(ListAgentConfigsRequest.safeParse({ namespace: "", limit: 10 }).success).toBe(false);
+    expect(ListAgentConfigsRequest.safeParse({ namespace: "tenant-a", limit: 0 }).success).toBe(
+      false,
+    );
   });
 
   it("round-trips a stored agent config with no sampling overrides — absence is the stored form", () => {
@@ -69,6 +102,7 @@ describe("configs", () => {
 
   it("rejects a bare-string inference config — it must say which provider serves the model", () => {
     const result = CreateAgentConfigRequest.safeParse({
+      namespace: "default",
       inference: "claude-sonnet-5",
       systemPrompt: "s",
     });
@@ -113,12 +147,6 @@ describe("configs", () => {
     };
     expect(AgentConfig.safeParse({ ...config, archivedAt: null }).success).toBe(false);
     expect(AgentConfig.safeParse({ ...config, archivedAt: true }).success).toBe(false);
-  });
-
-  it("accepts an archive request carrying nothing but its scope", () => {
-    expect(ArchiveAgentConfigRequest.safeParse({}).success).toBe(true);
-    expect(ArchiveAgentConfigRequest.safeParse({ namespace: "tenant-a" }).success).toBe(true);
-    expect(ArchiveAgentConfigRequest.safeParse({ namespace: "" }).success).toBe(false);
   });
 });
 


### PR DESCRIPTION
Adds AgentConfigRef, AgentConfigVersionRef, and ListAgentConfigsRequest, requires an explicit namespace at creation, and folds latest/exact-version reads into getAgentConfig. Migrates the Store port, PostgreSQL adapter, driver, API callers, and tests to namespace-scoped references and pagination while removing the obsolete archive request type. The core API accepts the namespace supplied by its caller so a managed layer can verify identity and inject it. Verified with pnpm test, pnpm typecheck, and pnpm format:check.