### PR TITLE
Add the env config update endpoint

### DIFF
--- a/apps/api/src/routes/env-configs.ts
+++ b/apps/api/src/routes/env-configs.ts
@@ -1,21 +1,18 @@
 // apps/api/src/routes/env-configs.ts
-// The env-config resource — write-once sandbox recipes. Thin: validate
+// The env-config resource — sandbox recipes updated in place. Thin: validate
 // the core request shape → Store call → status code; the core schemas
 // ARE the wire format, so there is no HTTP-side translation layer.
-//
-// Write-once is structural, not policy: the Store port exposes no
-// update, archive, or delete for config rows, so create is the only
-// verb that writes — the other two routes read. Sessions reference
-// config ids; a row that could change under a running session would
-// reinterpret its history.
 import { Hono } from "hono";
-import { CreateEnvConfigRequest } from "@funky/core";
+import { CreateEnvConfigRequest, UpdateEnvConfigRequest } from "@funky/core";
 import type { Store } from "@funky/agent";
 import { errorResponse } from "../http";
 import { ListQuery, page, validate } from "./common";
 
 /** The slice of the harness Store this resource needs. */
-export type EnvConfigStore = Pick<Store, "createEnvConfig" | "getEnvConfig" | "listEnvConfigs">;
+export type EnvConfigStore = Pick<
+  Store,
+  "createEnvConfig" | "getEnvConfig" | "updateEnvConfig" | "listEnvConfigs"
+>;
 
 type Env = { Variables: { requestId: string; namespace: string } };
 
@@ -57,6 +54,18 @@ export function envConfigRoutes(store: EnvConfigStore) {
   r.get("/:id", async (c) => {
     const id = c.req.param("id");
     const config = await store.getEnvConfig({ namespace: c.get("namespace"), id });
+    if (!config) {
+      return errorResponse(c, 404, "not_found_error", `no env config ${id}`);
+    }
+    return c.json(config);
+  });
+
+  r.post("/:id", validate("json", UpdateEnvConfigRequest), async (c) => {
+    const id = c.req.param("id");
+    const config = await store.updateEnvConfig(
+      { namespace: c.get("namespace"), id },
+      c.req.valid("json"),
+    );
     if (!config) {
       return errorResponse(c, 404, "not_found_error", `no env config ${id}`);
     }

--- a/apps/api/test/env-configs.test.ts
+++ b/apps/api/test/env-configs.test.ts
@@ -132,6 +132,78 @@ describe("GET /v1/env-configs/:id", () => {
   });
 });
 
+describe("POST /v1/env-configs/:id", () => {
+  const asTenant = (tenant: string) => ({ "X-Funky-Namespace": tenant });
+
+  it("partially updates the recipe in place", async () => {
+    const created = await (
+      await post(app, "/v1/env-configs", {
+        namespace: "default",
+        network: { type: "allowlist", domains: ["pypi.org"] },
+        packages: { pip: ["numpy"] },
+        metadata: { stage: "initial" },
+      })
+    ).json();
+
+    const res = await post(app, `/v1/env-configs/${created.id}`, {
+      packages: { npm: ["zod@4"] },
+    });
+    expect(res.status).toBe(200);
+    const updated = await res.json();
+    expect(updated).toEqual({
+      ...created,
+      packages: { npm: ["zod@4"] },
+    });
+    expect(await (await get(app, `/v1/env-configs/${created.id}`)).json()).toEqual(updated);
+  });
+
+  it("accepts an empty update as a no-op", async () => {
+    const created = await (await post(app, "/v1/env-configs", { namespace: "default" })).json();
+    const res = await post(app, `/v1/env-configs/${created.id}`, {});
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(created);
+  });
+
+  it("validates the update body", async () => {
+    const created = await (await post(app, "/v1/env-configs", { namespace: "default" })).json();
+    for (const body of [{ network: { type: "vpn" } }, { packages: ["numpy"] }]) {
+      const res = await post(app, `/v1/env-configs/${created.id}`, body);
+      expect(res.status).toBe(400);
+      expect((await res.json()).error.type).toBe("invalid_request_error");
+    }
+  });
+
+  it("404s unknown and foreign ids without mutating the foreign config", async () => {
+    const unknown = await post(
+      scoped,
+      "/v1/env-configs/nope",
+      { packages: { npm: ["zod"] } },
+      asTenant("update-a"),
+    );
+    expect(unknown.status).toBe(404);
+
+    const created = await (
+      await post(
+        scoped,
+        "/v1/env-configs",
+        { namespace: "update-a", packages: { pip: ["numpy"] } },
+        asTenant("update-a"),
+      )
+    ).json();
+    const foreign = await post(
+      scoped,
+      `/v1/env-configs/${created.id}`,
+      { packages: { npm: ["zod"] } },
+      asTenant("update-b"),
+    );
+    expect(foreign.status).toBe(404);
+    const own = await (
+      await get(scoped, `/v1/env-configs/${created.id}`, asTenant("update-a"))
+    ).json();
+    expect(own.packages).toEqual({ pip: ["numpy"] });
+  });
+});
+
 describe("namespace scoping (namespaceSource=header — the managed-gateway shape)", () => {
   const asTenant = (tenant: string) => ({ "X-Funky-Namespace": tenant });
 

--- a/packages/adapters/src/store/pg.ts
+++ b/packages/adapters/src/store/pg.ts
@@ -49,6 +49,7 @@ import {
   Session,
   SessionEntry,
   UpdateAgentConfigRequest,
+  UpdateEnvConfigRequest,
   UserMessage,
   WorkItem,
 } from "@funky/core";
@@ -388,6 +389,25 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         .select()
         .from(envConfigs)
         .where(and(eq(envConfigs.id, id), eq(envConfigs.namespace, namespace)));
+      return row === undefined ? undefined : toEnvConfig(row);
+    },
+
+    async updateEnvConfig(ref, req) {
+      const { id, namespace } = EnvConfigRef.parse(ref);
+      const parsed = UpdateEnvConfigRequest.parse(req);
+      const scope = and(eq(envConfigs.id, id), eq(envConfigs.namespace, namespace));
+      const updates = {
+        ...(parsed.network === undefined ? {} : { network: parsed.network }),
+        ...(parsed.packages === undefined ? {} : { packages: parsed.packages }),
+        ...(parsed.metadata === undefined ? {} : { metadata: wrap(parsed.metadata) }),
+      };
+
+      if (Object.keys(updates).length === 0) {
+        const [row] = await db.select().from(envConfigs).where(scope);
+        return row === undefined ? undefined : toEnvConfig(row);
+      }
+
+      const [row] = await db.update(envConfigs).set(updates).where(scope).returning();
       return row === undefined ? undefined : toEnvConfig(row);
     },
 

--- a/packages/adapters/test/store-conformance.ts
+++ b/packages/adapters/test/store-conformance.ts
@@ -292,6 +292,61 @@ export function describeStoreConformance(
         expect(config?.packages).toEqual({ pip: ["pandas==2.2.0"] });
       });
 
+      it("partially updates an env config in place while preserving its identity", async () => {
+        const ref = await newEnv({
+          network: { type: "allowlist", domains: ["pypi.org"] },
+          packages: { pip: ["pandas==2.2.0"] },
+          metadata: { stage: "initial" },
+        });
+        const before = await store.getEnvConfig(ref);
+
+        const withPackages = await store.updateEnvConfig(ref, {
+          packages: { npm: ["zod@4"] },
+        });
+        expect(withPackages).toEqual({
+          ...before,
+          packages: { npm: ["zod@4"] },
+        });
+
+        const updated = await store.updateEnvConfig(ref, {
+          network: { type: "none" },
+          metadata: null,
+        });
+        expect(updated).toEqual({
+          ...withPackages,
+          network: { type: "none" },
+          metadata: null,
+        });
+        expect(await store.getEnvConfig(ref)).toEqual(updated);
+      });
+
+      it("treats an empty env config update as a read-like no-op", async () => {
+        const ref = await newEnv();
+        const before = await store.getEnvConfig(ref);
+        expect(await store.updateEnvConfig(ref, {})).toEqual(before);
+        expect(await store.getEnvConfig(ref)).toEqual(before);
+      });
+
+      it("preserves disjoint concurrent env config updates", async () => {
+        const ref = await newEnv();
+        await Promise.all([
+          store.updateEnvConfig(ref, { network: { type: "none" } }),
+          store.updateEnvConfig(ref, { packages: { npm: ["zod@4"] } }),
+        ]);
+        expect(await store.getEnvConfig(ref)).toMatchObject({
+          network: { type: "none" },
+          packages: { npm: ["zod@4"] },
+        });
+      });
+
+      it("rejects an invalid env config update at the boundary", async () => {
+        const ref = await newEnv();
+        await expect(
+          // biome-ignore lint/suspicious/noExplicitAny: deliberately malformed
+          store.updateEnvConfig(ref, { network: { type: "vpn" } } as any),
+        ).rejects.toThrow();
+      });
+
       it("returns undefined for unknown or foreign agent config refs", async () => {
         const ref = await newAgent({ namespace: "tenant-a" });
         expect(
@@ -309,6 +364,23 @@ export function describeStoreConformance(
           await store.getEnvConfig({ namespace: DEFAULT_NAMESPACE, id: "nope" }),
         ).toBeUndefined();
         expect(await store.getEnvConfig({ namespace: "tenant-b", id: ref.id })).toBeUndefined();
+      });
+
+      it("treats an unknown or foreign env config update target as absent", async () => {
+        const ref = await newEnv({ namespace: "tenant-a", packages: { pip: ["numpy"] } });
+        await expect(
+          store.updateEnvConfig(
+            { namespace: "tenant-a", id: "nope" },
+            { packages: { npm: ["zod"] } },
+          ),
+        ).resolves.toBeUndefined();
+        await expect(
+          store.updateEnvConfig(
+            { namespace: "tenant-b", id: ref.id },
+            { packages: { npm: ["zod"] } },
+          ),
+        ).resolves.toBeUndefined();
+        expect((await store.getEnvConfig(ref))?.packages).toEqual({ pip: ["numpy"] });
       });
     });
 

--- a/packages/agent/src/ports/store.ts
+++ b/packages/agent/src/ports/store.ts
@@ -19,6 +19,7 @@ import type {
   SessionEntry,
   SessionId,
   UpdateAgentConfigRequest,
+  UpdateEnvConfigRequest,
   UserMessage,
   WorkItem,
 } from "@funky/core";
@@ -89,6 +90,13 @@ export interface Store {
   createEnvConfig(req: CreateEnvConfigRequest): Promise<EnvConfigRef>;
   /** Returns the namespace-scoped environment config. */
   getEnvConfig(ref: EnvConfigRef): Promise<EnvConfig | undefined>;
+  /**
+   * Partially update one namespace's environment config in place. Omitted
+   * fields are preserved; an empty request is a read-like no-op. Namespace
+   * is immutable and carried by the ref. An unknown or foreign ref is
+   * indistinguishable from absence and returns undefined.
+   */
+  updateEnvConfig(ref: EnvConfigRef, req: UpdateEnvConfigRequest): Promise<EnvConfig | undefined>;
   /** One namespace's env configs, newest first — see ListEnvConfigsRequest. */
   listEnvConfigs(req: ListEnvConfigsRequest): Promise<EnvConfig[]>;
 

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -54,9 +54,9 @@ export const DEFAULT_NAMESPACE = "default";
 // --- configs ---
 
 // Agent configs are mutable, with a monotonic version used for optional
-// optimistic concurrency. Env configs remain immutable sandbox recipes.
-// Sessions pin the latest concrete agent version at creation, so later agent
-// updates cannot change the behavior of an existing session.
+// optimistic concurrency. Env configs update in place. Sessions pin the
+// latest concrete agent version at creation, while retaining an env config
+// reference.
 //
 // Archive is the one terminal transition: it retires an agent config
 // without deleting it — the row stays readable and its versions stay
@@ -114,8 +114,7 @@ export const AgentConfig = CreateAgentConfigRequest.extend({
 });
 export type AgentConfig = z.infer<typeof AgentConfig>;
 
-// The env config is the sandbox recipe — the immutable description of
-// the world a session runs in.
+// The env config is the sandbox recipe describing the world a session runs in.
 /** A namespace-scoped reference to an env config. */
 export const EnvConfigRef = z.object({
   namespace: z.string().min(1),
@@ -140,6 +139,14 @@ export const CreateEnvConfigRequest = z.object({
   metadata: JsonValue.optional(),
 });
 export type CreateEnvConfigRequest = z.infer<typeof CreateEnvConfigRequest>;
+
+/** An in-place partial update; omission preserves the stored field. */
+export const UpdateEnvConfigRequest = z.object({
+  network: NetworkPolicy.optional(),
+  packages: Packages.optional(),
+  metadata: JsonValue.optional(),
+});
+export type UpdateEnvConfigRequest = z.infer<typeof UpdateEnvConfigRequest>;
 
 export const EnvConfig = CreateEnvConfigRequest.extend({
   id: z.string(),

--- a/packages/core/test/store.test.ts
+++ b/packages/core/test/store.test.ts
@@ -14,6 +14,7 @@ import {
   PendingInput,
   Session,
   UpdateAgentConfigRequest,
+  UpdateEnvConfigRequest,
   WorkItem,
 } from "../src/store";
 
@@ -196,6 +197,23 @@ describe("env configs", () => {
     expect(ListEnvConfigsRequest.safeParse({ namespace: "tenant-a", limit: 0 }).success).toBe(
       false,
     );
+  });
+
+  it("accepts partial and empty in-place env config updates", () => {
+    expect(
+      UpdateEnvConfigRequest.safeParse({
+        network: { type: "none" },
+        packages: { pip: ["numpy"] },
+        metadata: { revision: 2 },
+      }).success,
+    ).toBe(true);
+    expect(UpdateEnvConfigRequest.safeParse({ packages: {} }).success).toBe(true);
+    expect(UpdateEnvConfigRequest.safeParse({}).success).toBe(true);
+  });
+
+  it("rejects malformed env config updates", () => {
+    expect(UpdateEnvConfigRequest.safeParse({ network: { type: "vpn" } }).success).toBe(false);
+    expect(UpdateEnvConfigRequest.safeParse({ packages: ["numpy"] }).success).toBe(false);
   });
 
   it("rejects an unknown network policy type", () => {


### PR DESCRIPTION
Adds `UpdateEnvConfigRequest` and the Store port method for namespace-scoped, partial in-place environment updates. Implements atomic PostgreSQL updates, read-like empty updates, and `POST /v1/env-configs/:id` with validation and namespace-isolated 404 behavior. Expands core, store-conformance, concurrency, and API coverage for every update field plus invalid, unknown, and foreign targets.

Testing: `pnpm typecheck`; `pnpm test` (330 passed, 3 skipped).