### PR TITLE
Add namespace-scoped env config references

### DIFF
--- a/apps/api/src/routes/env-configs.ts
+++ b/apps/api/src/routes/env-configs.ts
@@ -8,13 +8,6 @@
 // verb that writes — the other two routes read. Sessions reference
 // config ids; a row that could change under a running session would
 // reinterpret its history.
-//
-// Namespace discipline: the wire schema OMITS namespace — a client can
-// never choose one. The auth middleware decided it (c.get("namespace"));
-// create stamps it, and get answers 404 for a foreign row, so a foreign
-// id is indistinguishable from a nonexistent one. The list is the one
-// read the api can't scope that way — there is no id to check
-// afterwards — so it passes the namespace INTO the store instead.
 import { Hono } from "hono";
 import { CreateEnvConfigRequest } from "@funky/core";
 import type { Store } from "@funky/agent";
@@ -26,21 +19,16 @@ export type EnvConfigStore = Pick<Store, "createEnvConfig" | "getEnvConfig" | "l
 
 type Env = { Variables: { requestId: string; namespace: string } };
 
-const WireCreateEnvConfig = CreateEnvConfigRequest.omit({ namespace: true });
-
 export function envConfigRoutes(store: EnvConfigStore) {
   const r = new Hono<Env>();
 
   // create → 201 with the materialized row: defaults are resolved at
   // create (network → unrestricted, packages → {}), so the caller sees
   // the decision that was stored, not the request they sent.
-  r.post("/", validate("json", WireCreateEnvConfig), async (c) => {
-    const id = await store.createEnvConfig({
-      ...c.req.valid("json"),
-      namespace: c.get("namespace"),
-    });
-    const config = await store.getEnvConfig(id);
-    if (!config) throw new Error(`env config ${id} missing after create`);
+  r.post("/", validate("json", CreateEnvConfigRequest), async (c) => {
+    const ref = await store.createEnvConfig(c.req.valid("json"));
+    const config = await store.getEnvConfig(ref);
+    if (!config) throw new Error(`env config ${ref.id} missing after create`);
     return c.json(config, 201);
   });
 
@@ -68,8 +56,8 @@ export function envConfigRoutes(store: EnvConfigStore) {
 
   r.get("/:id", async (c) => {
     const id = c.req.param("id");
-    const config = await store.getEnvConfig(id);
-    if (!config || config.namespace !== c.get("namespace")) {
+    const config = await store.getEnvConfig({ namespace: c.get("namespace"), id });
+    if (!config) {
       return errorResponse(c, 404, "not_found_error", `no env config ${id}`);
     }
     return c.json(config);

--- a/apps/api/test/env-configs.test.ts
+++ b/apps/api/test/env-configs.test.ts
@@ -28,8 +28,8 @@ afterAll(async () => {
 });
 
 describe("POST /v1/env-configs", () => {
-  it("materializes an empty request: every default becomes a stored decision", async () => {
-    const res = await post(app, "/v1/env-configs", {});
+  it("materializes a request without recipe overrides", async () => {
+    const res = await post(app, "/v1/env-configs", { namespace: "default" });
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.network).toEqual({ type: "unrestricted" });
@@ -41,6 +41,7 @@ describe("POST /v1/env-configs", () => {
 
   it("stores an explicit recipe verbatim and GET returns the same row", async () => {
     const recipe = {
+      namespace: "default",
       network: { type: "allowlist", domains: ["registry.npmjs.org"] },
       packages: { npm: ["express@4.18.0"] },
       metadata: { label: "npm-only" },
@@ -56,11 +57,19 @@ describe("POST /v1/env-configs", () => {
   });
 
   it("rejects a malformed network policy, 400", async () => {
-    const res = await post(app, "/v1/env-configs", { network: { type: "limited" } });
+    const res = await post(app, "/v1/env-configs", {
+      namespace: "default",
+      network: { type: "limited" },
+    });
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.type).toBe("error");
     expect(body.error.type).toBe("invalid_request_error");
+  });
+
+  it("requires a namespace", async () => {
+    const res = await post(app, "/v1/env-configs", {});
+    expect(res.status).toBe(400);
   });
 });
 
@@ -72,7 +81,12 @@ describe("GET /v1/env-configs", () => {
 
   it("lists env configs only — the two config kinds are separate collections", async () => {
     const created = await (
-      await post(scoped, "/v1/env-configs", { packages: { npm: ["zod@4"] } }, asTenant("list-env"))
+      await post(
+        scoped,
+        "/v1/env-configs",
+        { namespace: "list-env", packages: { npm: ["zod@4"] } },
+        asTenant("list-env"),
+      )
     ).json();
     await post(
       scoped,
@@ -91,7 +105,7 @@ describe("GET /v1/env-configs", () => {
   });
 
   it("is wired on the static namespace source too", async () => {
-    const created = await (await post(app, "/v1/env-configs", {})).json();
+    const created = await (await post(app, "/v1/env-configs", { namespace: "default" })).json();
     const body = await (await get(app, "/v1/env-configs?limit=100")).json();
     expect(body.data).toContainEqual(created);
     // The default page is bounded whether or not the caller asks.
@@ -100,7 +114,9 @@ describe("GET /v1/env-configs", () => {
   });
 
   it("400s a cursor from another namespace", async () => {
-    const foreign = await (await post(scoped, "/v1/env-configs", {}, asTenant("env-cur-b"))).json();
+    const foreign = await (
+      await post(scoped, "/v1/env-configs", { namespace: "env-cur-b" }, asTenant("env-cur-b"))
+    ).json();
     const res = await get(scoped, `/v1/env-configs?after=${foreign.id}`, asTenant("env-cur-a"));
     expect(res.status).toBe(400);
     expect((await res.json()).error.type).toBe("invalid_request_error");
@@ -119,19 +135,21 @@ describe("GET /v1/env-configs/:id", () => {
 describe("namespace scoping (namespaceSource=header — the managed-gateway shape)", () => {
   const asTenant = (tenant: string) => ({ "X-Funky-Namespace": tenant });
 
-  it("stamps the middleware's namespace and ignores any client-supplied one", async () => {
+  it("uses the namespace supplied in the request", async () => {
     const res = await post(
       scoped,
       "/v1/env-configs",
-      { namespace: "tenant-b" }, // stripped by the wire schema; the header decides
+      { namespace: "tenant-b" },
       asTenant("tenant-a"),
     );
     expect(res.status).toBe(201);
-    expect((await res.json()).namespace).toBe("tenant-a");
+    expect((await res.json()).namespace).toBe("tenant-b");
   });
 
   it("a foreign row 404s exactly like a nonexistent one", async () => {
-    const created = await (await post(scoped, "/v1/env-configs", {}, asTenant("tenant-a"))).json();
+    const created = await (
+      await post(scoped, "/v1/env-configs", { namespace: "tenant-a" }, asTenant("tenant-a"))
+    ).json();
 
     const foreign = await get(scoped, `/v1/env-configs/${created.id}`, asTenant("tenant-b"));
     expect(foreign.status).toBe(404);
@@ -143,7 +161,12 @@ describe("namespace scoping (namespaceSource=header — the managed-gateway shap
   });
 
   it("rejects a malformed namespace header", async () => {
-    const res = await post(scoped, "/v1/env-configs", {}, asTenant("no spaces allowed"));
+    const res = await post(
+      scoped,
+      "/v1/env-configs",
+      { namespace: "tenant-a" },
+      asTenant("no spaces allowed"),
+    );
     expect(res.status).toBe(400);
   });
 });

--- a/apps/api/test/sessions.test.ts
+++ b/apps/api/test/sessions.test.ts
@@ -54,7 +54,7 @@ async function seedConfigs(
       headers,
     )
   ).json();
-  const env = await (await post(on, "/v1/env-configs", {}, headers)).json();
+  const env = await (await post(on, "/v1/env-configs", { namespace }, headers)).json();
   return { agentConfigId: agent.id, envConfigId: env.id };
 }
 

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -43,7 +43,10 @@ const deps: DriverDeps = {
   bindTools: async (sessionId) => {
     const session = await store.getSession(sessionId);
     if (!session) throw new Error(`worker: unknown session ${sessionId}`);
-    const env = await store.getEnvConfig(session.envConfigId);
+    const env = await store.getEnvConfig({
+      namespace: session.namespace,
+      id: session.envConfigId,
+    });
     if (!env) throw new Error(`worker: session ${sessionId} has no env config`);
     const sandbox = await ensureSandbox(store, sandboxes, sessionId, {
       timeoutMs: cfg.sandboxTimeoutMs,

--- a/apps/worker/test/e2e.test.ts
+++ b/apps/worker/test/e2e.test.ts
@@ -116,10 +116,10 @@ if (!url || !anthropicKey || !e2bKey) {
         "tools, then reply with a one-sentence summary. If a tool result says " +
         "the execution was interrupted, issue that call again.",
     });
-    const envConfigId = await store.createEnvConfig({});
+    const envConfigRef = await store.createEnvConfig({ namespace: DEFAULT_NAMESPACE });
     const sessionId = await store.createSession({
       agentConfigId: agentConfigRef.id,
-      envConfigId,
+      envConfigId: envConfigRef.id,
     });
     sessions.push(sessionId);
     const result = await store.intake(sessionId, {
@@ -371,7 +371,9 @@ if (!url || !anthropicKey || !e2bKey) {
               "tools, then reply with a one-sentence summary. If a tool result says " +
               "the execution was interrupted, issue that call again.",
           });
-          const env = await apiJson("POST", "/v1/env-configs", {});
+          const env = await apiJson("POST", "/v1/env-configs", {
+            namespace: DEFAULT_NAMESPACE,
+          });
           const session = await apiJson("POST", "/v1/sessions", {
             agentConfigId: agent.id,
             envConfigId: env.id,

--- a/packages/adapters/src/store/pg.ts
+++ b/packages/adapters/src/store/pg.ts
@@ -40,9 +40,11 @@ import {
   CreateSessionRequest,
   DEFAULT_NAMESPACE,
   EnvConfig,
+  EnvConfigRef,
   IntakeResult,
   type JsonValue,
   ListAgentConfigsRequest,
+  ListEnvConfigsRequest,
   PendingInput,
   Session,
   SessionEntry,
@@ -54,7 +56,6 @@ import {
   ArchivedError,
   type CommitStepRequest,
   FencedError,
-  type ListConfigsRequest,
   type Store,
   VersionConflictError,
 } from "@funky/agent";
@@ -372,29 +373,34 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       await db.insert(envConfigs).values({
         id,
         // Materialized at create — resolved decisions, not restatable defaults.
+        namespace: parsed.namespace,
         network: parsed.network ?? { type: "unrestricted" },
         packages: parsed.packages ?? {},
-        namespace: parsed.namespace ?? DEFAULT_NAMESPACE,
         metadata: wrap(parsed.metadata),
         createdAt: now(),
       });
-      return id;
+      return EnvConfigRef.parse({ namespace: parsed.namespace, id });
     },
 
-    async getEnvConfig(id) {
-      const [row] = await db.select().from(envConfigs).where(eq(envConfigs.id, id));
+    async getEnvConfig(ref) {
+      const { id, namespace } = EnvConfigRef.parse(ref);
+      const [row] = await db
+        .select()
+        .from(envConfigs)
+        .where(and(eq(envConfigs.id, id), eq(envConfigs.namespace, namespace)));
       return row === undefined ? undefined : toEnvConfig(row);
     },
 
-    async listEnvConfigs(req: ListConfigsRequest) {
-      const scope = eq(envConfigs.namespace, req.namespace);
-      const page = await olderThanCursor(envConfigs, scope, req.after);
+    async listEnvConfigs(req) {
+      const parsed = ListEnvConfigsRequest.parse(req);
+      const scope = eq(envConfigs.namespace, parsed.namespace);
+      const page = await olderThanCursor(envConfigs, scope, parsed.after);
       const rows = await db
         .select()
         .from(envConfigs)
         .where(and(scope, page))
         .orderBy(desc(envConfigs.createdAt), desc(envConfigs.id))
-        .limit(req.limit);
+        .limit(parsed.limit);
       return rows.map(toEnvConfig);
     },
 

--- a/packages/adapters/test/crash-resume.test.ts
+++ b/packages/adapters/test/crash-resume.test.ts
@@ -286,8 +286,11 @@ beforeAll(async () => {
       inference: inferenceConfig,
       systemPrompt: "be brief",
     });
-    const envConfigId = await store.createEnvConfig({});
-    sessionId = await store.createSession({ agentConfigId: agentConfigRef.id, envConfigId });
+    const envConfigRef = await store.createEnvConfig({ namespace: DEFAULT_NAMESPACE });
+    sessionId = await store.createSession({
+      agentConfigId: agentConfigRef.id,
+      envConfigId: envConfigRef.id,
+    });
     const result = await store.intake(sessionId, user(PROMPTS[0]));
     if (result.kind !== "started") throw new Error("seed intake did not start a run");
     await client.close();

--- a/packages/adapters/test/driver.test.ts
+++ b/packages/adapters/test/driver.test.ts
@@ -137,8 +137,8 @@ async function newSession(): Promise<string> {
     inference: inferenceConfig,
     systemPrompt: "be brief",
   });
-  const envConfigId = await store.createEnvConfig({});
-  return store.createSession({ agentConfigId: agentConfigRef.id, envConfigId });
+  const envConfigRef = await store.createEnvConfig({ namespace: DEFAULT_NAMESPACE });
+  return store.createSession({ agentConfigId: agentConfigRef.id, envConfigId: envConfigRef.id });
 }
 
 /** Claim the session's ready item — the tests' stand-in for the loop shell. */

--- a/packages/adapters/test/store-conformance.ts
+++ b/packages/adapters/test/store-conformance.ts
@@ -11,7 +11,9 @@ import {
   type AgentConfigRef,
   type AssistantMessage,
   type CreateAgentConfigRequest,
+  type CreateEnvConfigRequest,
   DEFAULT_NAMESPACE,
+  type EnvConfigRef,
   type UserMessage,
 } from "@funky/core";
 import {
@@ -62,12 +64,22 @@ export function describeStoreConformance(
       });
     }
 
+    async function newEnv(overrides: Partial<CreateEnvConfigRequest> = {}): Promise<EnvConfigRef> {
+      return store.createEnvConfig({
+        namespace: DEFAULT_NAMESPACE,
+        ...overrides,
+      });
+    }
+
     async function newSession(): Promise<string> {
       const agentConfigRef = await newAgent({
         inference: { provider: "fake", model: "scripted" },
       });
-      const envConfigId = await store.createEnvConfig({});
-      return store.createSession({ agentConfigId: agentConfigRef.id, envConfigId });
+      const envConfigRef = await newEnv();
+      return store.createSession({
+        agentConfigId: agentConfigRef.id,
+        envConfigId: envConfigRef.id,
+      });
     }
 
     /** intake must have started a run; returns the claimed item + token. */
@@ -264,18 +276,18 @@ export function describeStoreConformance(
       });
 
       it("materializes network and packages at env config create", async () => {
-        const id = await store.createEnvConfig({});
-        const config = await store.getEnvConfig(id);
+        const ref = await newEnv();
+        const config = await store.getEnvConfig(ref);
         expect(config?.network).toEqual({ type: "unrestricted" });
         expect(config?.packages).toEqual({});
       });
 
       it("preserves a provided recipe verbatim", async () => {
-        const id = await store.createEnvConfig({
+        const ref = await newEnv({
           network: { type: "allowlist", domains: ["pypi.org"] },
           packages: { pip: ["pandas==2.2.0"] },
         });
-        const config = await store.getEnvConfig(id);
+        const config = await store.getEnvConfig(ref);
         expect(config?.network).toEqual({ type: "allowlist", domains: ["pypi.org"] });
         expect(config?.packages).toEqual({ pip: ["pandas==2.2.0"] });
       });
@@ -291,8 +303,12 @@ export function describeStoreConformance(
         ).toBeUndefined();
       });
 
-      it("returns undefined for an unknown env config id", async () => {
-        expect(await store.getEnvConfig("nope")).toBeUndefined();
+      it("returns undefined for unknown or foreign env config refs", async () => {
+        const ref = await newEnv({ namespace: "tenant-a" });
+        expect(
+          await store.getEnvConfig({ namespace: DEFAULT_NAMESPACE, id: "nope" }),
+        ).toBeUndefined();
+        expect(await store.getEnvConfig({ namespace: "tenant-b", id: ref.id })).toBeUndefined();
       });
     });
 
@@ -388,27 +404,27 @@ export function describeStoreConformance(
       it("refuses a new session naming an archived config, at any version", async () => {
         const agentConfigRef = await newAgent();
         await store.updateAgentConfig(agentConfigRef, { systemPrompt: "v2" });
-        const envConfigId = await store.createEnvConfig({});
+        const envConfigRef = await newEnv();
         await store.archiveAgentConfig(agentConfigRef);
 
         await expect(
-          store.createSession({ agentConfigId: agentConfigRef.id, envConfigId }),
+          store.createSession({ agentConfigId: agentConfigRef.id, envConfigId: envConfigRef.id }),
         ).rejects.toBeInstanceOf(ArchivedError);
         await expect(
           store.createSession({
             agentConfigId: agentConfigRef.id,
             agentConfigVersion: 1,
-            envConfigId,
+            envConfigId: envConfigRef.id,
           }),
         ).rejects.toBeInstanceOf(ArchivedError);
       });
 
       it("lets sessions that already reference it run on", async () => {
         const agentConfigRef = await newAgent({ systemPrompt: "pinned" });
-        const envConfigId = await store.createEnvConfig({});
+        const envConfigRef = await newEnv();
         const sessionId = await store.createSession({
           agentConfigId: agentConfigRef.id,
-          envConfigId,
+          envConfigId: envConfigRef.id,
         });
         await store.archiveAgentConfig(agentConfigRef);
 
@@ -435,10 +451,10 @@ export function describeStoreConformance(
 
       it("settles a create/archive race one of the two legal ways", async () => {
         const agentConfigRef = await newAgent();
-        const envConfigId = await store.createEnvConfig({});
+        const envConfigRef = await newEnv();
 
         const [created, archived] = await Promise.allSettled([
-          store.createSession({ agentConfigId: agentConfigRef.id, envConfigId }),
+          store.createSession({ agentConfigId: agentConfigRef.id, envConfigId: envConfigRef.id }),
           store.archiveAgentConfig(agentConfigRef),
         ]);
 
@@ -454,7 +470,7 @@ export function describeStoreConformance(
         }
         // Whoever won, the door is shut behind them.
         await expect(
-          store.createSession({ agentConfigId: agentConfigRef.id, envConfigId }),
+          store.createSession({ agentConfigId: agentConfigRef.id, envConfigId: envConfigRef.id }),
         ).rejects.toBeInstanceOf(ArchivedError);
       });
 
@@ -531,7 +547,7 @@ export function describeStoreConformance(
         // (createdAt, id) key's total order — walking in pages must equal
         // the whole list exactly.
         for (let i = 0; i < 5; i++) {
-          await store.createEnvConfig({});
+          await newEnv();
         }
         const whole = await store.listEnvConfigs({ namespace: DEFAULT_NAMESPACE, limit: 10 });
         expect(whole).toHaveLength(5);
@@ -571,10 +587,10 @@ export function describeStoreConformance(
 
       it("lists the two config kinds independently", async () => {
         await agentConfigs(2);
-        const envId = await store.createEnvConfig({});
+        const envRef = await newEnv();
         const envs = await store.listEnvConfigs({ namespace: DEFAULT_NAMESPACE, limit: 10 });
-        expect(envs.map((c) => c.id)).toEqual([envId]);
-        expect(envs[0]).toEqual(await store.getEnvConfig(envId));
+        expect(envs.map((c) => c.id)).toEqual([envRef.id]);
+        expect(envs[0]).toEqual(await store.getEnvConfig(envRef));
         expect(
           await store.listAgentConfigs({ namespace: DEFAULT_NAMESPACE, limit: 10 }),
         ).toHaveLength(2);
@@ -596,11 +612,11 @@ export function describeStoreConformance(
           inference: { provider: "fake", model: "m1" },
           systemPrompt: "v1",
         });
-        const envConfigId = await store.createEnvConfig({});
+        const envConfigRef = await newEnv();
         await store.updateAgentConfig(agentConfigRef, { systemPrompt: "v2", version: 1 });
         const sessionId = await store.createSession({
           agentConfigId: agentConfigRef.id,
-          envConfigId,
+          envConfigId: envConfigRef.id,
         });
         await store.updateAgentConfig(agentConfigRef, { systemPrompt: "v3", version: 2 });
 
@@ -618,13 +634,13 @@ export function describeStoreConformance(
 
       it("pins an explicitly requested agent version", async () => {
         const agentConfigRef = await newAgent({ systemPrompt: "v1" });
-        const envConfigId = await store.createEnvConfig({});
+        const envConfigRef = await newEnv();
         await store.updateAgentConfig(agentConfigRef, { systemPrompt: "v2", version: 1 });
 
         const sessionId = await store.createSession({
           agentConfigId: agentConfigRef.id,
           agentConfigVersion: 1,
-          envConfigId,
+          envConfigId: envConfigRef.id,
         });
 
         expect((await store.getSession(sessionId))?.agentConfigVersion).toBe(1);
@@ -658,14 +674,16 @@ export function describeStoreConformance(
       });
 
       it("rejects a session naming an unknown agent config or version", async () => {
-        const envConfigId = await store.createEnvConfig({});
-        await expect(store.createSession({ agentConfigId: "nope", envConfigId })).rejects.toThrow();
+        const envConfigRef = await newEnv();
+        await expect(
+          store.createSession({ agentConfigId: "nope", envConfigId: envConfigRef.id }),
+        ).rejects.toThrow();
         const agentConfigRef = await newAgent();
         await expect(
           store.createSession({
             agentConfigId: agentConfigRef.id,
             agentConfigVersion: 2,
-            envConfigId,
+            envConfigId: envConfigRef.id,
           }),
         ).rejects.toThrow();
       });
@@ -679,49 +697,49 @@ export function describeStoreConformance(
     });
 
     describe("namespace", () => {
-      it("uses an explicit agent namespace while env configs and sessions default", async () => {
+      it("uses the explicit default namespace for configs while sessions default", async () => {
         const agentConfigRef = await newAgent();
-        const envConfigId = await store.createEnvConfig({});
+        const envConfigRef = await newEnv();
         const sessionId = await store.createSession({
           agentConfigId: agentConfigRef.id,
-          envConfigId,
+          envConfigId: envConfigRef.id,
         });
         expect((await store.getAgentConfig(agentConfigRef))?.namespace).toBe(DEFAULT_NAMESPACE);
-        expect((await store.getEnvConfig(envConfigId))?.namespace).toBe(DEFAULT_NAMESPACE);
+        expect((await store.getEnvConfig(envConfigRef))?.namespace).toBe(DEFAULT_NAMESPACE);
         expect((await store.getSession(sessionId))?.namespace).toBe(DEFAULT_NAMESPACE);
       });
 
       it("stores an explicit namespace verbatim", async () => {
         const agentConfigRef = await newAgent({ namespace: "tenant-a" });
-        const envConfigId = await store.createEnvConfig({ namespace: "tenant-a" });
+        const envConfigRef = await newEnv({ namespace: "tenant-a" });
         const sessionId = await store.createSession({
           agentConfigId: agentConfigRef.id,
-          envConfigId,
+          envConfigId: envConfigRef.id,
           namespace: "tenant-a",
         });
         expect((await store.getAgentConfig(agentConfigRef))?.namespace).toBe("tenant-a");
-        expect((await store.getEnvConfig(envConfigId))?.namespace).toBe("tenant-a");
+        expect((await store.getEnvConfig(envConfigRef))?.namespace).toBe("tenant-a");
         expect((await store.getSession(sessionId))?.namespace).toBe("tenant-a");
       });
 
       it("a foreign-namespace config is unknown — sessions and their configs share one namespace", async () => {
         const agentA = await newAgent({ namespace: "tenant-a" });
-        const envA = await store.createEnvConfig({ namespace: "tenant-a" });
-        const envB = await store.createEnvConfig({ namespace: "tenant-b" });
+        const envA = await newEnv({ namespace: "tenant-a" });
+        const envB = await newEnv({ namespace: "tenant-b" });
 
         // Cross-namespace refs reject exactly like dangling refs — the
         // error is the same "unknown", so existence never leaks.
         await expect(
           store.createSession({
             agentConfigId: agentA.id,
-            envConfigId: envB,
+            envConfigId: envB.id,
             namespace: "tenant-a",
           }),
         ).rejects.toThrow("unknown env config");
         await expect(
           store.createSession({
             agentConfigId: agentA.id,
-            envConfigId: envA,
+            envConfigId: envA.id,
             namespace: "tenant-b",
           }),
         ).rejects.toThrow("unknown agent config");
@@ -729,7 +747,7 @@ export function describeStoreConformance(
         await expect(
           store.createSession({
             agentConfigId: agentA.id,
-            envConfigId: envA,
+            envConfigId: envA.id,
             namespace: "tenant-a",
           }),
         ).resolves.toBeDefined();

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -27,10 +27,4 @@ export type {
   SandboxProvider,
 } from "./ports/sandbox-provider";
 export { ArchivedError, FencedError, VersionConflictError } from "./ports/store";
-export type {
-  Claim,
-  CommitStepRequest,
-  LeaseToken,
-  ListConfigsRequest,
-  Store,
-} from "./ports/store";
+export type { Claim, CommitStepRequest, LeaseToken, Store } from "./ports/store";

--- a/packages/agent/src/ports/store.ts
+++ b/packages/agent/src/ports/store.ts
@@ -8,10 +8,12 @@ import type {
   CreateEnvConfigRequest,
   CreateSessionRequest,
   EnvConfig,
+  EnvConfigRef,
   InputId,
   IntakeResult,
   ItemId,
   ListAgentConfigsRequest,
+  ListEnvConfigsRequest,
   PendingInput,
   Session,
   SessionEntry,
@@ -83,11 +85,12 @@ export interface Store {
   /** One namespace's agent configs, newest first — see ListAgentConfigsRequest. */
   listAgentConfigs(req: ListAgentConfigsRequest): Promise<AgentConfig[]>;
 
-  /** Create the environment config. Namespace must be specified */
-  createEnvConfig(req: CreateEnvConfigRequest): Promise<ConfigId>;
-  getEnvConfig(id: ConfigId): Promise<EnvConfig | undefined>;
-  /** One namespace's env configs, newest first — see ListConfigsRequest. */
-  listEnvConfigs(req: ListConfigsRequest): Promise<EnvConfig[]>;
+  /** Create an environment config. Namespace must be specified. */
+  createEnvConfig(req: CreateEnvConfigRequest): Promise<EnvConfigRef>;
+  /** Returns the namespace-scoped environment config. */
+  getEnvConfig(ref: EnvConfigRef): Promise<EnvConfig | undefined>;
+  /** One namespace's env configs, newest first — see ListEnvConfigsRequest. */
+  listEnvConfigs(req: ListEnvConfigsRequest): Promise<EnvConfig[]>;
 
   // --- sessions ---
 
@@ -173,36 +176,6 @@ export interface Store {
   commitStep(req: CommitStepRequest): Promise<void>;
 
   // P4 adds reaper operations (lease expiry, interrupted-result synthesis).
-}
-
-/**
- * The env config list read's argument. Agent configs use the equivalent
- * core ListAgentConfigsRequest vocabulary.
- *
- * `namespace` is required, and it is the one read whose tenancy the
- * store enforces rather than the api: a list has no id to fetch and
- * check afterwards, so the scope has to be inside the query.
- *
- * `limit` is required too — the port has no unbounded list, so no
- * caller can forget to bound one. The store returns at most that many
- * rows; a caller wanting to know whether more exist asks for one more
- * than it will show.
- *
- * `after` is a position cursor with the same meaning as readEntries'
- * seq — "what comes next" — in this list's newest-first order: the id
- * of the last row of the page before. It is resolved inside the
- * namespace, so a foreign cursor throws "unknown cursor" exactly like a
- * nonexistent one and nothing leaks. Keyset, not offset, and ordered by
- * immutable (createdAt, id), so updates cannot move a page boundary. A
- * concurrent create lands ahead of the first page and cannot duplicate or
- * skip a row mid-walk.
- */
-export interface ListConfigsRequest {
-  namespace: string;
-  /** At most this many rows. */
-  limit: number;
-  /** Id of the previous page's last row; absent starts at the newest. */
-  after?: ConfigId;
 }
 
 /**

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -42,8 +42,8 @@ export type InputId = string;
 // The tenancy boundary, driven by the managed service's trusted gateway
 // (an OSS deployment runs single-tenant). Ownership is exactly-one and
 // lives as a fact on the three ownable row types — decided at create and
-// immutable. Agent config creation requires that ownership explicitly;
-// env configs and sessions still resolve absence to DEFAULT_NAMESPACE.
+// immutable. Config creation requires that ownership explicitly; sessions
+// still resolve absence to DEFAULT_NAMESPACE.
 // Work items, entries, and pending inputs derive theirs through sessionId;
 // the worker and the driver never read it. The store guarantees a session
 // and its configs share one namespace, and scopes config references by the
@@ -116,12 +116,27 @@ export type AgentConfig = z.infer<typeof AgentConfig>;
 
 // The env config is the sandbox recipe — the immutable description of
 // the world a session runs in.
+/** A namespace-scoped reference to an env config. */
+export const EnvConfigRef = z.object({
+  namespace: z.string().min(1),
+  id: z.string().min(1),
+});
+export type EnvConfigRef = z.infer<typeof EnvConfigRef>;
+
+/** Lists one namespace's env configs with keyset pagination. */
+export const ListEnvConfigsRequest = z.object({
+  namespace: z.string().min(1),
+  limit: z.number().int().min(1),
+  after: z.string().min(1).optional(),
+});
+export type ListEnvConfigsRequest = z.infer<typeof ListEnvConfigsRequest>;
+
 export const CreateEnvConfigRequest = z.object({
+  namespace: z.string().min(1),
   network: NetworkPolicy.optional(),
   // Presence is guaranteed at create() or creation fails — missing deps
   // surface at provision, not mid-session.
   packages: Packages.optional(),
-  namespace: z.string().min(1).optional(),
   metadata: JsonValue.optional(),
 });
 export type CreateEnvConfigRequest = z.infer<typeof CreateEnvConfigRequest>;
@@ -131,7 +146,6 @@ export const EnvConfig = CreateEnvConfigRequest.extend({
   // Materialized at create — resolved decisions, not restatable defaults:
   network: NetworkPolicy, // absence resolved to { type: "unrestricted" }
   packages: Packages, // absence resolved to {}
-  namespace: z.string().min(1), // absence resolved to DEFAULT_NAMESPACE
   createdAt: z.iso.datetime(),
 });
 export type EnvConfig = z.infer<typeof EnvConfig>;

--- a/packages/core/test/store.test.ts
+++ b/packages/core/test/store.test.ts
@@ -7,8 +7,10 @@ import {
   CreateEnvConfigRequest,
   CreateSessionRequest,
   EnvConfig,
+  EnvConfigRef,
   IntakeResult,
   ListAgentConfigsRequest,
+  ListEnvConfigsRequest,
   PendingInput,
   Session,
   UpdateAgentConfigRequest,
@@ -164,23 +166,50 @@ describe("env configs", () => {
   });
 
   it("rejects a flat package list — specs are keyed by their package manager", () => {
-    const result = CreateEnvConfigRequest.safeParse({ packages: ["numpy", "pandas"] });
+    const result = CreateEnvConfigRequest.safeParse({
+      namespace: "tenant-a",
+      packages: ["numpy", "pandas"],
+    });
     expect(result.success).toBe(false);
   });
 
-  it("accepts an empty create request — network and packages resolve at create", () => {
-    const result = CreateEnvConfigRequest.safeParse({});
+  it("accepts a create request without recipe overrides — they resolve at create", () => {
+    const result = CreateEnvConfigRequest.safeParse({ namespace: "tenant-a" });
     expect(result.success).toBe(true);
   });
 
+  it("requires an explicit namespace when creating an env config", () => {
+    expect(CreateEnvConfigRequest.safeParse({}).success).toBe(false);
+  });
+
+  it("validates namespace-scoped env config references", () => {
+    expect(EnvConfigRef.safeParse({ namespace: "tenant-a", id: "ec1" }).success).toBe(true);
+    expect(EnvConfigRef.safeParse({ namespace: "tenant-a", id: "" }).success).toBe(false);
+    expect(EnvConfigRef.safeParse({ namespace: "", id: "ec1" }).success).toBe(false);
+  });
+
+  it("validates namespaced env config pagination", () => {
+    expect(
+      ListEnvConfigsRequest.safeParse({ namespace: "tenant-a", limit: 10, after: "ec1" }).success,
+    ).toBe(true);
+    expect(ListEnvConfigsRequest.safeParse({ namespace: "", limit: 10 }).success).toBe(false);
+    expect(ListEnvConfigsRequest.safeParse({ namespace: "tenant-a", limit: 0 }).success).toBe(
+      false,
+    );
+  });
+
   it("rejects an unknown network policy type", () => {
-    const result = CreateEnvConfigRequest.safeParse({ network: { type: "vpn" } });
+    const result = CreateEnvConfigRequest.safeParse({
+      namespace: "tenant-a",
+      network: { type: "vpn" },
+    });
     expect(result.success).toBe(false);
   });
 
   it("rejects a stored env config missing network — materialized decisions must be present", () => {
     const result = EnvConfig.safeParse({
       id: "ec1",
+      namespace: "tenant-a",
       packages: {},
       createdAt: "2026-08-11T12:00:00Z",
     });


### PR DESCRIPTION
Adds `EnvConfigRef` and `ListEnvConfigsRequest`, requires explicit namespaces on environment config creation, and updates the Store port to use scoped references. Migrates the PostgreSQL adapter, API routes, worker lookup, and all affected fixtures while preserving namespace-isolated reads and pagination behavior. Expands core, conformance, and API coverage for required namespaces plus unknown and foreign references.

Testing: `pnpm typecheck`; `pnpm test` (319 passed, 3 skipped).