### PR TITLE
Add namespace-scoped session and work item references

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2,7 +2,6 @@
 // The whole application, network-free. Tests: buildApp(deps) + app.request().
 import { Hono } from "hono";
 import type { Store } from "@funky/agent";
-import type { NamespaceSource } from "./config";
 import { errorHandler, errorResponse } from "./http";
 import { auth } from "./middleware/auth";
 import { requestId } from "./middleware/request-id";
@@ -15,15 +14,13 @@ export type AppDeps = {
   store: Store;
   /** null = auth explicitly disabled (dev only) */
   authToken: string | null;
-  /** "static" (OSS) or "header" (behind the managed gateway) */
-  namespaceSource: NamespaceSource;
   /** liveness of the DB, e.g. () => pool.query("SELECT 1") */
   ping: () => Promise<unknown>;
   /** SSE tail pacing for /sessions/:id/stream */
   stream: StreamPacing;
 };
 
-type Env = { Variables: { requestId: string; namespace: string } };
+type Env = { Variables: { requestId: string } };
 
 export function buildApp(deps: AppDeps) {
   const app = new Hono<Env>();
@@ -36,7 +33,7 @@ export function buildApp(deps: AppDeps) {
     return c.json({ status: "ok" as const });
   });
 
-  app.use("/v1/*", auth(deps.authToken, deps.namespaceSource));
+  app.use("/v1/*", auth(deps.authToken));
   app.route("/v1/agent-configs", agentConfigRoutes(deps.store));
   app.route("/v1/env-configs", envConfigRoutes(deps.store));
   app.route("/v1/sessions", sessionRoutes(deps.store, deps.stream));

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -5,12 +5,6 @@
 // override, never an omission.
 import { z } from "zod";
 
-/** Where a request's namespace comes from: "static" pins every request
- *  to DEFAULT_NAMESPACE (the OSS deployment shape); "header" trusts
- *  X-Funky-Namespace — for the managed gateway, which authenticates
- *  users itself and holds this api's bearer token privately. */
-export type NamespaceSource = "static" | "header";
-
 const EnvSchema = z
   .object({
     DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
@@ -18,7 +12,6 @@ const EnvSchema = z
     DB_POOL_MAX: z.coerce.number().int().min(1).default(10),
     FUNKY_AUTH: z.enum(["enabled", "disabled"]).default("enabled"),
     FUNKY_AUTH_TOKEN: z.string().min(16, "FUNKY_AUTH_TOKEN must be ≥16 chars").optional(),
-    FUNKY_NAMESPACE_SOURCE: z.enum(["static", "header"]).default("static"),
     /** SSE tail pacing: how often /stream re-polls the entries cursor,
      *  and how long a quiet stream goes before a keep-alive comment. */
     FUNKY_STREAM_POLL_MS: z.coerce.number().int().min(1).default(1000),
@@ -28,10 +21,6 @@ const EnvSchema = z
     message:
       "FUNKY_AUTH_TOKEN is required. Set it in the environment, " +
       "or set FUNKY_AUTH=disabled for local development (NOT for anything reachable).",
-  })
-  .refine((e) => e.FUNKY_AUTH !== "disabled" || e.FUNKY_NAMESPACE_SOURCE !== "header", {
-    path: ["FUNKY_NAMESPACE_SOURCE"],
-    message: "FUNKY_NAMESPACE_SOURCE=header requires FUNKY_AUTH=enabled",
   })
   // The stream loop checks the heartbeat once per poll, so a poll slower
   // than the heartbeat would silently stretch the keepalive past its
@@ -47,7 +36,6 @@ export type Config = {
   dbPoolMax: number;
   /** null = auth explicitly disabled (dev only) */
   authToken: string | null;
-  namespaceSource: NamespaceSource;
   streamPollMs: number;
   streamHeartbeatMs: number;
 };
@@ -70,7 +58,6 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     port: e.PORT,
     dbPoolMax: e.DB_POOL_MAX,
     authToken: e.FUNKY_AUTH === "disabled" ? null : e.FUNKY_AUTH_TOKEN!,
-    namespaceSource: e.FUNKY_NAMESPACE_SOURCE,
     streamPollMs: e.FUNKY_STREAM_POLL_MS,
     streamHeartbeatMs: e.FUNKY_STREAM_HEARTBEAT_MS,
   };

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -18,7 +18,6 @@ const store = createPgStore(drizzle({ client: pool }) as unknown as StoreDb);
 const app = buildApp({
   store,
   authToken: cfg.authToken,
-  namespaceSource: cfg.namespaceSource,
   ping: () => pool.query("SELECT 1"),
   stream: { pollMs: cfg.streamPollMs, heartbeatMs: cfg.streamHeartbeatMs },
 });

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,20 +1,15 @@
 // apps/api/src/middleware/auth.ts
-// Static bearer auth + the namespace decision, in one middleware because
-// the header source is only trustworthy AFTER authentication: the
-// managed gateway holds this api's token privately and injects
-// X-Funky-Namespace per authenticated user. An OSS deployment runs
-// source "static" and every request is DEFAULT_NAMESPACE. Routes read
-// the decision from c.get("namespace") and never from the request body.
+// Static bearer auth, nothing else. The token is a root credential: its
+// holder — the managed gateway, or a self-deploy operator — can address
+// every namespace, and says which one each request means IN the request
+// (create bodies carry it; id-addressed routes take ?namespace=).
+// Tenant authorization is the managed layer's job, above this api.
 import { createHash, timingSafeEqual } from "node:crypto";
 import { createMiddleware } from "hono/factory";
-import { DEFAULT_NAMESPACE } from "@funky/core";
-import type { NamespaceSource } from "../config";
 import { errorResponse } from "../http";
 
-const VALID_NAMESPACE = /^[A-Za-z0-9_-]{1,64}$/;
-
 /** token === null means FUNKY_AUTH=disabled (dev only; config.ts already warned). */
-export const auth = (token: string | null, namespaceSource: NamespaceSource) =>
+export const auth = (token: string | null) =>
   createMiddleware(async (c, next) => {
     if (token !== null) {
       const header = c.req.header("authorization") ?? "";
@@ -23,18 +18,6 @@ export const auth = (token: string | null, namespaceSource: NamespaceSource) =>
         return errorResponse(c, 401, "authentication_error", "invalid or missing bearer token");
       }
     }
-
-    if (namespaceSource === "static") {
-      c.set("namespace", DEFAULT_NAMESPACE);
-      await next();
-      return;
-    }
-
-    const namespace = c.req.header("X-Funky-Namespace") ?? DEFAULT_NAMESPACE;
-    if (!VALID_NAMESPACE.test(namespace)) {
-      return errorResponse(c, 400, "invalid_request_error", "invalid X-Funky-Namespace");
-    }
-    c.set("namespace", namespace);
     await next();
   });
 

--- a/apps/api/src/routes/agent-configs.ts
+++ b/apps/api/src/routes/agent-configs.ts
@@ -1,14 +1,20 @@
 // apps/api/src/routes/agent-configs.ts
 // The agent-config resource — versioned behavior recipes (inference +
-// system prompt), tenant-private like every config. Updates follow
-// UpdateAgent semantics: partial replacement and an optional version
-// precondition for optimistic concurrency. Archive follows ArchiveAgent
-// semantics: the terminal state, with no route back.
+// system prompt). Updates follow UpdateAgent semantics: partial
+// replacement and an optional version precondition for optimistic
+// concurrency. Archive follows ArchiveAgent semantics: the terminal
+// state, with no route back.
+//
+// Namespace is part of the request (this api's caller holds the root
+// token; the managed layer above does tenant authorization): the create
+// body carries it — the core request schema IS the wire shape — and
+// every other route takes ?namespace=, defaulting for single-tenant
+// self-deploys (see common.ts NamespaceQuery).
 import { Hono } from "hono";
-import { CreateAgentConfigRequest, UpdateAgentConfigRequest } from "@funky/core";
+import { type AgentConfig, CreateAgentConfigRequest, UpdateAgentConfigRequest } from "@funky/core";
 import { ArchivedError, type Store, VersionConflictError } from "@funky/agent";
 import { errorResponse } from "../http";
-import { ListQuery, page, validate } from "./common";
+import { ListQuery, NamespaceQuery, page, validate } from "./common";
 
 /** The slice of the harness Store this resource needs. */
 export type AgentConfigStore = Pick<
@@ -20,29 +26,34 @@ export type AgentConfigStore = Pick<
   | "archiveAgentConfig"
 >;
 
-type Env = { Variables: { requestId: string; namespace: string } };
+type Env = { Variables: { requestId: string } };
+
+// The core request, with the body's namespace defaulted the same way
+// the query's is (common.ts NamespaceQuery).
+const CreateAgentConfigBody = CreateAgentConfigRequest.extend(NamespaceQuery.shape);
+
+/** Store row → wire resource: the ref's qualified id becomes the
+ *  resource's `id`; everything else — namespace included — rides
+ *  through to the trusted caller. */
+const wire = ({ agentConfigId, ...rest }: AgentConfig) => ({ id: agentConfigId, ...rest });
 
 export function agentConfigRoutes(store: AgentConfigStore) {
   const r = new Hono<Env>();
 
-  r.post("/", validate("json", CreateAgentConfigRequest), async (c) => {
+  r.post("/", validate("json", CreateAgentConfigBody), async (c) => {
     const ref = await store.createAgentConfig(c.req.valid("json"));
     const config = await store.getAgentConfig(ref);
-    if (!config) throw new Error(`agent config ${ref.id} missing after create`);
-    return c.json(config, 201);
+    if (!config) throw new Error(`agent config ${ref.agentConfigId} missing after create`);
+    return c.json(wire(config), 201);
   });
 
   // list → one page of this namespace's rows, newest first. The store
   // is asked for limit + 1: the extra row is hasMore (see page()).
   r.get("/", validate("query", ListQuery), async (c) => {
-    const { limit, after } = c.req.valid("query");
+    const { namespace, limit, after } = c.req.valid("query");
     try {
-      const rows = await store.listAgentConfigs({
-        namespace: c.get("namespace"),
-        limit: limit + 1,
-        after,
-      });
-      return c.json(page(rows, limit));
+      const rows = await store.listAgentConfigs({ namespace, limit: limit + 1, after });
+      return c.json(page(rows.map(wire), limit));
     } catch (err) {
       // A cursor the store can't resolve — foreign or made-up, the same
       // "unknown" either way — is the client's mistake, so 400 not 500.
@@ -53,51 +64,59 @@ export function agentConfigRoutes(store: AgentConfigStore) {
     }
   });
 
-  r.get("/:id", async (c) => {
+  r.get("/:id", validate("query", NamespaceQuery), async (c) => {
     const id = c.req.param("id");
-    const config = await store.getAgentConfig({ namespace: c.get("namespace"), id });
+    const { namespace } = c.req.valid("query");
+    const config = await store.getAgentConfig({ namespace, agentConfigId: id });
     if (!config) {
       return errorResponse(c, 404, "not_found_error", `no agent config ${id}`);
     }
-    return c.json(config);
+    return c.json(wire(config));
   });
 
-  r.post("/:id", validate("json", UpdateAgentConfigRequest), async (c) => {
-    const id = c.req.param("id");
-    try {
-      const config = await store.updateAgentConfig(
-        { namespace: c.get("namespace"), id },
-        c.req.valid("json"),
-      );
-      if (config === undefined) {
-        return errorResponse(c, 404, "not_found_error", `no agent config ${id}`);
+  r.post(
+    "/:id",
+    validate("query", NamespaceQuery),
+    validate("json", UpdateAgentConfigRequest),
+    async (c) => {
+      const id = c.req.param("id");
+      const { namespace } = c.req.valid("query");
+      try {
+        const config = await store.updateAgentConfig(
+          { namespace, agentConfigId: id },
+          c.req.valid("json"),
+        );
+        if (config === undefined) {
+          return errorResponse(c, 404, "not_found_error", `no agent config ${id}`);
+        }
+        return c.json(wire(config));
+      } catch (err) {
+        if (err instanceof VersionConflictError) {
+          return errorResponse(c, 409, "conflict_error", err.message);
+        }
+        // An archived config is read-only: the request conflicts with a
+        // state it cannot leave, so 409 — the same shape as a stale
+        // version, but nothing the client can retry into success.
+        if (err instanceof ArchivedError) {
+          return errorResponse(c, 409, "conflict_error", err.message);
+        }
+        throw err;
       }
-      return c.json(config);
-    } catch (err) {
-      if (err instanceof VersionConflictError) {
-        return errorResponse(c, 409, "conflict_error", err.message);
-      }
-      // An archived config is read-only: the request conflicts with a
-      // state it cannot leave, so 409 — the same shape as a stale
-      // version, but nothing the client can retry into success.
-      if (err instanceof ArchivedError) {
-        return errorResponse(c, 409, "conflict_error", err.message);
-      }
-      throw err;
-    }
-  });
+    },
+  );
 
   // archive → the terminal state. No body (there is nothing to say but
   // "retire this"), and no unarchive route, here or ever. Idempotent by
   // consequence: a second archive answers 200 with the first one's
   // archivedAt, because the state it asks for is already the state.
-  r.post("/:id/archive", async (c) => {
+  r.post("/:id/archive", validate("query", NamespaceQuery), async (c) => {
     const id = c.req.param("id");
-    const config = await store.archiveAgentConfig({ namespace: c.get("namespace"), id });
+    const { namespace } = c.req.valid("query");
+    const config = await store.archiveAgentConfig({ namespace, agentConfigId: id });
     if (config === undefined) {
       return errorResponse(c, 404, "not_found_error", `no agent config ${id}`);
     }
-    return c.json(config);
+    return c.json(wire(config));
   });
 
   return r;

--- a/apps/api/src/routes/common.ts
+++ b/apps/api/src/routes/common.ts
@@ -5,6 +5,7 @@
 // gets back, written once so no two resources page differently.
 import { zValidator } from "@hono/zod-validator";
 import { type ZodType, z } from "zod";
+import { DEFAULT_NAMESPACE } from "@funky/core";
 import { errorResponse } from "../http";
 
 export const validate = <T extends ZodType>(target: "json" | "query", schema: T) =>
@@ -17,6 +18,28 @@ export const validate = <T extends ZodType>(target: "json" | "query", schema: T)
     }
   });
 
+/**
+ * The namespace is part of the request (the caller holds the root token
+ * and says which tenant it means): create bodies carry it in the body,
+ * every id-addressed or list route as a query parameter. In both spots
+ * absence resolves to DEFAULT_NAMESPACE — the single-tenant self-deploy
+ * convenience the core comment blesses as "the api gateway's job"; the
+ * store itself always receives it explicitly. This object is that one
+ * spelling: routes validate it as a query, and create bodies extend the
+ * core request with its shape so the same default applies.
+ *
+ * The format bound is load-bearing, not taste: namespace is a component
+ * of every table's primary key, and an unbounded string overflows the
+ * btree tuple limit — a 500 where a 400 belongs.
+ */
+export const NamespaceQuery = z.object({
+  namespace: z
+    .string()
+    .regex(/^[A-Za-z0-9_-]{1,64}$/, "1-64 characters: letters, digits, _ and -")
+    .default(DEFAULT_NAMESPACE),
+});
+export type NamespaceQuery = z.infer<typeof NamespaceQuery>;
+
 /** Page size when the caller doesn't ask, and the ceiling when it does. */
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
@@ -27,7 +50,7 @@ const MAX_LIMIT = 100;
  * request we quietly answer with something else. `after` is the id of
  * the previous page's last row — the cursor `page()` hands back.
  */
-export const ListQuery = z.object({
+export const ListQuery = NamespaceQuery.extend({
   limit: z.coerce.number().int().min(1).max(MAX_LIMIT).default(DEFAULT_LIMIT),
   after: z.string().min(1).optional(),
 });

--- a/apps/api/src/routes/env-configs.ts
+++ b/apps/api/src/routes/env-configs.ts
@@ -1,12 +1,15 @@
 // apps/api/src/routes/env-configs.ts
-// The env-config resource — sandbox recipes updated in place. Thin: validate
-// the core request shape → Store call → status code; the core schemas
-// ARE the wire format, so there is no HTTP-side translation layer.
+// The env-config resource — sandbox recipes updated in place. Thin:
+// validate the request shape → Store call → wire row, where the wire
+// mapping only renames the ref's qualified id to the resource's `id`.
+// Namespace is part of the request: the create body carries it — the
+// core request schema IS the wire shape — and the other routes take
+// ?namespace= (see agent-configs.ts and common.ts NamespaceQuery).
 import { Hono } from "hono";
-import { CreateEnvConfigRequest, UpdateEnvConfigRequest } from "@funky/core";
+import { CreateEnvConfigRequest, type EnvConfig, UpdateEnvConfigRequest } from "@funky/core";
 import type { Store } from "@funky/agent";
 import { errorResponse } from "../http";
-import { ListQuery, page, validate } from "./common";
+import { ListQuery, NamespaceQuery, page, validate } from "./common";
 
 /** The slice of the harness Store this resource needs. */
 export type EnvConfigStore = Pick<
@@ -14,7 +17,14 @@ export type EnvConfigStore = Pick<
   "createEnvConfig" | "getEnvConfig" | "updateEnvConfig" | "listEnvConfigs"
 >;
 
-type Env = { Variables: { requestId: string; namespace: string } };
+type Env = { Variables: { requestId: string } };
+
+// The core request, with the body's namespace defaulted the same way
+// the query's is (common.ts NamespaceQuery).
+const CreateEnvConfigBody = CreateEnvConfigRequest.extend(NamespaceQuery.shape);
+
+/** Store row → wire resource — see the header. */
+const wire = ({ envConfigId, ...rest }: EnvConfig) => ({ id: envConfigId, ...rest });
 
 export function envConfigRoutes(store: EnvConfigStore) {
   const r = new Hono<Env>();
@@ -22,24 +32,20 @@ export function envConfigRoutes(store: EnvConfigStore) {
   // create → 201 with the materialized row: defaults are resolved at
   // create (network → unrestricted, packages → {}), so the caller sees
   // the decision that was stored, not the request they sent.
-  r.post("/", validate("json", CreateEnvConfigRequest), async (c) => {
+  r.post("/", validate("json", CreateEnvConfigBody), async (c) => {
     const ref = await store.createEnvConfig(c.req.valid("json"));
     const config = await store.getEnvConfig(ref);
-    if (!config) throw new Error(`env config ${ref.id} missing after create`);
-    return c.json(config, 201);
+    if (!config) throw new Error(`env config ${ref.envConfigId} missing after create`);
+    return c.json(wire(config), 201);
   });
 
   // list → one page of this namespace's rows, newest first. The store
   // is asked for limit + 1: the extra row is hasMore (see page()).
   r.get("/", validate("query", ListQuery), async (c) => {
-    const { limit, after } = c.req.valid("query");
+    const { namespace, limit, after } = c.req.valid("query");
     try {
-      const rows = await store.listEnvConfigs({
-        namespace: c.get("namespace"),
-        limit: limit + 1,
-        after,
-      });
-      return c.json(page(rows, limit));
+      const rows = await store.listEnvConfigs({ namespace, limit: limit + 1, after });
+      return c.json(page(rows.map(wire), limit));
     } catch (err) {
       // The store resolves the cursor inside the namespace; a foreign
       // one is "unknown" exactly like a made-up one. Either way the
@@ -51,26 +57,33 @@ export function envConfigRoutes(store: EnvConfigStore) {
     }
   });
 
-  r.get("/:id", async (c) => {
+  r.get("/:id", validate("query", NamespaceQuery), async (c) => {
     const id = c.req.param("id");
-    const config = await store.getEnvConfig({ namespace: c.get("namespace"), id });
+    const { namespace } = c.req.valid("query");
+    const config = await store.getEnvConfig({ namespace, envConfigId: id });
     if (!config) {
       return errorResponse(c, 404, "not_found_error", `no env config ${id}`);
     }
-    return c.json(config);
+    return c.json(wire(config));
   });
 
-  r.post("/:id", validate("json", UpdateEnvConfigRequest), async (c) => {
-    const id = c.req.param("id");
-    const config = await store.updateEnvConfig(
-      { namespace: c.get("namespace"), id },
-      c.req.valid("json"),
-    );
-    if (!config) {
-      return errorResponse(c, 404, "not_found_error", `no env config ${id}`);
-    }
-    return c.json(config);
-  });
+  r.post(
+    "/:id",
+    validate("query", NamespaceQuery),
+    validate("json", UpdateEnvConfigRequest),
+    async (c) => {
+      const id = c.req.param("id");
+      const { namespace } = c.req.valid("query");
+      const config = await store.updateEnvConfig(
+        { namespace, envConfigId: id },
+        c.req.valid("json"),
+      );
+      if (!config) {
+        return errorResponse(c, 404, "not_found_error", `no env config ${id}`);
+      }
+      return c.json(wire(config));
+    },
+  );
 
   return r;
 }

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -1,8 +1,16 @@
 // apps/api/src/routes/sessions.ts
 // The sessions resource — the intake half of the Store port, plus the
-// inspection reads. Every route under /:id does the ownership check
-// once at the top: a foreign session 404s exactly like a nonexistent
-// one, so nothing leaks across namespaces.
+// inspection reads. Every route under /:id resolves ownership once at
+// the top with a namespace-scoped get: the store answers a foreign
+// session exactly like a nonexistent one, so no route compares
+// namespaces by hand. The row the get returns is its own SessionRef, so
+// it addresses every later call.
+//
+// Namespace is part of the request (the caller holds the root token;
+// tenant authorization lives in the managed layer above): the create
+// body carries it — the core request schema IS the wire shape — and
+// every id-addressed route takes ?namespace=, defaulting for
+// single-tenant self-deploys (common.ts NamespaceQuery).
 //
 // The api writes nothing itself: intake and requestCancel are the only
 // mutations, both Store transactions. Whether a message starts a run or
@@ -12,10 +20,10 @@
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { z } from "zod";
-import { CreateSessionRequest, UserMessage } from "@funky/core";
+import { CreateSessionRequest, type Session, UserMessage, type WorkItem } from "@funky/core";
 import { ArchivedError, type Store } from "@funky/agent";
 import { errorResponse } from "../http";
-import { validate } from "./common";
+import { NamespaceQuery, validate } from "./common";
 
 /** The slice of the harness Store this resource needs. */
 export type SessionStore = Pick<
@@ -31,9 +39,19 @@ export type StreamPacing = {
   heartbeatMs: number;
 };
 
-type Env = { Variables: { requestId: string; namespace: string } };
+type Env = { Variables: { requestId: string } };
 
-const WireCreateSession = CreateSessionRequest.omit({ namespace: true });
+// The core request, with the body's namespace defaulted the same way
+// the query's is (common.ts NamespaceQuery).
+const CreateSessionBody = CreateSessionRequest.extend(NamespaceQuery.shape);
+
+/** Store row → wire resource: the ref's qualified id becomes the
+ *  resource's `id`; everything else — namespace included — rides
+ *  through to the trusted caller. */
+const wire = ({ sessionId, ...rest }: Session) => ({ id: sessionId, ...rest });
+
+/** Same rule for items: the row, with its own qualified id as `id`. */
+const wireItem = ({ itemId, ...rest }: WorkItem) => ({ id: itemId, ...rest });
 
 // "Always an array; plain strings are normalized at intake"
 // (core/messages.ts) — this is the intake boundary, so the wire accepts
@@ -42,17 +60,19 @@ const WireMessage = z.object({
   content: z.union([z.string(), UserMessage.shape.content]),
 });
 
-const EntriesQuery = z.object({
+const EntriesQuery = NamespaceQuery.extend({
   after: z.coerce.number().int().nonnegative().optional(),
 });
 
 export function sessionRoutes(store: SessionStore, pacing: StreamPacing) {
   const r = new Hono<Env>();
 
-  r.post("/", validate("json", WireCreateSession), async (c) => {
-    let id: string;
+  r.post("/", validate("json", CreateSessionBody), async (c) => {
+    let session: Session | undefined;
     try {
-      id = await store.createSession({ ...c.req.valid("json"), namespace: c.get("namespace") });
+      const ref = await store.createSession(c.req.valid("json"));
+      session = await store.getSession(ref);
+      if (!session) throw new Error(`session ${ref.sessionId} missing after create`);
     } catch (err) {
       // An archived agent config exists and is readable — it just cannot
       // be referenced by anything new. That is a conflict with its
@@ -67,47 +87,50 @@ export function sessionRoutes(store: SessionStore, pacing: StreamPacing) {
       }
       throw err;
     }
-    const session = await store.getSession(id);
-    if (!session) throw new Error(`session ${id} missing after create`);
-    return c.json(session, 201);
+    return c.json(wire(session), 201);
   });
 
-  r.get("/:id", async (c) => {
-    const session = await owned(c);
+  r.get("/:id", validate("query", NamespaceQuery), async (c) => {
+    const session = await owned(c, c.req.valid("query").namespace);
     if (!session) return notFound(c);
-    return c.json(session);
+    return c.json(wire(session));
   });
 
-  r.post("/:id/messages", validate("json", WireMessage), async (c) => {
-    const session = await owned(c);
-    if (!session) return notFound(c);
-    const { content } = c.req.valid("json");
-    const message: UserMessage = {
-      role: "user",
-      content: typeof content === "string" ? [{ type: "text", text: content }] : content,
-    };
-    return c.json(await store.intake(session.id, message), 202);
-  });
+  r.post(
+    "/:id/messages",
+    validate("query", NamespaceQuery),
+    validate("json", WireMessage),
+    async (c) => {
+      const session = await owned(c, c.req.valid("query").namespace);
+      if (!session) return notFound(c);
+      const { content } = c.req.valid("json");
+      const message: UserMessage = {
+        role: "user",
+        content: typeof content === "string" ? [{ type: "text", text: content }] : content,
+      };
+      return c.json(await store.intake(session, message), 202);
+    },
+  );
 
-  r.post("/:id/cancel", async (c) => {
-    const session = await owned(c);
+  r.post("/:id/cancel", validate("query", NamespaceQuery), async (c) => {
+    const session = await owned(c, c.req.valid("query").namespace);
     if (!session) return notFound(c);
     // Appends a control entry; the worker answers it at a step boundary,
     // so cancellation is accepted here, not completed.
-    await store.requestCancel(session.id);
+    await store.requestCancel(session);
     return c.body(null, 202);
   });
 
   r.get("/:id/entries", validate("query", EntriesQuery), async (c) => {
-    const session = await owned(c);
+    const session = await owned(c, c.req.valid("query").namespace);
     if (!session) return notFound(c);
-    return c.json(await store.readEntries(session.id, c.req.valid("query").after));
+    return c.json(await store.readEntries(session, c.req.valid("query").after));
   });
 
-  r.get("/:id/items", async (c) => {
-    const session = await owned(c);
+  r.get("/:id/items", validate("query", NamespaceQuery), async (c) => {
+    const session = await owned(c, c.req.valid("query").namespace);
     if (!session) return notFound(c);
-    return c.json(await store.listItems(session.id));
+    return c.json((await store.listItems(session)).map(wireItem));
   });
 
   // The entries read, delivered incrementally: replay past the cursor,
@@ -124,7 +147,7 @@ export function sessionRoutes(store: SessionStore, pacing: StreamPacing) {
   // The stream has no server-side end — sessions don't terminate. The
   // client hangs up; `aborted` stops the loop.
   r.get("/:id/stream", validate("query", EntriesQuery), async (c) => {
-    const session = await owned(c);
+    const session = await owned(c, c.req.valid("query").namespace);
     if (!session) return notFound(c);
     let after = c.req.valid("query").after;
     const lastEventId = c.req.header("Last-Event-ID");
@@ -139,7 +162,7 @@ export function sessionRoutes(store: SessionStore, pacing: StreamPacing) {
       let cursor = after;
       let quietSince = Date.now();
       while (!stream.aborted) {
-        const entries = [...(await store.readEntries(session.id, cursor))].sort(
+        const entries = [...(await store.readEntries(session, cursor))].sort(
           (a, b) => a.seq - b.seq,
         );
         for (const entry of entries) {
@@ -159,11 +182,10 @@ export function sessionRoutes(store: SessionStore, pacing: StreamPacing) {
     });
   });
 
-  /** The one ownership check: undefined for unknown AND foreign rows. */
-  async function owned(c: { req: { param(k: "id"): string }; get(k: "namespace"): string }) {
-    const session = await store.getSession(c.req.param("id"));
-    if (!session || session.namespace !== c.get("namespace")) return undefined;
-    return session;
+  /** The one ownership check — a scoped get: the store answers undefined
+   *  for unknown AND foreign rows, so nothing is compared by hand here. */
+  async function owned(c: { req: { param(k: "id"): string } }, namespace: string) {
+    return store.getSession({ namespace, sessionId: c.req.param("id") });
   }
 
   function notFound(c: Parameters<typeof errorResponse>[0]) {

--- a/apps/api/test/agent-configs.test.ts
+++ b/apps/api/test/agent-configs.test.ts
@@ -1,8 +1,11 @@
 // Route tests over the REAL store — PGlite + the pg adapter — same
-// pattern as env-configs.test.ts. The middleware machinery (auth,
-// header source validation) is covered there and in app.test.ts; here
-// we pin this resource's wiring, materialization, and its own
-// namespace-scoped Store references.
+// pattern as env-configs.test.ts. The middleware machinery (auth) is
+// covered in app.test.ts; here we pin this resource's wiring,
+// materialization, and its namespace-scoped Store references.
+//
+// Namespace is part of the request: create bodies carry it, every other
+// route takes ?namespace= — and in both spots absence defaults to
+// "default" (common.ts NamespaceQuery).
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -21,16 +24,17 @@ const recipeFor = (namespace: string) => ({ ...RECIPE, namespace });
 
 let client: PGlite;
 let app: ReturnType<typeof buildApp>;
-let scoped: ReturnType<typeof buildApp>; // namespaceSource "header" over the SAME store
 
 beforeAll(async () => {
   client = new PGlite();
   await client.exec(storeDdl);
   const store = createPgStore(drizzle({ client }) as unknown as StoreDb);
-  const base = { store, authToken: null, ping: async () => ({}) };
-  const stream = { pollMs: 1000, heartbeatMs: 15_000 };
-  app = buildApp({ ...base, namespaceSource: "static", stream });
-  scoped = buildApp({ ...base, namespaceSource: "header", stream });
+  app = buildApp({
+    store,
+    authToken: null,
+    ping: async () => ({}),
+    stream: { pollMs: 1000, heartbeatMs: 15_000 },
+  });
 });
 
 afterAll(async () => {
@@ -50,6 +54,7 @@ describe("POST /v1/agent-configs", () => {
     expect(typeof body.createdAt).toBe("string");
     expect(body.updatedAt).toBe(body.createdAt);
 
+    // Reads default ?namespace= to "default" — the self-deploy shape.
     const fetched = await get(app, `/v1/agent-configs/${body.id}`);
     expect(fetched.status).toBe(200);
     expect(await fetched.json()).toEqual(body);
@@ -58,15 +63,23 @@ describe("POST /v1/agent-configs", () => {
   it("uses the namespace supplied in the request", async () => {
     const res = await post(app, "/v1/agent-configs", recipeFor("caller-namespace"));
     expect(res.status).toBe(201);
-    expect((await res.json()).namespace).toBe("caller-namespace");
+    const created = await res.json();
+    expect(created.namespace).toBe("caller-namespace");
+    expect(
+      (await get(app, `/v1/agent-configs/${created.id}?namespace=caller-namespace`)).status,
+    ).toBe(200);
+    // Without the query the read defaults to "default" — a different
+    // namespace, so the row is unknown there.
+    expect((await get(app, `/v1/agent-configs/${created.id}`)).status).toBe(404);
   });
 
-  it("requires a namespace", async () => {
+  it("defaults the namespace when the body omits it", async () => {
     const res = await post(app, "/v1/agent-configs", {
       inference: RECIPE.inference,
       systemPrompt: RECIPE.systemPrompt,
     });
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(201);
+    expect((await res.json()).namespace).toBe("default");
   });
 
   it("rejects a bare-string inference config, 400", async () => {
@@ -96,12 +109,10 @@ describe("GET /v1/agent-configs", () => {
   // created back to back can share a timestamp. That the order is
   // newest-first is pinned in the store conformance suite, which owns
   // an injected clock.
-  const asTenant = (tenant: string) => ({ "X-Funky-Namespace": tenant });
-
   async function seed(tenant: string, n: number): Promise<string[]> {
     const ids: string[] = [];
     for (let i = 0; i < n; i++) {
-      const res = await post(scoped, "/v1/agent-configs", recipeFor(tenant), asTenant(tenant));
+      const res = await post(app, "/v1/agent-configs", recipeFor(tenant));
       expect(res.status).toBe(201);
       ids.push((await res.json()).id);
     }
@@ -110,30 +121,28 @@ describe("GET /v1/agent-configs", () => {
 
   it("returns the namespace's rows in one page, whole rows, hasMore false", async () => {
     const ids = await seed("list-one", 3);
-    const res = await get(scoped, "/v1/agent-configs", asTenant("list-one"));
+    const res = await get(app, "/v1/agent-configs?namespace=list-one");
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.data.map((c: { id: string }) => c.id).sort()).toEqual([...ids].sort());
     expect(body.hasMore).toBe(false);
     expect(body.lastId).toBe(body.data[2].id);
     // A listed row is the same row a get returns.
-    const one = await get(scoped, `/v1/agent-configs/${ids[0]}`, asTenant("list-one"));
+    const one = await get(app, `/v1/agent-configs/${ids[0]}?namespace=list-one`);
     expect(body.data).toContainEqual(await one.json());
   });
 
   it("pages with limit and after: the walk equals the whole list", async () => {
     await seed("list-page", 3);
-    const whole = await (await get(scoped, "/v1/agent-configs", asTenant("list-page"))).json();
+    const whole = await (await get(app, "/v1/agent-configs?namespace=list-page")).json();
 
-    const first = await (
-      await get(scoped, "/v1/agent-configs?limit=2", asTenant("list-page"))
-    ).json();
+    const first = await (await get(app, "/v1/agent-configs?namespace=list-page&limit=2")).json();
     expect(first.data).toHaveLength(2);
     expect(first.hasMore).toBe(true); // the over-fetched row, not a guess
     expect(first.lastId).toBe(first.data[1].id);
 
     const second = await (
-      await get(scoped, `/v1/agent-configs?limit=2&after=${first.lastId}`, asTenant("list-page"))
+      await get(app, `/v1/agent-configs?namespace=list-page&limit=2&after=${first.lastId}`)
     ).json();
     expect(second.data).toHaveLength(1);
     expect(second.hasMore).toBe(false);
@@ -142,20 +151,20 @@ describe("GET /v1/agent-configs", () => {
   });
 
   it("answers an empty namespace with an empty page and no cursor", async () => {
-    const body = await (await get(scoped, "/v1/agent-configs", asTenant("list-empty"))).json();
+    const body = await (await get(app, "/v1/agent-configs?namespace=list-empty")).json();
     expect(body).toEqual({ data: [], hasMore: false });
   });
 
   it("never crosses the namespace boundary", async () => {
     const mine = await seed("list-mine", 2);
     await seed("list-theirs", 1);
-    const body = await (await get(scoped, "/v1/agent-configs", asTenant("list-mine"))).json();
+    const body = await (await get(app, "/v1/agent-configs?namespace=list-mine")).json();
     expect(body.data.map((c: { id: string }) => c.id).sort()).toEqual([...mine].sort());
   });
 
   it("400s a limit outside the bounds and a non-numeric one", async () => {
     for (const q of ["limit=0", "limit=101", "limit=abc", "limit=1.5"]) {
-      const res = await get(scoped, `/v1/agent-configs?${q}`, asTenant("list-one"));
+      const res = await get(app, `/v1/agent-configs?namespace=list-one&${q}`);
       expect(res.status).toBe(400);
       expect((await res.json()).error.type).toBe("invalid_request_error");
     }
@@ -164,7 +173,7 @@ describe("GET /v1/agent-configs", () => {
   it("400s a cursor the store can't resolve — foreign like made-up", async () => {
     const [foreign] = await seed("list-cursor-b", 1);
     for (const after of ["nope", foreign]) {
-      const res = await get(scoped, `/v1/agent-configs?after=${after}`, asTenant("list-cursor-a"));
+      const res = await get(app, `/v1/agent-configs?namespace=list-cursor-a&after=${after}`);
       expect(res.status).toBe(400);
       expect((await res.json()).error.type).toBe("invalid_request_error");
     }
@@ -244,35 +253,23 @@ describe("POST /v1/agent-configs/:id", () => {
   });
 
   it("404s unknown and foreign ids without mutating the foreign config", async () => {
-    const asTenant = (tenant: string) => ({ "X-Funky-Namespace": tenant });
-    const unknown = await post(
-      scoped,
-      "/v1/agent-configs/nope",
-      { systemPrompt: "x" },
-      asTenant("update-a"),
-    );
+    const unknown = await post(app, "/v1/agent-configs/nope?namespace=update-a", {
+      systemPrompt: "x",
+    });
     expect(unknown.status).toBe(404);
 
-    const created = await (
-      await post(scoped, "/v1/agent-configs", recipeFor("update-a"), asTenant("update-a"))
-    ).json();
-    const foreign = await post(
-      scoped,
-      `/v1/agent-configs/${created.id}`,
-      { systemPrompt: "x", version: 1 },
-      asTenant("update-b"),
-    );
+    const created = await (await post(app, "/v1/agent-configs", recipeFor("update-a"))).json();
+    const foreign = await post(app, `/v1/agent-configs/${created.id}?namespace=update-b`, {
+      systemPrompt: "x",
+      version: 1,
+    });
     expect(foreign.status).toBe(404);
-    const own = await (
-      await get(scoped, `/v1/agent-configs/${created.id}`, asTenant("update-a"))
-    ).json();
+    const own = await (await get(app, `/v1/agent-configs/${created.id}?namespace=update-a`)).json();
     expect(own).toMatchObject({ systemPrompt: RECIPE.systemPrompt, version: 1 });
   });
 });
 
 describe("POST /v1/agent-configs/:id/archive", () => {
-  const asTenant = (tenant: string) => ({ "X-Funky-Namespace": tenant });
-
   it("archives the config and returns it with the mark, 200", async () => {
     const created = await (await post(app, "/v1/agent-configs", RECIPE)).json();
     const res = await post(app, `/v1/agent-configs/${created.id}/archive`);
@@ -307,25 +304,14 @@ describe("POST /v1/agent-configs/:id/archive", () => {
   });
 
   it("404s unknown and foreign ids without archiving the foreign config", async () => {
-    expect(
-      (await post(scoped, "/v1/agent-configs/nope/archive", undefined, asTenant("arch-a"))).status,
-    ).toBe(404);
+    expect((await post(app, "/v1/agent-configs/nope/archive?namespace=arch-a")).status).toBe(404);
 
-    const created = await (
-      await post(scoped, "/v1/agent-configs", recipeFor("arch-a"), asTenant("arch-a"))
-    ).json();
-    const foreign = await post(
-      scoped,
-      `/v1/agent-configs/${created.id}/archive`,
-      undefined,
-      asTenant("arch-b"),
-    );
+    const created = await (await post(app, "/v1/agent-configs", recipeFor("arch-a"))).json();
+    const foreign = await post(app, `/v1/agent-configs/${created.id}/archive?namespace=arch-b`);
     expect(foreign.status).toBe(404);
     expect((await foreign.json()).error.type).toBe("not_found_error");
 
-    const own = await (
-      await get(scoped, `/v1/agent-configs/${created.id}`, asTenant("arch-a"))
-    ).json();
+    const own = await (await get(app, `/v1/agent-configs/${created.id}?namespace=arch-a`)).json();
     expect("archivedAt" in own).toBe(false);
   });
 });
@@ -338,16 +324,13 @@ describe("GET /v1/agent-configs/:id", () => {
   });
 
   it("scopes by namespace: a foreign row 404s exactly like a nonexistent one", async () => {
-    const asTenant = (tenant: string) => ({ "X-Funky-Namespace": tenant });
-    const created = await (
-      await post(scoped, "/v1/agent-configs", recipeFor("tenant-a"), asTenant("tenant-a"))
-    ).json();
-    expect(created.namespace).toBe("tenant-a");
+    const created = await (await post(app, "/v1/agent-configs", recipeFor("tenant-a"))).json();
 
-    const foreign = await get(scoped, `/v1/agent-configs/${created.id}`, asTenant("tenant-b"));
+    const foreign = await get(app, `/v1/agent-configs/${created.id}?namespace=tenant-b`);
     expect(foreign.status).toBe(404);
 
-    const own = await get(scoped, `/v1/agent-configs/${created.id}`, asTenant("tenant-a"));
+    const own = await get(app, `/v1/agent-configs/${created.id}?namespace=tenant-a`);
     expect(own.status).toBe(200);
+    expect((await own.json()).namespace).toBe("tenant-a");
   });
 });

--- a/apps/api/test/config.test.ts
+++ b/apps/api/test/config.test.ts
@@ -29,7 +29,6 @@ describe("loadConfig — valid input", () => {
       port: 3000,
       dbPoolMax: 10,
       authToken: BASE.FUNKY_AUTH_TOKEN,
-      namespaceSource: "static",
       streamPollMs: 1000,
       streamHeartbeatMs: 15_000,
     });
@@ -48,13 +47,6 @@ describe("loadConfig — valid input", () => {
   it("FUNKY_AUTH=disabled yields a null token (and no token required)", () => {
     const cfg = loadConfig({ DATABASE_URL: BASE.DATABASE_URL, FUNKY_AUTH: "disabled" });
     expect(cfg.authToken).toBeNull();
-  });
-
-  it("namespace source defaults to static and parses header", () => {
-    expect(loadConfig(BASE).namespaceSource).toBe("static");
-    expect(loadConfig({ ...BASE, FUNKY_NAMESPACE_SOURCE: "header" }).namespaceSource).toBe(
-      "header",
-    );
   });
 });
 
@@ -80,16 +72,6 @@ describe("loadConfig — invalid input", () => {
         ...BASE,
         FUNKY_STREAM_POLL_MS: "60000",
         FUNKY_STREAM_HEARTBEAT_MS: "15000",
-      }),
-    ).toThrow("process.exit(1)");
-  });
-
-  it("exits when the header source is combined with disabled auth", () => {
-    expect(() =>
-      loadConfig({
-        DATABASE_URL: BASE.DATABASE_URL,
-        FUNKY_AUTH: "disabled",
-        FUNKY_NAMESPACE_SOURCE: "header",
       }),
     ).toThrow("process.exit(1)");
   });

--- a/apps/api/test/env-configs.test.ts
+++ b/apps/api/test/env-configs.test.ts
@@ -1,6 +1,10 @@
 // Route tests over the REAL store — PGlite + the pg adapter, the same
 // binding the driver suites use — so materialization (defaults resolved
 // at create) is asserted end to end, never mocked.
+//
+// Namespace is part of the request: create bodies carry it, every other
+// route takes ?namespace= — and in both spots absence defaults to
+// "default" (common.ts NamespaceQuery).
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -11,16 +15,17 @@ import { get, post } from "./helpers";
 
 let client: PGlite;
 let app: ReturnType<typeof buildApp>;
-let scoped: ReturnType<typeof buildApp>; // namespaceSource "header" over the SAME store
 
 beforeAll(async () => {
   client = new PGlite();
   await client.exec(storeDdl);
   const store = createPgStore(drizzle({ client }) as unknown as StoreDb);
-  const base = { store, authToken: null, ping: async () => ({}) };
-  const stream = { pollMs: 1000, heartbeatMs: 15_000 };
-  app = buildApp({ ...base, namespaceSource: "static", stream });
-  scoped = buildApp({ ...base, namespaceSource: "header", stream });
+  app = buildApp({
+    store,
+    authToken: null,
+    ping: async () => ({}),
+    stream: { pollMs: 1000, heartbeatMs: 15_000 },
+  });
 });
 
 afterAll(async () => {
@@ -67,9 +72,26 @@ describe("POST /v1/env-configs", () => {
     expect(body.error.type).toBe("invalid_request_error");
   });
 
-  it("requires a namespace", async () => {
+  it("defaults the namespace when the body omits it", async () => {
     const res = await post(app, "/v1/env-configs", {});
+    expect(res.status).toBe(201);
+    expect((await res.json()).namespace).toBe("default");
+  });
+
+  it("rejects an empty namespace — absence defaults, emptiness is a mistake", async () => {
+    const res = await post(app, "/v1/env-configs", { namespace: "" });
     expect(res.status).toBe(400);
+  });
+
+  // Namespace is a PK component on every table; without the format
+  // bound an oversized value overflows the btree tuple limit and
+  // surfaces as a 500 instead of this 400.
+  it("rejects a malformed namespace, 400 — oversized or bad characters", async () => {
+    for (const namespace of ["x".repeat(65), "tenant a", "tenant/../b"]) {
+      const res = await post(app, "/v1/env-configs", { namespace });
+      expect(res.status).toBe(400);
+      expect((await res.json()).error.type).toBe("invalid_request_error");
+    }
   });
 });
 
@@ -77,34 +99,23 @@ describe("GET /v1/env-configs", () => {
   // The pagination machinery itself (limit bounds, over-fetched
   // hasMore, the page walk) is pinned in agent-configs.test.ts, which
   // shares it; here we pin this resource's own wiring.
-  const asTenant = (tenant: string) => ({ "X-Funky-Namespace": tenant });
 
   it("lists env configs only — the two config kinds are separate collections", async () => {
     const created = await (
-      await post(
-        scoped,
-        "/v1/env-configs",
-        { namespace: "list-env", packages: { npm: ["zod@4"] } },
-        asTenant("list-env"),
-      )
+      await post(app, "/v1/env-configs", { namespace: "list-env", packages: { npm: ["zod@4"] } })
     ).json();
-    await post(
-      scoped,
-      "/v1/agent-configs",
-      {
-        namespace: "list-env",
-        inference: { provider: "fake", model: "m" },
-        systemPrompt: "s",
-      },
-      asTenant("list-env"),
-    );
+    await post(app, "/v1/agent-configs", {
+      namespace: "list-env",
+      inference: { provider: "fake", model: "m" },
+      systemPrompt: "s",
+    });
 
-    const res = await get(scoped, "/v1/env-configs", asTenant("list-env"));
+    const res = await get(app, "/v1/env-configs?namespace=list-env");
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ data: [created], hasMore: false, lastId: created.id });
   });
 
-  it("is wired on the static namespace source too", async () => {
+  it("defaults the namespace when the query omits it", async () => {
     const created = await (await post(app, "/v1/env-configs", { namespace: "default" })).json();
     const body = await (await get(app, "/v1/env-configs?limit=100")).json();
     expect(body.data).toContainEqual(created);
@@ -114,10 +125,8 @@ describe("GET /v1/env-configs", () => {
   });
 
   it("400s a cursor from another namespace", async () => {
-    const foreign = await (
-      await post(scoped, "/v1/env-configs", { namespace: "env-cur-b" }, asTenant("env-cur-b"))
-    ).json();
-    const res = await get(scoped, `/v1/env-configs?after=${foreign.id}`, asTenant("env-cur-a"));
+    const foreign = await (await post(app, "/v1/env-configs", { namespace: "env-cur-b" })).json();
+    const res = await get(app, `/v1/env-configs?namespace=env-cur-a&after=${foreign.id}`);
     expect(res.status).toBe(400);
     expect((await res.json()).error.type).toBe("invalid_request_error");
   });
@@ -133,8 +142,6 @@ describe("GET /v1/env-configs/:id", () => {
 });
 
 describe("POST /v1/env-configs/:id", () => {
-  const asTenant = (tenant: string) => ({ "X-Funky-Namespace": tenant });
-
   it("partially updates the recipe in place", async () => {
     const created = await (
       await post(app, "/v1/env-configs", {
@@ -174,71 +181,49 @@ describe("POST /v1/env-configs/:id", () => {
   });
 
   it("404s unknown and foreign ids without mutating the foreign config", async () => {
-    const unknown = await post(
-      scoped,
-      "/v1/env-configs/nope",
-      { packages: { npm: ["zod"] } },
-      asTenant("update-a"),
-    );
+    const unknown = await post(app, "/v1/env-configs/nope?namespace=update-a", {
+      packages: { npm: ["zod"] },
+    });
     expect(unknown.status).toBe(404);
 
     const created = await (
-      await post(
-        scoped,
-        "/v1/env-configs",
-        { namespace: "update-a", packages: { pip: ["numpy"] } },
-        asTenant("update-a"),
-      )
+      await post(app, "/v1/env-configs", { namespace: "update-a", packages: { pip: ["numpy"] } })
     ).json();
-    const foreign = await post(
-      scoped,
-      `/v1/env-configs/${created.id}`,
-      { packages: { npm: ["zod"] } },
-      asTenant("update-b"),
-    );
+    const foreign = await post(app, `/v1/env-configs/${created.id}?namespace=update-b`, {
+      packages: { npm: ["zod"] },
+    });
     expect(foreign.status).toBe(404);
-    const own = await (
-      await get(scoped, `/v1/env-configs/${created.id}`, asTenant("update-a"))
-    ).json();
+    const own = await (await get(app, `/v1/env-configs/${created.id}?namespace=update-a`)).json();
     expect(own.packages).toEqual({ pip: ["numpy"] });
   });
 });
 
-describe("namespace scoping (namespaceSource=header — the managed-gateway shape)", () => {
-  const asTenant = (tenant: string) => ({ "X-Funky-Namespace": tenant });
-
-  it("uses the namespace supplied in the request", async () => {
-    const res = await post(
-      scoped,
-      "/v1/env-configs",
-      { namespace: "tenant-b" },
-      asTenant("tenant-a"),
-    );
+describe("namespace scoping", () => {
+  it("creates in the namespace the request names and scopes reads by the query", async () => {
+    const res = await post(app, "/v1/env-configs", { namespace: "tenant-a" });
     expect(res.status).toBe(201);
-    expect((await res.json()).namespace).toBe("tenant-b");
+    const created = await res.json();
+    expect(created.namespace).toBe("tenant-a");
+    expect((await get(app, `/v1/env-configs/${created.id}?namespace=tenant-a`)).status).toBe(200);
+    expect((await get(app, `/v1/env-configs/${created.id}?namespace=tenant-b`)).status).toBe(404);
   });
 
   it("a foreign row 404s exactly like a nonexistent one", async () => {
-    const created = await (
-      await post(scoped, "/v1/env-configs", { namespace: "tenant-a" }, asTenant("tenant-a"))
-    ).json();
+    const created = await (await post(app, "/v1/env-configs", { namespace: "tenant-a" })).json();
 
-    const foreign = await get(scoped, `/v1/env-configs/${created.id}`, asTenant("tenant-b"));
+    const foreign = await get(app, `/v1/env-configs/${created.id}?namespace=tenant-b`);
     expect(foreign.status).toBe(404);
     expect((await foreign.json()).error.type).toBe("not_found_error");
 
-    const own = await get(scoped, `/v1/env-configs/${created.id}`, asTenant("tenant-a"));
+    const own = await get(app, `/v1/env-configs/${created.id}?namespace=tenant-a`);
     expect(own.status).toBe(200);
     expect((await own.json()).namespace).toBe("tenant-a");
   });
 
-  it("rejects a malformed namespace header", async () => {
-    const res = await post(
-      scoped,
-      "/v1/env-configs",
-      { namespace: "tenant-a" },
-      asTenant("no spaces allowed"),
-    );
-    expect(res.status).toBe(400);
+  it("400s an empty or malformed namespace in the query", async () => {
+    for (const namespace of ["", "x".repeat(65), "tenant%20a"]) {
+      const res = await get(app, `/v1/env-configs/some-id?namespace=${namespace}`);
+      expect(res.status).toBe(400);
+    }
   });
 });

--- a/apps/api/test/helpers.ts
+++ b/apps/api/test/helpers.ts
@@ -2,18 +2,14 @@
 // + app.request(), exactly as app.ts advertises.
 import type { Store } from "@funky/agent";
 import { buildApp } from "../src/app";
-import type { NamespaceSource } from "../src/config";
 
 export type App = ReturnType<typeof buildApp>;
 
 /** An app whose store is never reached — for envelope/auth/health tests. */
-export function makeApp(
-  opts: { authToken?: string | null; namespaceSource?: NamespaceSource } = {},
-): App {
+export function makeApp(opts: { authToken?: string | null } = {}): App {
   return buildApp({
     store: {} as unknown as Store,
     authToken: opts.authToken ?? null,
-    namespaceSource: opts.namespaceSource ?? "static",
     ping: async () => ({}),
     stream: { pollMs: 1000, heartbeatMs: 15_000 },
   });

--- a/apps/api/test/sessions.test.ts
+++ b/apps/api/test/sessions.test.ts
@@ -12,7 +12,6 @@ import { get, post } from "./helpers";
 
 let client: PGlite;
 let app: ReturnType<typeof buildApp>;
-let scoped: ReturnType<typeof buildApp>; // namespaceSource "header" over the SAME store
 let heartbeatApp: ReturnType<typeof buildApp>; // heartbeat fires within a test's patience
 
 // Fast enough that stream tests never wait on the poll; a heartbeat
@@ -25,45 +24,37 @@ beforeAll(async () => {
   await client.exec(storeDdl);
   const store = createPgStore(drizzle({ client }) as unknown as StoreDb);
   const base = { store, authToken: null, ping: async () => ({}) };
-  app = buildApp({ ...base, namespaceSource: "static", stream: PACING });
-  scoped = buildApp({ ...base, namespaceSource: "header", stream: PACING });
-  heartbeatApp = buildApp({
-    ...base,
-    namespaceSource: "static",
-    stream: { pollMs: 10, heartbeatMs: 25 },
-  });
+  app = buildApp({ ...base, stream: PACING });
+  heartbeatApp = buildApp({ ...base, stream: { pollMs: 10, heartbeatMs: 25 } });
 });
 
 afterAll(async () => {
   await client.close();
 });
 
-const asTenant = (tenant: string) => ({ "X-Funky-Namespace": tenant });
-
-/** Seed the two configs over HTTP; returns their ids. */
+/** Seed the two configs over HTTP; returns their ids. Namespace is part
+ *  of the request: it rides in the create bodies. */
 async function seedConfigs(
   on: ReturnType<typeof buildApp>,
-  headers: Record<string, string> = {},
+  namespace = "default",
 ): Promise<{ agentConfigId: string; envConfigId: string }> {
-  const namespace = headers["X-Funky-Namespace"] ?? "default";
   const agent = await (
-    await post(
-      on,
-      "/v1/agent-configs",
-      { namespace, inference: { provider: "fake", model: "m" }, systemPrompt: "s" },
-      headers,
-    )
+    await post(on, "/v1/agent-configs", {
+      namespace,
+      inference: { provider: "fake", model: "m" },
+      systemPrompt: "s",
+    })
   ).json();
-  const env = await (await post(on, "/v1/env-configs", { namespace }, headers)).json();
+  const env = await (await post(on, "/v1/env-configs", { namespace })).json();
   return { agentConfigId: agent.id, envConfigId: env.id };
 }
 
 async function seedSession(
   on: ReturnType<typeof buildApp>,
-  headers: Record<string, string> = {},
+  namespace = "default",
 ): Promise<string> {
-  const configs = await seedConfigs(on, headers);
-  const res = await post(on, "/v1/sessions", configs, headers);
+  const configs = await seedConfigs(on, namespace);
+  const res = await post(on, "/v1/sessions", { namespace, ...configs });
   expect(res.status).toBe(201);
   return (await res.json()).id;
 }
@@ -71,7 +62,11 @@ async function seedSession(
 describe("POST /v1/sessions", () => {
   it("creates and returns the materialized session, 201", async () => {
     const configs = await seedConfigs(app);
-    const res = await post(app, "/v1/sessions", { ...configs, agentConfigVersion: 1 });
+    const res = await post(app, "/v1/sessions", {
+      namespace: "default",
+      ...configs,
+      agentConfigVersion: 1,
+    });
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.agentConfigId).toBe(configs.agentConfigId);
@@ -81,28 +76,44 @@ describe("POST /v1/sessions", () => {
     expect(typeof body.id).toBe("string");
   });
 
+  it("defaults the namespace when the body omits it", async () => {
+    const configs = await seedConfigs(app);
+    const res = await post(app, "/v1/sessions", configs);
+    expect(res.status).toBe(201);
+    expect((await res.json()).namespace).toBe("default");
+  });
+
   it("400s a dangling config reference", async () => {
     const { envConfigId } = await seedConfigs(app);
-    const res = await post(app, "/v1/sessions", { agentConfigId: "nope", envConfigId });
+    const res = await post(app, "/v1/sessions", {
+      namespace: "default",
+      agentConfigId: "nope",
+      envConfigId,
+    });
     expect(res.status).toBe(400);
     expect((await res.json()).error.type).toBe("invalid_request_error");
   });
 
   it("400s an unknown agent config version", async () => {
     const configs = await seedConfigs(app);
-    const res = await post(app, "/v1/sessions", { ...configs, agentConfigVersion: 2 });
+    const res = await post(app, "/v1/sessions", {
+      namespace: "default",
+      ...configs,
+      agentConfigVersion: 2,
+    });
     expect(res.status).toBe(400);
     expect((await res.json()).error.type).toBe("invalid_request_error");
   });
 
   it("409s an archived agent config, while sessions already on it keep working", async () => {
     const configs = await seedConfigs(app);
-    const sessionId = (await (await post(app, "/v1/sessions", configs)).json()).id;
+    const create = { namespace: "default", ...configs };
+    const sessionId = (await (await post(app, "/v1/sessions", create)).json()).id;
     expect((await post(app, `/v1/agent-configs/${configs.agentConfigId}/archive`)).status).toBe(
       200,
     );
 
-    const res = await post(app, "/v1/sessions", configs);
+    const res = await post(app, "/v1/sessions", create);
     expect(res.status).toBe(409);
     expect((await res.json()).error.type).toBe("conflict_error");
 
@@ -113,8 +124,8 @@ describe("POST /v1/sessions", () => {
   });
 
   it("400s a foreign-namespace config identically to a dangling one", async () => {
-    const configs = await seedConfigs(scoped, asTenant("tenant-a"));
-    const res = await post(scoped, "/v1/sessions", configs, asTenant("tenant-b"));
+    const configs = await seedConfigs(app, "tenant-a");
+    const res = await post(app, "/v1/sessions", { namespace: "tenant-b", ...configs });
     expect(res.status).toBe(400);
     expect((await res.json()).error.message).toMatch(/^unknown /);
   });
@@ -124,9 +135,9 @@ describe("GET /v1/sessions/:id", () => {
   it("404s unknown and foreign sessions alike", async () => {
     expect((await get(app, "/v1/sessions/nope")).status).toBe(404);
 
-    const sessionId = await seedSession(scoped, asTenant("tenant-a"));
-    expect((await get(scoped, `/v1/sessions/${sessionId}`, asTenant("tenant-b"))).status).toBe(404);
-    expect((await get(scoped, `/v1/sessions/${sessionId}`, asTenant("tenant-a"))).status).toBe(200);
+    const sessionId = await seedSession(app, "tenant-a");
+    expect((await get(app, `/v1/sessions/${sessionId}?namespace=tenant-b`)).status).toBe(404);
+    expect((await get(app, `/v1/sessions/${sessionId}?namespace=tenant-a`)).status).toBe(200);
   });
 });
 
@@ -205,13 +216,8 @@ describe("POST /v1/sessions/:id/cancel", () => {
   });
 
   it("404s a foreign session", async () => {
-    const sessionId = await seedSession(scoped, asTenant("tenant-a"));
-    const res = await post(
-      scoped,
-      `/v1/sessions/${sessionId}/cancel`,
-      undefined,
-      asTenant("tenant-b"),
-    );
+    const sessionId = await seedSession(app, "tenant-a");
+    const res = await post(app, `/v1/sessions/${sessionId}/cancel?namespace=tenant-b`);
     expect(res.status).toBe(404);
   });
 });
@@ -309,8 +315,8 @@ describe("GET /v1/sessions/:id/stream", () => {
   });
 
   it("404s a foreign session before any byte streams", async () => {
-    const sessionId = await seedSession(scoped, asTenant("tenant-a"));
-    const res = await get(scoped, `/v1/sessions/${sessionId}/stream`, asTenant("tenant-b"));
+    const sessionId = await seedSession(app, "tenant-a");
+    const res = await get(app, `/v1/sessions/${sessionId}/stream?namespace=tenant-b`);
     expect(res.status).toBe(404);
   });
 

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -39,16 +39,14 @@ const deps: DriverDeps = {
   toolSpecs: sandboxToolSpecs,
   // Ensure-on-claim: the loop calls this only for an execute_tools item
   // that will actually execute. The session's env config is the sandbox
-  // recipe — its resolved network policy rides into create.
-  bindTools: async (sessionId) => {
-    const session = await store.getSession(sessionId);
-    if (!session) throw new Error(`worker: unknown session ${sessionId}`);
-    const env = await store.getEnvConfig({
-      namespace: session.namespace,
-      id: session.envConfigId,
-    });
-    if (!env) throw new Error(`worker: session ${sessionId} has no env config`);
-    const sandbox = await ensureSandbox(store, sandboxes, sessionId, {
+  // recipe — its resolved network policy rides into create. The session
+  // row is its own ref, and structurally contains its env config's.
+  bindTools: async (ref) => {
+    const session = await store.getSession(ref);
+    if (!session) throw new Error(`worker: unknown session ${ref.sessionId}`);
+    const env = await store.getEnvConfig(session);
+    if (!env) throw new Error(`worker: session ${ref.sessionId} has no env config`);
+    const sandbox = await ensureSandbox(store, sandboxes, ref, {
       timeoutMs: cfg.sandboxTimeoutMs,
       network: env.network,
     });

--- a/apps/worker/test/e2e.test.ts
+++ b/apps/worker/test/e2e.test.ts
@@ -27,7 +27,7 @@ import {
   DEFAULT_NAMESPACE,
   type AgentMessage,
   type SessionEntry,
-  type SessionId,
+  type SessionRef,
 } from "@funky/core";
 import { createE2bProvider, createPgStore, type StoreDb } from "@funky/adapters";
 import { storeDdl } from "../../../packages/adapters/test/store-ddl";
@@ -52,7 +52,7 @@ if (!url || !anthropicKey || !e2bKey) {
   const LEASE_MS = 3_000;
 
   const workers: ChildProcess[] = [];
-  const sessions: SessionId[] = [];
+  const sessions: SessionRef[] = [];
 
   beforeAll(async () => {
     await pool.query("DROP SCHEMA public CASCADE; CREATE SCHEMA public;");
@@ -64,8 +64,8 @@ if (!url || !anthropicKey || !e2bKey) {
       if (worker.exitCode === null && worker.signalCode === null) worker.kill("SIGKILL");
     }
     // Orphan hygiene: kill the sandboxes the runs created.
-    for (const sessionId of sessions) {
-      const session = await store.getSession(sessionId);
+    for (const sessionRef of sessions) {
+      const session = await store.getSession(sessionRef);
       if (!session?.sandboxId) continue;
       await sandboxes
         .connect(session.sandboxId)
@@ -103,7 +103,7 @@ if (!url || !anthropicKey || !e2bKey) {
     return worker;
   }
 
-  async function seedSession(task: string): Promise<SessionId> {
+  async function seedSession(task: string): Promise<SessionRef> {
     const agentConfigRef = await store.createAgentConfig({
       namespace: DEFAULT_NAMESPACE,
       inference: {
@@ -117,17 +117,18 @@ if (!url || !anthropicKey || !e2bKey) {
         "the execution was interrupted, issue that call again.",
     });
     const envConfigRef = await store.createEnvConfig({ namespace: DEFAULT_NAMESPACE });
-    const sessionId = await store.createSession({
-      agentConfigId: agentConfigRef.id,
-      envConfigId: envConfigRef.id,
+    const sessionRef = await store.createSession({
+      namespace: DEFAULT_NAMESPACE,
+      agentConfigId: agentConfigRef.agentConfigId,
+      envConfigId: envConfigRef.envConfigId,
     });
-    sessions.push(sessionId);
-    const result = await store.intake(sessionId, {
+    sessions.push(sessionRef);
+    const result = await store.intake(sessionRef, {
       role: "user",
       content: [{ type: "text", text: task }],
     });
     expect(result.kind).toBe("started");
-    return sessionId;
+    return sessionRef;
   }
 
   const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
@@ -146,8 +147,8 @@ if (!url || !anthropicKey || !e2bKey) {
   }
 
   // A run's end is the atomic NON-creation of a next item: all items done.
-  async function runFinished(sessionId: SessionId): Promise<boolean> {
-    const items = await store.listItems(sessionId);
+  async function runFinished(sessionRef: SessionRef): Promise<boolean> {
+    const items = await store.listItems(sessionRef);
     return items.length > 0 && items.every((item) => item.status === "done");
   }
 
@@ -175,19 +176,19 @@ if (!url || !anthropicKey || !e2bKey) {
       "drives a real tool task end to end through the forked worker",
       { timeout: 180_000 },
       async () => {
-        const sessionId = await seedSession(
+        const sessionRef = await seedSession(
           "Create a file at /home/user/hello.txt containing exactly: hello funky",
         );
         const worker = forkWorker();
         try {
-          await waitFor(() => runFinished(sessionId), 150_000, "the run to finish");
+          await waitFor(() => runFinished(sessionRef), 150_000, "the run to finish");
         } finally {
           // Claims have no session filter: a worker that outlives its test
           // would steal the next test's items.
           await killWorker(worker);
         }
 
-        const entries = await store.readEntries(sessionId);
+        const entries = await store.readEntries(sessionRef);
         assertEveryCallResolvedOnce(entries);
         const msgs = messages(entries);
         const tail = msgs[msgs.length - 1];
@@ -197,7 +198,7 @@ if (!url || !anthropicKey || !e2bKey) {
 
         // The workspace really changed: read the file back through the
         // provider, via the binding the driver registered.
-        const session = await store.getSession(sessionId);
+        const session = await store.getSession(sessionRef);
         if (!session?.sandboxId) throw new Error("no sandbox bound to the session");
         const sandbox = await sandboxes.connect(session.sandboxId);
         const bytes = await sandbox.readFile("/home/user/hello.txt");
@@ -212,7 +213,7 @@ if (!url || !anthropicKey || !e2bKey) {
         // The sleep is the kill window: an execute_tools item stays leased
         // for its whole duration, so the parent reliably lands the SIGKILL
         // while tools are (or are about to be) executing.
-        const sessionId = await seedSession(
+        const sessionRef = await seedSession(
           "First run the bash command `sleep 15`. Then create a file at " +
             "/home/user/done.txt containing exactly: recovered",
         );
@@ -221,7 +222,7 @@ if (!url || !anthropicKey || !e2bKey) {
         const first = forkWorker();
         await waitFor(
           async () => {
-            const items = await store.listItems(sessionId);
+            const items = await store.listItems(sessionRef);
             return items.some((item) => item.type === "execute_tools" && item.status === "leased");
           },
           120_000,
@@ -231,16 +232,16 @@ if (!url || !anthropicKey || !e2bKey) {
 
         const resume = forkWorker();
         try {
-          await waitFor(() => runFinished(sessionId), 240_000, "the resumed run to finish");
+          await waitFor(() => runFinished(sessionRef), 240_000, "the resumed run to finish");
         } finally {
           await killWorker(resume);
         }
 
-        const entries = await store.readEntries(sessionId);
+        const entries = await store.readEntries(sessionRef);
         assertEveryCallResolvedOnce(entries);
         // The carve-out ran: the killed batch was re-claimed, not re-executed —
         // its calls settled as synthesized interrupted results.
-        const items = await store.listItems(sessionId);
+        const items = await store.listItems(sessionRef);
         expect(items.some((item) => item.type === "execute_tools" && item.attempt > 1)).toBe(true);
         const msgs = messages(entries);
         expect(
@@ -378,7 +379,9 @@ if (!url || !anthropicKey || !e2bKey) {
             agentConfigId: agent.id,
             envConfigId: env.id,
           });
-          sessions.push(session.id);
+          // The wire echoes namespace, so the response rebuilds the ref
+          // (apiJson returns any — nothing checks this line but us).
+          sessions.push({ namespace: session.namespace, sessionId: session.id });
           const started = await apiJson("POST", `/v1/sessions/${session.id}/messages`, {
             content:
               "First run the bash command `sleep 15`. Then create a file at " +

--- a/packages/adapters/migrations/20260820000000_init/migration.sql
+++ b/packages/adapters/migrations/20260820000000_init/migration.sql
@@ -8,13 +8,21 @@
 -- database exists that this cannot be re-derived on, changes become
 -- incremental migrations beside this file and it stops being edited.
 
--- namespace: the tenancy boundary (core/store.ts). Only the three
--- ownable row types carry it; children derive theirs through
--- session_id. No SQL DEFAULT — the adapter materializes the value, so
--- the resolution lives in exactly one place.
+-- namespace: the tenancy boundary (core/store.ts). Every table carries
+-- it — the ownable rows because ownership is a fact on them, the
+-- children (versions, entries, work items, pending inputs) as a copy
+-- from their parent, made structural by composite FKs so it can never
+-- diverge. No SQL DEFAULT — the caller supplies the value on every
+-- create, so no resolution exists here at all.
+--
+-- Every table is keyed by its full path, namespace leading: point reads
+-- arrive ref-scoped, so the PK serves them directly, and namespace is
+-- the partition key the future PARTITION BY needs on every table (a
+-- partitioned table's PK and unique indexes must include the partition
+-- column — which is also why no bare-id UNIQUE exists anywhere).
 CREATE TABLE agent_configs (
-  id text PRIMARY KEY,
   namespace text NOT NULL,
+  id text NOT NULL,
   -- Pointer to the latest snapshot in agent_config_versions. Bumping it
   -- is the update path's lock and its optional compare-and-set.
   current_version integer NOT NULL,
@@ -22,57 +30,69 @@ CREATE TABLE agent_configs (
   -- The terminal state, set once and never cleared. NULL is not a
   -- toggle's off position — there is no unarchive — it is the absence
   -- of the archive event.
-  archived_at timestamptz
+  archived_at timestamptz,
+  PRIMARY KEY (namespace, id)
 );
 
 -- Every mutation appends one immutable snapshot, and a session pins one,
 -- so a later update can never change a running session's behavior.
 CREATE TABLE agent_config_versions (
-  agent_config_id text NOT NULL REFERENCES agent_configs(id),
+  namespace text NOT NULL,
+  agent_config_id text NOT NULL,
   version integer NOT NULL,
   inference jsonb NOT NULL,
   system_prompt text NOT NULL,
   metadata jsonb,
   updated_at timestamptz NOT NULL,
-  PRIMARY KEY (agent_config_id, version)
+  -- The PK is the AgentConfigVersionRef verbatim.
+  PRIMARY KEY (namespace, agent_config_id, version),
+  FOREIGN KEY (namespace, agent_config_id) REFERENCES agent_configs (namespace, id)
 );
 
 CREATE TABLE env_configs (
-  id text PRIMARY KEY,
+  namespace text NOT NULL,
+  id text NOT NULL,
   network jsonb NOT NULL,
   packages jsonb NOT NULL,
-  namespace text NOT NULL,
   metadata jsonb,
-  created_at timestamptz NOT NULL
+  created_at timestamptz NOT NULL,
+  PRIMARY KEY (namespace, id)
 );
 
 CREATE TABLE sessions (
-  id text PRIMARY KEY,
+  namespace text NOT NULL,
+  id text NOT NULL,
   agent_config_id text NOT NULL,
   -- Resolved from the agent's latest version at session creation; the
   -- composite FK below makes that behavior snapshot durable.
   agent_config_version integer NOT NULL,
-  env_config_id text NOT NULL REFERENCES env_configs(id),
-  namespace text NOT NULL,
+  env_config_id text NOT NULL,
   -- The session's one workspace; null until the driver's first
   -- execute_tools claim registers it (Store.bindSandbox, set-if-null).
   sandbox_id text,
   metadata jsonb,
   created_at timestamptz NOT NULL,
-  FOREIGN KEY (agent_config_id, agent_config_version)
-    REFERENCES agent_config_versions (agent_config_id, version)
+  PRIMARY KEY (namespace, id),
+  -- Same-namespace, structural, on both references: the pinned version
+  -- and the env recipe must live in the session's own namespace.
+  FOREIGN KEY (namespace, agent_config_id, agent_config_version)
+    REFERENCES agent_config_versions (namespace, agent_config_id, version),
+  FOREIGN KEY (namespace, env_config_id) REFERENCES env_configs (namespace, id)
 );
 
 CREATE TABLE session_entries (
-  session_id text NOT NULL REFERENCES sessions(id),
+  namespace text NOT NULL,
+  session_id text NOT NULL,
   seq integer NOT NULL,
   entry jsonb NOT NULL,
-  PRIMARY KEY (session_id, seq)
+  PRIMARY KEY (namespace, session_id, seq),
+  FOREIGN KEY (namespace, session_id) REFERENCES sessions (namespace, id)
 );
 
 CREATE TABLE work_items (
-  id text PRIMARY KEY,
-  session_id text NOT NULL REFERENCES sessions(id),
+  namespace text NOT NULL,
+  session_id text NOT NULL,
+  id text NOT NULL,
   type text NOT NULL,
   status text NOT NULL,
   lease_token text,
@@ -81,19 +101,39 @@ CREATE TABLE work_items (
   -- Times claimed (claimItem increments). The driver's at-most-once
   -- guard for tool side effects keys on attempt > 1.
   attempt integer NOT NULL DEFAULT 0,
-  created_at timestamptz NOT NULL
+  created_at timestamptz NOT NULL,
+  -- The PK is the WorkItemRef verbatim — the full path to the row; the
+  -- (namespace, session_id) prefix indexes the session-scoped scans.
+  PRIMARY KEY (namespace, session_id, id),
+  FOREIGN KEY (namespace, session_id) REFERENCES sessions (namespace, id)
 );
 
 -- The one-open-item invariant: at most one non-done item per session.
+-- Carries the partition key like every unique index here; per-session
+-- uniqueness still holds because session ids are store-minted UUIDs.
 CREATE UNIQUE INDEX work_items_one_open_per_session
-  ON work_items (session_id) WHERE status <> 'done';
-CREATE INDEX work_items_claim_scan ON work_items (status, created_at);
+  ON work_items (namespace, session_id) WHERE status <> 'done';
+-- The claim scan's index: partial, so the unbounded done majority never
+-- enters it — the index stays sized to live work, and a poll is one
+-- ordered walk that stops at the first claimable row. The claim query
+-- repeats this exact predicate so the planner's implication proof is
+-- trivial. Deliberately namespace-free: the claim scan is the worker
+-- pool's cross-tenant read.
+CREATE INDEX work_items_claim_scan
+  ON work_items (created_at) WHERE status <> 'done';
 
 CREATE TABLE pending_inputs (
-  session_id text NOT NULL REFERENCES sessions(id),
+  namespace text NOT NULL,
+  session_id text NOT NULL,
+  -- The port-level name — what consumeInputs targets. In the PK, so
+  -- an input id is unique within its session by construction.
+  id text NOT NULL,
+  -- Drain order — arrival order even under equal timestamps. A global
+  -- bigserial, gappy and never per-session dense: plumbing, not
+  -- contract. Reads scan the PK prefix and order by it.
   ord bigserial,
-  id text NOT NULL UNIQUE,
   message jsonb NOT NULL,
   arrived_at timestamptz NOT NULL,
-  PRIMARY KEY (session_id, ord)
+  PRIMARY KEY (namespace, session_id, id),
+  FOREIGN KEY (namespace, session_id) REFERENCES sessions (namespace, id)
 );

--- a/packages/adapters/src/store/pg.ts
+++ b/packages/adapters/src/store/pg.ts
@@ -38,7 +38,6 @@ import {
   CreateAgentConfigRequest,
   CreateEnvConfigRequest,
   CreateSessionRequest,
-  DEFAULT_NAMESPACE,
   EnvConfig,
   EnvConfigRef,
   IntakeResult,
@@ -48,10 +47,12 @@ import {
   PendingInput,
   Session,
   SessionEntry,
+  SessionRef,
   UpdateAgentConfigRequest,
   UpdateEnvConfigRequest,
   UserMessage,
   WorkItem,
+  WorkItemRef,
 } from "@funky/core";
 import {
   ArchivedError,
@@ -105,13 +106,14 @@ const agentConfigColumns = {
 };
 
 const currentAgentVersion = and(
+  eq(agentConfigVersions.namespace, agentConfigs.namespace),
   eq(agentConfigVersions.agentConfigId, agentConfigs.id),
   eq(agentConfigVersions.version, agentConfigs.currentVersion),
 );
 
 const toAgentConfig = (row: AgentConfigRow): AgentConfig =>
   AgentConfig.parse({
-    id: row.id,
+    agentConfigId: row.id,
     inference: row.inference,
     systemPrompt: row.systemPrompt,
     namespace: row.namespace,
@@ -125,7 +127,7 @@ const toAgentConfig = (row: AgentConfigRow): AgentConfig =>
 
 const toEnvConfig = (row: typeof envConfigs.$inferSelect): EnvConfig =>
   EnvConfig.parse({
-    id: row.id,
+    envConfigId: row.id,
     network: row.network,
     packages: row.packages,
     namespace: row.namespace,
@@ -136,13 +138,13 @@ const toEnvConfig = (row: typeof envConfigs.$inferSelect): EnvConfig =>
 export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
   const now = opts.now ?? (() => new Date());
 
-  async function lockSession(tx: Tx, sessionId: string): Promise<void> {
+  async function lockSession(tx: Tx, ref: SessionRef): Promise<void> {
     const rows = await tx
       .select({ id: sessions.id })
       .from(sessions)
-      .where(eq(sessions.id, sessionId))
+      .where(and(eq(sessions.id, ref.sessionId), eq(sessions.namespace, ref.namespace)))
       .for("update");
-    if (rows.length === 0) throw new Error(`unknown session: ${sessionId}`);
+    if (rows.length === 0) throw new Error(`unknown session: ${ref.sessionId}`);
   }
 
   /**
@@ -170,13 +172,14 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
   /** Mint envelopes and append; caller must hold the session lock. */
   async function appendEntries(
     tx: Tx,
-    sessionId: string,
+    ref: SessionRef,
     payloads: Array<Record<string, unknown>>,
   ): Promise<void> {
+    const { namespace, sessionId } = ref;
     const [tail] = await tx
       .select({ max: sql<number>`coalesce(max(${sessionEntries.seq}), -1)` })
       .from(sessionEntries)
-      .where(eq(sessionEntries.sessionId, sessionId));
+      .where(and(eq(sessionEntries.namespace, namespace), eq(sessionEntries.sessionId, sessionId)));
     let seq = Number(tail?.max ?? -1);
     for (const payload of payloads) {
       seq += 1;
@@ -186,7 +189,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         timestamp: iso(now()),
         ...payload,
       });
-      await tx.insert(sessionEntries).values({ sessionId, seq, entry });
+      await tx.insert(sessionEntries).values({ namespace, sessionId, seq, entry });
     }
   }
 
@@ -203,6 +206,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
           createdAt: timestamp,
         });
         await tx.insert(agentConfigVersions).values({
+          namespace: parsed.namespace,
           agentConfigId: id,
           version: 1,
           inference: parsed.inference,
@@ -211,7 +215,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
           updatedAt: timestamp,
         });
       });
-      return AgentConfigRef.parse({ namespace: parsed.namespace, id });
+      return AgentConfigRef.parse({ namespace: parsed.namespace, agentConfigId: id });
     },
 
     async getAgentConfig(ref) {
@@ -223,6 +227,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       const requestedVersion =
         version !== undefined
           ? and(
+              eq(agentConfigVersions.namespace, agentConfigs.namespace),
               eq(agentConfigVersions.agentConfigId, agentConfigs.id),
               eq(agentConfigVersions.version, version),
             )
@@ -231,14 +236,19 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         .select(agentConfigColumns)
         .from(agentConfigs)
         .innerJoin(agentConfigVersions, requestedVersion)
-        .where(and(eq(agentConfigs.id, parsed.id), eq(agentConfigs.namespace, parsed.namespace)));
+        .where(
+          and(
+            eq(agentConfigs.id, parsed.agentConfigId),
+            eq(agentConfigs.namespace, parsed.namespace),
+          ),
+        );
       return row === undefined ? undefined : toAgentConfig(row);
     },
 
     async updateAgentConfig(ref, req) {
-      const { id, namespace } = AgentConfigRef.parse(ref);
+      const { agentConfigId, namespace } = AgentConfigRef.parse(ref);
       const parsed = UpdateAgentConfigRequest.parse(req);
-      const scope = and(eq(agentConfigs.id, id), eq(agentConfigs.namespace, namespace));
+      const scope = and(eq(agentConfigs.id, agentConfigId), eq(agentConfigs.namespace, namespace));
       const target = and(
         scope,
         parsed.version === undefined ? undefined : eq(agentConfigs.currentVersion, parsed.version),
@@ -279,6 +289,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
               .from(agentConfigVersions)
               .where(
                 and(
+                  eq(agentConfigVersions.namespace, identity.namespace),
                   eq(agentConfigVersions.agentConfigId, identity.id),
                   eq(agentConfigVersions.version, identity.nextVersion - 1),
                 ),
@@ -296,7 +307,11 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
               metadata: parsed.metadata === undefined ? previous.metadata : wrap(parsed.metadata),
               updatedAt: now(),
             };
-            await tx.insert(agentConfigVersions).values({ agentConfigId: identity.id, ...version });
+            await tx.insert(agentConfigVersions).values({
+              namespace: identity.namespace,
+              agentConfigId: identity.id,
+              ...version,
+            });
             return toAgentConfig({
               id: identity.id,
               namespace: identity.namespace,
@@ -324,17 +339,17 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         if (current === undefined) return undefined;
         // Archived outranks the version verdict: it is terminal, so
         // "retry with the current version" would be a lie.
-        if (current.archivedAt !== null) throw new ArchivedError(id);
+        if (current.archivedAt !== null) throw new ArchivedError(agentConfigId);
         if (parsed.version !== undefined) {
           throw new VersionConflictError(parsed.version, current.version);
         }
-        throw new Error(`agent config ${id} was not updated`);
+        throw new Error(`agent config ${agentConfigId} was not updated`);
       });
     },
 
     async archiveAgentConfig(ref) {
-      const { id, namespace } = AgentConfigRef.parse(ref);
-      const scope = and(eq(agentConfigs.id, id), eq(agentConfigs.namespace, namespace));
+      const { agentConfigId, namespace } = AgentConfigRef.parse(ref);
+      const scope = and(eq(agentConfigs.id, agentConfigId), eq(agentConfigs.namespace, namespace));
       return db.transaction(async (tx) => {
         // Idempotent by predicate rather than by read-then-write: only an
         // unarchived row is stamped, so a second archive — or a racing one —
@@ -380,22 +395,22 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         metadata: wrap(parsed.metadata),
         createdAt: now(),
       });
-      return EnvConfigRef.parse({ namespace: parsed.namespace, id });
+      return EnvConfigRef.parse({ namespace: parsed.namespace, envConfigId: id });
     },
 
     async getEnvConfig(ref) {
-      const { id, namespace } = EnvConfigRef.parse(ref);
+      const { envConfigId, namespace } = EnvConfigRef.parse(ref);
       const [row] = await db
         .select()
         .from(envConfigs)
-        .where(and(eq(envConfigs.id, id), eq(envConfigs.namespace, namespace)));
+        .where(and(eq(envConfigs.id, envConfigId), eq(envConfigs.namespace, namespace)));
       return row === undefined ? undefined : toEnvConfig(row);
     },
 
     async updateEnvConfig(ref, req) {
-      const { id, namespace } = EnvConfigRef.parse(ref);
+      const { envConfigId, namespace } = EnvConfigRef.parse(ref);
       const parsed = UpdateEnvConfigRequest.parse(req);
-      const scope = and(eq(envConfigs.id, id), eq(envConfigs.namespace, namespace));
+      const scope = and(eq(envConfigs.id, envConfigId), eq(envConfigs.namespace, namespace));
       const updates = {
         ...(parsed.network === undefined ? {} : { network: parsed.network }),
         ...(parsed.packages === undefined ? {} : { packages: parsed.packages }),
@@ -426,11 +441,12 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
 
     async createSession(req) {
       const parsed = CreateSessionRequest.parse(req);
-      const namespace = parsed.namespace ?? DEFAULT_NAMESPACE;
+      const { namespace } = parsed;
       const requestedAgentVersion =
         parsed.agentConfigVersion === undefined
           ? currentAgentVersion
           : and(
+              eq(agentConfigVersions.namespace, agentConfigs.namespace),
               eq(agentConfigVersions.agentConfigId, agentConfigs.id),
               eq(agentConfigVersions.version, parsed.agentConfigVersion),
             );
@@ -473,14 +489,18 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
           createdAt: now(),
         });
       });
-      return id;
+      return SessionRef.parse({ namespace, sessionId: id });
     },
 
-    async getSession(id) {
-      const [row] = await db.select().from(sessions).where(eq(sessions.id, id));
+    async getSession(ref) {
+      const { namespace, sessionId } = SessionRef.parse(ref);
+      const [row] = await db
+        .select()
+        .from(sessions)
+        .where(and(eq(sessions.id, sessionId), eq(sessions.namespace, namespace)));
       if (!row) return undefined;
       return Session.parse({
-        id: row.id,
+        sessionId: row.id,
         agentConfigId: row.agentConfigId,
         agentConfigVersion: row.agentConfigVersion,
         envConfigId: row.envConfigId,
@@ -491,7 +511,9 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       });
     },
 
-    async bindSandbox(sessionId, sandboxId, previous) {
+    async bindSandbox(ref, sandboxId, previous) {
+      const { namespace, sessionId } = SessionRef.parse(ref);
+      const scope = and(eq(sessions.id, sessionId), eq(sessions.namespace, namespace));
       // The CAS: one UPDATE guarded by the expected current value — at
       // most one writer ever matches, whatever the interleaving.
       const expected =
@@ -499,40 +521,43 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       const [bound] = await db
         .update(sessions)
         .set({ sandboxId })
-        .where(and(eq(sessions.id, sessionId), expected))
+        .where(and(scope, expected))
         .returning({ sandboxId: sessions.sandboxId });
       if (bound?.sandboxId) return bound.sandboxId;
-      const [row] = await db
-        .select({ sandboxId: sessions.sandboxId })
-        .from(sessions)
-        .where(eq(sessions.id, sessionId));
+      const [row] = await db.select({ sandboxId: sessions.sandboxId }).from(sessions).where(scope);
       if (!row?.sandboxId) throw new Error(`unknown session: ${sessionId}`);
       return row.sandboxId;
     },
 
-    async readEntries(sessionId, after) {
+    async readEntries(ref, after) {
+      const { namespace, sessionId } = SessionRef.parse(ref);
+      // A foreign ref reads exactly like an unknown session: empty.
       const rows = await db
         .select({ entry: sessionEntries.entry })
         .from(sessionEntries)
         .where(
-          after === undefined
-            ? eq(sessionEntries.sessionId, sessionId)
-            : and(eq(sessionEntries.sessionId, sessionId), gt(sessionEntries.seq, after)),
+          and(
+            eq(sessionEntries.namespace, namespace),
+            eq(sessionEntries.sessionId, sessionId),
+            after === undefined ? undefined : gt(sessionEntries.seq, after),
+          ),
         )
         .orderBy(asc(sessionEntries.seq));
       return rows.map((r) => SessionEntry.parse(r.entry));
     },
 
-    async listItems(sessionId) {
+    async listItems(ref) {
+      const { namespace, sessionId } = SessionRef.parse(ref);
       const rows = await db
         .select()
         .from(workItems)
-        .where(eq(workItems.sessionId, sessionId))
+        .where(and(eq(workItems.sessionId, sessionId), eq(workItems.namespace, namespace)))
         .orderBy(asc(workItems.createdAt));
       return rows.map((r) =>
         WorkItem.parse({
-          id: r.id,
+          namespace: r.namespace,
           sessionId: r.sessionId,
+          itemId: r.id,
           type: r.type,
           status: r.status,
           attempt: r.attempt,
@@ -540,11 +565,18 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       );
     },
 
-    async pendingInputs(sessionId) {
+    async pendingInputs(ref) {
+      const { namespace, sessionId } = SessionRef.parse(ref);
+      // A foreign ref reads exactly like an unknown session: empty.
       const rows = await db
-        .select()
+        .select({
+          id: pendingInputs.id,
+          sessionId: pendingInputs.sessionId,
+          message: pendingInputs.message,
+          arrivedAt: pendingInputs.arrivedAt,
+        })
         .from(pendingInputs)
-        .where(eq(pendingInputs.sessionId, sessionId))
+        .where(and(eq(pendingInputs.namespace, namespace), eq(pendingInputs.sessionId, sessionId)))
         .orderBy(asc(pendingInputs.ord));
       return rows.map((r) =>
         PendingInput.parse({
@@ -559,24 +591,34 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
     async claimItem(req) {
       return db.transaction(async (tx) => {
         const t = now();
-        // "Expired" iff leaseExpiresAt <= now.
-        const claimable = or(
-          eq(workItems.status, "ready"),
-          and(eq(workItems.status, "leased"), lte(workItems.leaseExpiresAt, t)),
+        // "Expired" iff leaseExpiresAt <= now. The leading conjunct is
+        // redundant with the OR, but it matches the partial claim-scan
+        // index's predicate verbatim, so the planner's proof that the
+        // index applies is trivial rather than inferred.
+        const claimable = and(
+          ne(workItems.status, "done"),
+          or(
+            eq(workItems.status, "ready"),
+            and(eq(workItems.status, "leased"), lte(workItems.leaseExpiresAt, t)),
+          ),
         );
+        const scope =
+          req.session === undefined
+            ? undefined
+            : and(
+                eq(workItems.sessionId, SessionRef.parse(req.session).sessionId),
+                eq(workItems.namespace, req.session.namespace),
+              );
         const [candidate] = await tx
           .select({
             id: workItems.id,
+            namespace: workItems.namespace,
             sessionId: workItems.sessionId,
             type: workItems.type,
             attempt: workItems.attempt,
           })
           .from(workItems)
-          .where(
-            req.sessionId === undefined
-              ? claimable
-              : and(claimable, eq(workItems.sessionId, req.sessionId)),
-          )
+          .where(and(claimable, scope))
           .orderBy(asc(workItems.createdAt))
           .limit(1)
           .for("update", { skipLocked: true });
@@ -593,11 +635,20 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
             leaseExpiresAt: new Date(t.getTime() + req.leaseMs),
             attempt,
           })
-          .where(eq(workItems.id, candidate.id));
+          .where(
+            // The full path, so the write rides the PK — the bare id has
+            // no index of its own under the composite key.
+            and(
+              eq(workItems.namespace, candidate.namespace),
+              eq(workItems.sessionId, candidate.sessionId),
+              eq(workItems.id, candidate.id),
+            ),
+          );
         return {
           item: WorkItem.parse({
-            id: candidate.id,
+            namespace: candidate.namespace,
             sessionId: candidate.sessionId,
+            itemId: candidate.id,
             type: candidate.type,
             status: "leased",
             attempt,
@@ -607,7 +658,8 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       });
     },
 
-    async heartbeat(itemId, token) {
+    async heartbeat(ref, token) {
+      const { namespace, sessionId, itemId } = WorkItemRef.parse(ref);
       const t = now();
       const rows = await db
         .update(workItems)
@@ -616,7 +668,11 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         })
         .where(
           and(
+            // The full path is the address: a mismatched parent or a
+            // foreign namespace misses exactly like an unknown item.
             eq(workItems.id, itemId),
+            eq(workItems.sessionId, sessionId),
+            eq(workItems.namespace, namespace),
             eq(workItems.leaseToken, token),
             eq(workItems.status, "leased"),
             gt(workItems.leaseExpiresAt, t), // expired = lost, even if unclaimed
@@ -626,62 +682,84 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       return rows.length > 0;
     },
 
-    async requestCancel(sessionId) {
+    async requestCancel(ref) {
+      const parsed = SessionRef.parse(ref);
       await db.transaction(async (tx) => {
-        await lockSession(tx, sessionId);
-        await appendEntries(tx, sessionId, [{ type: "control", control: "cancel" }]);
+        await lockSession(tx, parsed);
+        await appendEntries(tx, parsed, [{ type: "control", control: "cancel" }]);
       });
     },
 
-    async intake(sessionId, message) {
+    async intake(ref, message) {
+      const { namespace, sessionId } = SessionRef.parse(ref);
       const msg = UserMessage.parse(message);
       return db.transaction(async (tx) => {
-        await lockSession(tx, sessionId); // the race referee
+        await lockSession(tx, { namespace, sessionId }); // the race referee
         const open = await tx
           .select({ id: workItems.id })
           .from(workItems)
-          .where(and(eq(workItems.sessionId, sessionId), ne(workItems.status, "done")))
+          .where(
+            and(
+              eq(workItems.namespace, namespace),
+              eq(workItems.sessionId, sessionId),
+              ne(workItems.status, "done"),
+            ),
+          )
           .limit(1);
         if (open.length > 0) {
           const inputId = randomUUID();
           await tx
             .insert(pendingInputs)
-            .values({ id: inputId, sessionId, message: msg, arrivedAt: now() });
+            .values({ namespace, sessionId, id: inputId, message: msg, arrivedAt: now() });
           return IntakeResult.parse({ kind: "queued", inputId });
         }
-        await appendEntries(tx, sessionId, [{ type: "message", message: msg }]);
+        await appendEntries(tx, { namespace, sessionId }, [{ type: "message", message: msg }]);
         const itemId = randomUUID();
-        await tx
-          .insert(workItems)
-          .values({ id: itemId, sessionId, type: "inference", status: "ready", createdAt: now() });
+        await tx.insert(workItems).values({
+          id: itemId,
+          namespace,
+          sessionId,
+          type: "inference",
+          status: "ready",
+          createdAt: now(),
+        });
         return IntakeResult.parse({ kind: "started", itemId });
       });
     },
 
     async commitStep(req: CommitStepRequest) {
+      const { namespace, sessionId, itemId } = WorkItemRef.parse(req.itemRef);
       const messages = req.append.map((m) => AgentMessage.parse(m));
       await db.transaction(async (tx) => {
         const [item] = await tx
           .select()
           .from(workItems)
-          .where(eq(workItems.id, req.itemId))
+          .where(
+            // The full path is the address: a mismatched parent session or
+            // a foreign namespace is unknown, exactly like a missing row.
+            and(
+              eq(workItems.id, itemId),
+              eq(workItems.sessionId, sessionId),
+              eq(workItems.namespace, namespace),
+            ),
+          )
           .for("update");
-        if (!item) throw new Error(`commitStep: unknown item ${req.itemId}`);
+        if (!item) throw new Error(`commitStep: unknown item ${itemId}`);
         if (item.status === "done") {
           if (item.leaseToken !== req.token)
             throw new FencedError(
-              `commitStep: fenced — ${req.itemId} was finished under another claim`,
+              `commitStep: fenced — ${itemId} was finished under another claim`,
             );
           return; // idempotent re-commit (crash-after-commit recovery)
         }
         if (item.status !== "leased" || item.leaseToken !== req.token)
-          throw new FencedError(`commitStep: fenced — stale token for ${req.itemId}`);
+          throw new FencedError(`commitStep: fenced — stale token for ${itemId}`);
         if (item.leaseExpiresAt === null || item.leaseExpiresAt.getTime() <= now().getTime())
-          throw new FencedError(`commitStep: fenced — ${req.itemId}'s lease expired before commit`);
-        await lockSession(tx, item.sessionId);
+          throw new FencedError(`commitStep: fenced — ${itemId}'s lease expired before commit`);
+        await lockSession(tx, { namespace, sessionId });
         await appendEntries(
           tx,
-          item.sessionId,
+          { namespace, sessionId },
           messages.map((m) => ({ type: "message", message: m })),
         );
         if (req.consumeInputs !== undefined && req.consumeInputs.length > 0) {
@@ -689,7 +767,8 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
             .delete(pendingInputs)
             .where(
               and(
-                eq(pendingInputs.sessionId, item.sessionId),
+                eq(pendingInputs.namespace, namespace),
+                eq(pendingInputs.sessionId, sessionId),
                 inArray(pendingInputs.id, req.consumeInputs),
               ),
             )
@@ -697,10 +776,20 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
           if (drained.length !== req.consumeInputs.length)
             throw new Error("commitStep: consumeInputs names an unknown or already-consumed input");
         }
-        await tx.update(workItems).set({ status: "done" }).where(eq(workItems.id, item.id));
+        await tx
+          .update(workItems)
+          .set({ status: "done" })
+          .where(
+            and(
+              eq(workItems.namespace, item.namespace),
+              eq(workItems.sessionId, item.sessionId),
+              eq(workItems.id, item.id),
+            ),
+          );
         if (req.next.kind !== "end_run") {
           await tx.insert(workItems).values({
             id: randomUUID(),
+            namespace: item.namespace,
             sessionId: item.sessionId,
             type: req.next.kind,
             status: "ready",
@@ -715,22 +804,29 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         const parked = await tx
           .select()
           .from(pendingInputs)
-          .where(eq(pendingInputs.sessionId, item.sessionId))
+          .where(
+            and(eq(pendingInputs.namespace, namespace), eq(pendingInputs.sessionId, sessionId)),
+          )
           .orderBy(asc(pendingInputs.ord));
         if (parked.length === 0) return;
         await appendEntries(
           tx,
-          item.sessionId,
+          { namespace, sessionId },
           parked.map((p) => ({ type: "message", message: p.message })),
         );
         await tx.delete(pendingInputs).where(
-          inArray(
-            pendingInputs.ord,
-            parked.map((p) => p.ord),
+          and(
+            eq(pendingInputs.namespace, namespace),
+            eq(pendingInputs.sessionId, sessionId),
+            inArray(
+              pendingInputs.id,
+              parked.map((p) => p.id),
+            ),
           ),
         );
         await tx.insert(workItems).values({
           id: randomUUID(),
+          namespace: item.namespace,
           sessionId: item.sessionId,
           type: "inference",
           status: "ready",

--- a/packages/adapters/src/store/schema.ts
+++ b/packages/adapters/src/store/schema.ts
@@ -36,66 +36,94 @@ import type {
 /** SQL NULL = absent; `{ v }` = present (v may be JSON null). */
 export type WrappedJson = { v: JsonValue };
 
-export const agentConfigs = pgTable("agent_configs", {
-  id: text("id").primaryKey(),
-  // The tenancy boundary (core/store.ts) — the adapter materializes the
-  // default; no SQL DEFAULT, so the resolution lives in exactly one place.
-  namespace: text("namespace").notNull(),
-  // Pointer to the latest immutable snapshot.
-  currentVersion: integer("current_version").notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
-  // The terminal state, set once: null = active. Archiving lives on the
-  // identity, not on a version — it retires the config, not a snapshot.
-  archivedAt: timestamp("archived_at", { withTimezone: true }),
-});
+// Every table carries namespace and is keyed by its full path, namespace
+// leading — point reads arrive ref-scoped, and namespace is the key the
+// future PARTITION BY needs on every table. Children copy it from their
+// parent, made structural by composite FKs; no bare-id UNIQUE exists
+// anywhere (see migration.sql).
+export const agentConfigs = pgTable(
+  "agent_configs",
+  {
+    // The tenancy boundary (core/store.ts); the caller supplies it on
+    // every create — no SQL DEFAULT, no adapter resolution.
+    namespace: text("namespace").notNull(),
+    id: text("id").notNull(),
+    // Pointer to the latest immutable snapshot.
+    currentVersion: integer("current_version").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+    // The terminal state, set once: null = active. Archiving lives on the
+    // identity, not on a version — it retires the config, not a snapshot.
+    archivedAt: timestamp("archived_at", { withTimezone: true }),
+  },
+  (t) => [primaryKey({ columns: [t.namespace, t.id] })],
+);
 
-// Immutable snapshots of every agent config version.
+// Immutable snapshots of every agent config version. The PK is the
+// AgentConfigVersionRef verbatim.
 export const agentConfigVersions = pgTable(
   "agent_config_versions",
   {
-    agentConfigId: text("agent_config_id")
-      .notNull()
-      .references(() => agentConfigs.id),
+    namespace: text("namespace").notNull(),
+    agentConfigId: text("agent_config_id").notNull(),
     version: integer("version").notNull(),
     inference: jsonb("inference").$type<InferenceConfig>().notNull(),
     systemPrompt: text("system_prompt").notNull(),
     metadata: jsonb("metadata").$type<WrappedJson>(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
   },
-  (t) => [primaryKey({ columns: [t.agentConfigId, t.version] })],
+  (t) => [
+    primaryKey({ columns: [t.namespace, t.agentConfigId, t.version] }),
+    foreignKey({
+      columns: [t.namespace, t.agentConfigId],
+      foreignColumns: [agentConfigs.namespace, agentConfigs.id],
+    }),
+  ],
 );
 
-export const envConfigs = pgTable("env_configs", {
-  id: text("id").primaryKey(),
-  // Materialized at create — never SQL NULL (resolved decisions, not defaults).
-  network: jsonb("network").$type<NetworkPolicy>().notNull(),
-  packages: jsonb("packages").$type<Packages>().notNull(),
-  namespace: text("namespace").notNull(),
-  metadata: jsonb("metadata").$type<WrappedJson>(),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
-});
+export const envConfigs = pgTable(
+  "env_configs",
+  {
+    namespace: text("namespace").notNull(),
+    id: text("id").notNull(),
+    // Materialized at create — never SQL NULL (resolved decisions, not defaults).
+    network: jsonb("network").$type<NetworkPolicy>().notNull(),
+    packages: jsonb("packages").$type<Packages>().notNull(),
+    metadata: jsonb("metadata").$type<WrappedJson>(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.namespace, t.id] })],
+);
 
 export const sessions = pgTable(
   "sessions",
   {
-    id: text("id").primaryKey(),
+    namespace: text("namespace").notNull(),
+    id: text("id").notNull(),
     agentConfigId: text("agent_config_id").notNull(),
     // Resolved from the agent's latest version at session creation. The
     // composite FK below makes every session's behavior snapshot durable.
     agentConfigVersion: integer("agent_config_version").notNull(),
-    envConfigId: text("env_config_id")
-      .notNull()
-      .references(() => envConfigs.id),
-    namespace: text("namespace").notNull(),
+    envConfigId: text("env_config_id").notNull(),
     // The session's one workspace; null until bindSandbox registers it.
     sandboxId: text("sandbox_id"),
     metadata: jsonb("metadata").$type<WrappedJson>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
   },
   (t) => [
+    primaryKey({ columns: [t.namespace, t.id] }),
+    // Same-namespace, structural, on both references: the pinned version
+    // and the env recipe must live in the session's own namespace.
     foreignKey({
-      columns: [t.agentConfigId, t.agentConfigVersion],
-      foreignColumns: [agentConfigVersions.agentConfigId, agentConfigVersions.version],
+      columns: [t.namespace, t.agentConfigId, t.agentConfigVersion],
+      foreignColumns: [
+        agentConfigVersions.namespace,
+        agentConfigVersions.agentConfigId,
+        agentConfigVersions.version,
+      ],
+    }),
+    foreignKey({
+      columns: [t.namespace, t.envConfigId],
+      foreignColumns: [envConfigs.namespace, envConfigs.id],
     }),
   ],
 );
@@ -103,22 +131,30 @@ export const sessions = pgTable(
 export const sessionEntries = pgTable(
   "session_entries",
   {
-    sessionId: text("session_id")
-      .notNull()
-      .references(() => sessions.id),
+    namespace: text("namespace").notNull(),
+    sessionId: text("session_id").notNull(),
     seq: integer("seq").notNull(),
     entry: jsonb("entry").$type<SessionEntry>().notNull(),
   },
-  (t) => [primaryKey({ columns: [t.sessionId, t.seq] })],
+  (t) => [
+    primaryKey({ columns: [t.namespace, t.sessionId, t.seq] }),
+    foreignKey({
+      columns: [t.namespace, t.sessionId],
+      foreignColumns: [sessions.namespace, sessions.id],
+    }),
+  ],
 );
 
 export const workItems = pgTable(
   "work_items",
   {
-    id: text("id").primaryKey(),
-    sessionId: text("session_id")
-      .notNull()
-      .references(() => sessions.id),
+    // Copied from the session at mint (core/store.ts): the claim is the
+    // one read that starts from nothing, so the claimed row itself must
+    // hand the driver the scope its later refs carry. The composite FK
+    // below makes the copy structural — it can never diverge.
+    namespace: text("namespace").notNull(),
+    sessionId: text("session_id").notNull(),
+    id: text("id").notNull(),
     type: text("type").notNull(), // ItemType
     status: text("status").notNull(), // ItemStatus
     // Lease bookkeeping — adapter internals, not port vocabulary.
@@ -131,31 +167,48 @@ export const workItems = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
   },
   (t) => [
+    primaryKey({ columns: [t.namespace, t.sessionId, t.id] }),
+    foreignKey({
+      columns: [t.namespace, t.sessionId],
+      foreignColumns: [sessions.namespace, sessions.id],
+    }),
     // The one-open-item invariant, enforced declaratively: at most one
-    // non-done item per session. This index IS "busy".
+    // non-done item per session. This index IS "busy". Carries the
+    // partition key like every unique index here.
     uniqueIndex("work_items_one_open_per_session")
-      .on(t.sessionId)
+      .on(t.namespace, t.sessionId)
       .where(sql`${t.status} <> 'done'`),
-    index("work_items_claim_scan").on(t.status, t.createdAt),
+    // Partial: only live rows, in arrival order — the claim poll is one
+    // ordered walk, and the unbounded done majority never enters. The
+    // claim query repeats the predicate verbatim (see pg.ts claimItem).
+    // Deliberately namespace-free: the claim scan is cross-tenant.
+    index("work_items_claim_scan")
+      .on(t.createdAt)
+      .where(sql`${t.status} <> 'done'`),
   ],
 );
 
 export const pendingInputs = pgTable(
   "pending_inputs",
   {
-    sessionId: text("session_id")
-      .notNull()
-      .references(() => sessions.id),
-    // Drain order — arrival order even under equal timestamps. The key
-    // shape mimics session_entries, but ord is plumbing, not contract:
-    // a global bigserial, gappy and never per-session dense (seq is the
-    // hand-minted dense one). The composite PK is the access path for
-    // the session-scoped reads that are this table's only queries.
+    namespace: text("namespace").notNull(),
+    sessionId: text("session_id").notNull(),
+    // The port-level name — what consumeInputs targets. In the PK, so an
+    // input id is unique within its session by construction.
+    id: text("id").notNull(),
+    // Drain order — arrival order even under equal timestamps. A global
+    // bigserial, gappy and never per-session dense (seq is the
+    // hand-minted dense one): plumbing, not contract. Reads scan the PK
+    // prefix and order by it.
     ord: bigserial("ord", { mode: "number" }),
-    // The port-level name — what consumeInputs targets.
-    id: text("id").notNull().unique(),
     message: jsonb("message").$type<UserMessage>().notNull(),
     arrivedAt: timestamp("arrived_at", { withTimezone: true }).notNull(),
   },
-  (t) => [primaryKey({ columns: [t.sessionId, t.ord] })],
+  (t) => [
+    primaryKey({ columns: [t.namespace, t.sessionId, t.id] }),
+    foreignKey({
+      columns: [t.namespace, t.sessionId],
+      foreignColumns: [sessions.namespace, sessions.id],
+    }),
+  ],
 );

--- a/packages/adapters/test/crash-resume.test.ts
+++ b/packages/adapters/test/crash-resume.test.ts
@@ -37,7 +37,7 @@ import { fileURLToPath } from "node:url";
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { DEFAULT_NAMESPACE } from "@funky/core";
+import { DEFAULT_NAMESPACE, type SessionRef } from "@funky/core";
 import { runStep, type StepDeps, type Store, toToolSpec } from "@funky/agent";
 import { createPgStore, type StoreDb } from "../src";
 import {
@@ -60,7 +60,7 @@ const SWEEP_SEED = Number(process.env["CRASH_SWEEP_SEED"] ?? 20_260_816);
 let workRoot: string;
 let templateFresh: string; // seeded: config + session + turn-one intake
 let templateMidway: string; // turn one complete + turn-two intake
-let sessionId: string;
+let sessionRef: SessionRef;
 let refEntries: unknown[];
 let refItemTypes: string[];
 
@@ -98,7 +98,7 @@ async function driveToIdle(store: Store): Promise<void> {
 async function intakeSecondPrompt(dir: string): Promise<void> {
   const { store, close } = await openDir(dir);
   try {
-    const result = await store.intake(sessionId, user(PROMPTS[1]));
+    const result = await store.intake(sessionRef, user(PROMPTS[1]));
     if (result.kind !== "started") {
       throw new Error(`expected turn-two intake to start a run, got "${result.kind}"`);
     }
@@ -137,14 +137,14 @@ const ANY_INTERRUPTION: number[][] = [[], [0], [1], [0, 1]];
 async function assertMatchesReference(dir: string, acceptable: number[][] = [[]]): Promise<void> {
   const { store, close } = await openDir(dir);
   try {
-    const actual = normalizeEntries(await store.readEntries(sessionId));
+    const actual = normalizeEntries(await store.readEntries(sessionRef));
     const variants = acceptable.map((batches) => withInterrupted(refEntries, batches));
     if (variants.length === 1) expect(actual).toEqual(variants[0]);
     else expect(variants).toContainEqual(actual);
-    const items = await store.listItems(sessionId);
+    const items = await store.listItems(sessionRef);
     expect(items.map((i) => i.type)).toEqual(refItemTypes);
     expect(items.map((i) => i.status)).toEqual(refItemTypes.map(() => "done"));
-    expect(await store.pendingInputs(sessionId)).toEqual([]);
+    expect(await store.pendingInputs(sessionRef)).toEqual([]);
   } finally {
     await close();
   }
@@ -287,11 +287,12 @@ beforeAll(async () => {
       systemPrompt: "be brief",
     });
     const envConfigRef = await store.createEnvConfig({ namespace: DEFAULT_NAMESPACE });
-    sessionId = await store.createSession({
-      agentConfigId: agentConfigRef.id,
-      envConfigId: envConfigRef.id,
+    sessionRef = await store.createSession({
+      namespace: DEFAULT_NAMESPACE,
+      agentConfigId: agentConfigRef.agentConfigId,
+      envConfigId: envConfigRef.envConfigId,
     });
-    const result = await store.intake(sessionId, user(PROMPTS[0]));
+    const result = await store.intake(sessionRef, user(PROMPTS[0]));
     if (result.kind !== "started") throw new Error("seed intake did not start a run");
     await client.close();
   }
@@ -301,7 +302,7 @@ beforeAll(async () => {
   {
     const { store, close } = await openDir(templateMidway);
     await driveToIdle(store);
-    const result = await store.intake(sessionId, user(PROMPTS[1]));
+    const result = await store.intake(sessionRef, user(PROMPTS[1]));
     if (result.kind !== "started") throw new Error("turn-two intake did not start a run");
     await close();
   }
@@ -311,8 +312,8 @@ beforeAll(async () => {
   {
     const { store, close } = await openDir(referenceDir);
     await driveToIdle(store);
-    refEntries = normalizeEntries(await store.readEntries(sessionId));
-    refItemTypes = (await store.listItems(sessionId)).map((i) => i.type);
+    refEntries = normalizeEntries(await store.readEntries(sessionRef));
+    refItemTypes = (await store.listItems(sessionRef)).map((i) => i.type);
     await close();
   }
 

--- a/packages/adapters/test/driver.test.ts
+++ b/packages/adapters/test/driver.test.ts
@@ -14,6 +14,7 @@ import {
   DEFAULT_NAMESPACE,
   type ProviderEvent,
   type SessionEntry,
+  type SessionRef,
   type Usage,
   type UserMessage,
 } from "@funky/core";
@@ -131,19 +132,23 @@ const inferenceConfig = {
   temperature: 0.2,
 };
 
-async function newSession(): Promise<string> {
+async function newSession(): Promise<SessionRef> {
   const agentConfigRef = await store.createAgentConfig({
     namespace: DEFAULT_NAMESPACE,
     inference: inferenceConfig,
     systemPrompt: "be brief",
   });
   const envConfigRef = await store.createEnvConfig({ namespace: DEFAULT_NAMESPACE });
-  return store.createSession({ agentConfigId: agentConfigRef.id, envConfigId: envConfigRef.id });
+  return store.createSession({
+    namespace: DEFAULT_NAMESPACE,
+    agentConfigId: agentConfigRef.agentConfigId,
+    envConfigId: envConfigRef.envConfigId,
+  });
 }
 
 /** Claim the session's ready item — the tests' stand-in for the loop shell. */
-async function claim(sessionId: string, leaseMs = 60_000): Promise<Claim> {
-  const claimed = await store.claimItem({ leaseMs, sessionId });
+async function claim(ref: SessionRef, leaseMs = 60_000): Promise<Claim> {
+  const claimed = await store.claimItem({ leaseMs, session: ref });
   if (!claimed) throw new Error("expected a claimable item");
   return claimed;
 }
@@ -172,7 +177,7 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
 
 describe("driver steps over the pg store", () => {
   it("runs a full turn: inference → tools → inference → completion", async () => {
-    const sessionId = await newSession();
+    const sessionRef = await newSession();
     const provider = scriptedProvider([callEcho("hi"), sayText("done!")]);
     const deps: StepDeps = {
       store,
@@ -180,16 +185,16 @@ describe("driver steps over the pg store", () => {
       toolSpecs: [...echoOnly.values()].map(toToolSpec),
     };
 
-    await store.intake(sessionId, user("go"));
+    await store.intake(sessionRef, user("go"));
     // Only the execute_tools step receives executables — the loop's
     // ensure-on-claim; inference steps declare specs without a sandbox.
-    await runStep(deps, await claim(sessionId), 60_000); // inference → tool call
-    await runStep(deps, await claim(sessionId), 60_000, echoOnly); // execute_tools
-    await runStep(deps, await claim(sessionId), 60_000); // inference → end_turn
+    await runStep(deps, await claim(sessionRef), 60_000); // inference → tool call
+    await runStep(deps, await claim(sessionRef), 60_000, echoOnly); // execute_tools
+    await runStep(deps, await claim(sessionRef), 60_000); // inference → end_turn
     // The run ended: its end is the non-creation of a fourth item.
-    expect(await store.claimItem({ leaseMs: 60_000, sessionId })).toBeUndefined();
+    expect(await store.claimItem({ leaseMs: 60_000, session: sessionRef })).toBeUndefined();
 
-    const log = messages(await store.readEntries(sessionId));
+    const log = messages(await store.readEntries(sessionRef));
     expect(log.map((m) => m.role)).toEqual(["user", "assistant", "toolResult", "assistant"]);
     expect(log[2]).toMatchObject({ toolName: "echo", content: [{ type: "text", text: "hi" }] });
     expect(log[3]).toMatchObject({ stopReason: "end_turn" });
@@ -212,27 +217,27 @@ describe("driver steps over the pg store", () => {
   });
 
   it("drains an input queued before the step as steering, not a follow-up", async () => {
-    const sessionId = await newSession();
-    await store.intake(sessionId, user("go"));
-    const queued = await store.intake(sessionId, user("steer"));
+    const sessionRef = await newSession();
+    await store.intake(sessionRef, user("go"));
+    const queued = await store.intake(sessionRef, user("steer"));
     expect(queued.kind).toBe("queued");
 
     const provider = scriptedProvider([sayText("ok")]);
-    await runStep({ store, provider, toolSpecs: [] }, await claim(sessionId), 60_000);
+    await runStep({ store, provider, toolSpecs: [] }, await claim(sessionRef), 60_000);
 
     // Steering shaped the context (appended at the tail)…
     expect(provider.requests[0]?.context.map((m) => m.role)).toEqual(["user", "user"]);
     // …rode in the commit before the step's output, and was consumed.
-    const log = messages(await store.readEntries(sessionId));
+    const log = messages(await store.readEntries(sessionRef));
     expect(log.map((m) => m.role)).toEqual(["user", "user", "assistant"]);
-    expect(await store.pendingInputs(sessionId)).toHaveLength(0);
+    expect(await store.pendingInputs(sessionRef)).toHaveLength(0);
     // One run, one item: steering never chains a new run.
-    expect(await store.listItems(sessionId)).toHaveLength(1);
+    expect(await store.listItems(sessionRef)).toHaveLength(1);
   });
 
   it("auto-chains an input that arrives mid-step into a follow-up run", async () => {
-    const sessionId = await newSession();
-    await store.intake(sessionId, user("go"));
+    const sessionRef = await newSession();
+    await store.intake(sessionRef, user("go"));
 
     const gate = deferred();
     const provider = scriptedProvider([
@@ -241,67 +246,67 @@ describe("driver steps over the pg store", () => {
     ]);
     const deps: StepDeps = { store, provider, toolSpecs: [] };
 
-    const inFlight = runStep(deps, await claim(sessionId), 60_000);
+    const inFlight = runStep(deps, await claim(sessionRef), 60_000);
     // Arrive after run 1's inference prep: too late to steer this step.
     await until(() => provider.requests.length === 1);
-    const queued = await store.intake(sessionId, user("follow-up"));
+    const queued = await store.intake(sessionRef, user("follow-up"));
     expect(queued.kind).toBe("queued");
     gate.resolve();
     await inFlight;
 
     // The terminal commit chained a second run…
-    await runStep(deps, await claim(sessionId), 60_000);
+    await runStep(deps, await claim(sessionRef), 60_000);
 
     // …with the follow-up as an ordinary user entry after run 1's terminal message.
-    const log = messages(await store.readEntries(sessionId));
+    const log = messages(await store.readEntries(sessionRef));
     expect(log.map((m) => m.role)).toEqual(["user", "assistant", "user", "assistant"]);
     expect(provider.requests[1]?.context.map((m) => m.role)).toEqual(["user", "assistant", "user"]);
-    expect(await store.listItems(sessionId)).toHaveLength(2);
+    expect(await store.listItems(sessionRef)).toHaveLength(2);
   });
 
   it("ends a cancelled run at the claim boundary and parks queued inputs", async () => {
-    const sessionId = await newSession();
-    await store.intake(sessionId, user("go"));
-    await store.requestCancel(sessionId);
-    const queued = await store.intake(sessionId, user("while cancelled"));
+    const sessionRef = await newSession();
+    await store.intake(sessionRef, user("go"));
+    await store.requestCancel(sessionRef);
+    const queued = await store.intake(sessionRef, user("while cancelled"));
     expect(queued.kind).toBe("queued");
 
     const provider = scriptedProvider([sayText("fresh")]);
     const deps: StepDeps = { store, provider, toolSpecs: [] };
-    await runStep(deps, await claim(sessionId), 60_000);
+    await runStep(deps, await claim(sessionRef), 60_000);
 
     // The run ended without inference, appending nothing; the queued
     // input is parked, not chained.
     expect(provider.requests).toHaveLength(0);
-    expect(await store.readEntries(sessionId)).toHaveLength(2); // user + control
-    expect(await store.pendingInputs(sessionId)).toHaveLength(1);
+    expect(await store.readEntries(sessionRef)).toHaveLength(2); // user + control
+    expect(await store.pendingInputs(sessionRef)).toHaveLength(1);
 
     // The consumed cancel does not re-fire: the next intake starts a run
     // that completes normally, draining the parked input as steering.
-    const next = await store.intake(sessionId, user("again"));
+    const next = await store.intake(sessionRef, user("again"));
     expect(next.kind).toBe("started");
-    await runStep(deps, await claim(sessionId), 60_000);
+    await runStep(deps, await claim(sessionRef), 60_000);
 
-    const log = messages(await store.readEntries(sessionId));
+    const log = messages(await store.readEntries(sessionRef));
     expect(log[log.length - 1]).toMatchObject({ role: "assistant", stopReason: "end_turn" });
     expect(provider.requests[0]?.context.map((m) => m.role)).toEqual(["user", "user", "user"]);
   });
 
   it("commits a provider failure and ends the run as error — no retry", async () => {
-    const sessionId = await newSession();
-    await store.intake(sessionId, user("go"));
+    const sessionRef = await newSession();
+    await store.intake(sessionRef, user("go"));
     const provider = scriptedProvider([[{ throw: new Error("provider exploded") }]]);
-    await runStep({ store, provider, toolSpecs: [] }, await claim(sessionId), 60_000);
+    await runStep({ store, provider, toolSpecs: [] }, await claim(sessionRef), 60_000);
 
-    const log = messages(await store.readEntries(sessionId));
+    const log = messages(await store.readEntries(sessionRef));
     expect(log).toHaveLength(2);
     expect(log[1]).toMatchObject({ role: "assistant", stopReason: "error" });
     expect(provider.requests).toHaveLength(1);
-    expect(await store.claimItem({ leaseMs: 60_000, sessionId })).toBeUndefined();
+    expect(await store.claimItem({ leaseMs: 60_000, session: sessionRef })).toBeUndefined();
   });
 
   it("synthesizes interrupted results on a re-claimed execute_tools item — no re-execution", async () => {
-    const sessionId = await newSession();
+    const sessionRef = await newSession();
     const provider = scriptedProvider([callEcho("hi"), sayText("recovered")]);
     let executions = 0;
     const spiedEcho: Tool = {
@@ -313,20 +318,20 @@ describe("driver steps over the pg store", () => {
     };
     const deps: StepDeps = { store, provider, toolSpecs: [...echoOnly.values()].map(toToolSpec) };
 
-    await store.intake(sessionId, user("go"));
-    await runStep(deps, await claim(sessionId), 60_000); // inference → tool call
+    await store.intake(sessionRef, user("go"));
+    await runStep(deps, await claim(sessionRef), 60_000); // inference → tool call
 
     // First claim of the execute_tools item dies without committing —
     // whether its side effects ran is unknowable.
-    const first = await claim(sessionId, 300);
+    const first = await claim(sessionRef, 300);
     expect(first.item.attempt).toBe(1);
     clock.advance(10_000);
-    const second = await claim(sessionId);
+    const second = await claim(sessionRef);
     expect(second.item.attempt).toBe(2);
 
     await runStep(deps, second, 60_000, new Map([[spiedEcho.name, spiedEcho]]));
     expect(executions).toBe(0);
-    const log = messages(await store.readEntries(sessionId));
+    const log = messages(await store.readEntries(sessionRef));
     expect(log[2]).toMatchObject({
       role: "toolResult",
       toolName: "echo",
@@ -335,58 +340,58 @@ describe("driver steps over the pg store", () => {
     });
 
     // The run continues: the model sees the interruption and answers.
-    await runStep(deps, await claim(sessionId), 60_000);
-    const finalLog = messages(await store.readEntries(sessionId));
+    await runStep(deps, await claim(sessionRef), 60_000);
+    const finalLog = messages(await store.readEntries(sessionRef));
     expect(finalLog.map((m) => m.role)).toEqual(["user", "assistant", "toolResult", "assistant"]);
     expect(finalLog[3]).toMatchObject({ stopReason: "end_turn" });
   });
 
   it("revalidates the lease at entry: an expired claim does no work at all", async () => {
-    const sessionId = await newSession();
-    await store.intake(sessionId, user("go"));
+    const sessionRef = await newSession();
+    await store.intake(sessionRef, user("go"));
     const provider = scriptedProvider([sayText("later")]);
     const deps: StepDeps = { store, provider, toolSpecs: [] };
 
     // The lease dies between claim and runStep — the window the loop's
     // sandbox bind occupies. The awaited first beat must catch it.
-    const expired = await claim(sessionId, 300);
+    const expired = await claim(sessionRef, 300);
     clock.advance(10_000);
     await runStep(deps, expired, 300);
     expect(provider.requests).toHaveLength(0);
-    expect(messages(await store.readEntries(sessionId))).toHaveLength(1);
+    expect(messages(await store.readEntries(sessionRef))).toHaveLength(1);
 
     // The re-claim executes cleanly.
-    await runStep(deps, await claim(sessionId), 60_000);
-    expect(messages(await store.readEntries(sessionId)).map((m) => m.role)).toEqual([
+    await runStep(deps, await claim(sessionRef), 60_000);
+    expect(messages(await store.readEntries(sessionRef)).map((m) => m.role)).toEqual([
       "user",
       "assistant",
     ]);
   });
 
   it("drops an interrupted inference step on lease loss; the next claim re-executes", async () => {
-    const sessionId = await newSession();
-    await store.intake(sessionId, user("go"));
+    const sessionRef = await newSession();
+    await store.intake(sessionRef, user("go"));
     const provider = scriptedProvider([["untilAborted"], sayText("recovered")]);
     const deps: StepDeps = { store, provider, toolSpecs: [] };
 
-    const inFlight = runStep(deps, await claim(sessionId, 500), 500);
+    const inFlight = runStep(deps, await claim(sessionRef, 500), 500);
     await until(() => provider.requests.length === 1);
     clock.advance(10_000); // the next heartbeat reports the lease lost
     await inFlight;
 
     // The aborted attempt left no trace…
-    expect(messages(await store.readEntries(sessionId))).toHaveLength(1);
+    expect(messages(await store.readEntries(sessionRef))).toHaveLength(1);
     // …and the re-claim (fresh token, expired lease) re-executes cleanly.
-    await runStep(deps, await claim(sessionId), 60_000);
-    const log = messages(await store.readEntries(sessionId));
+    await runStep(deps, await claim(sessionRef), 60_000);
+    const log = messages(await store.readEntries(sessionRef));
     expect(log.map((m) => m.role)).toEqual(["user", "assistant"]);
     expect(log[1]).toMatchObject({ stopReason: "end_turn" });
     expect(provider.requests).toHaveLength(2);
   });
 
   it("drops the step when the commit is fenced, and the re-claim redoes it", async () => {
-    const sessionId = await newSession();
-    await store.intake(sessionId, user("go"));
+    const sessionRef = await newSession();
+    await store.intake(sessionRef, user("go"));
 
     let fencedOnce = false;
     const fencingStore: Store = {
@@ -404,14 +409,14 @@ describe("driver steps over the pg store", () => {
     const deps: StepDeps = { store: fencingStore, provider, toolSpecs: [] };
 
     // First step's commit is fenced: runStep swallows it and drops the work.
-    await runStep(deps, await claim(sessionId, 300), 300);
+    await runStep(deps, await claim(sessionRef, 300), 300);
     expect(fencedOnce).toBe(true);
-    expect(messages(await store.readEntries(sessionId))).toHaveLength(1);
+    expect(messages(await store.readEntries(sessionRef))).toHaveLength(1);
 
     // Expire the dropped claim; the re-claim's step commits for real.
     clock.advance(1_000);
-    await runStep(deps, await claim(sessionId), 60_000);
-    const log = messages(await store.readEntries(sessionId));
+    await runStep(deps, await claim(sessionRef), 60_000);
+    const log = messages(await store.readEntries(sessionRef));
     expect(log.map((m) => m.role)).toEqual(["user", "assistant"]);
     expect(log[1]).toMatchObject({ content: [{ type: "text", text: "b" }] });
     expect(provider.requests).toHaveLength(2);

--- a/packages/adapters/test/store-conformance.ts
+++ b/packages/adapters/test/store-conformance.ts
@@ -14,7 +14,9 @@ import {
   type CreateEnvConfigRequest,
   DEFAULT_NAMESPACE,
   type EnvConfigRef,
+  type SessionRef,
   type UserMessage,
+  type WorkItemRef,
 } from "@funky/core";
 import {
   ArchivedError,
@@ -71,24 +73,28 @@ export function describeStoreConformance(
       });
     }
 
-    async function newSession(): Promise<string> {
+    async function newSession(): Promise<SessionRef> {
       const agentConfigRef = await newAgent({
         inference: { provider: "fake", model: "scripted" },
       });
       const envConfigRef = await newEnv();
       return store.createSession({
-        agentConfigId: agentConfigRef.id,
-        envConfigId: envConfigRef.id,
+        namespace: DEFAULT_NAMESPACE,
+        agentConfigId: agentConfigRef.agentConfigId,
+        envConfigId: envConfigRef.envConfigId,
       });
     }
 
-    /** intake must have started a run; returns the claimed item + token. */
-    async function startAndClaim(sessionId: string): Promise<{ itemId: string; token: string }> {
-      const result = await store.intake(sessionId, user("go"));
+    /** intake must have started a run; returns the claimed item + token.
+     *  The claimed row IS its own WorkItemRef — passed on unrebuilt. */
+    async function startAndClaim(
+      ref: SessionRef,
+    ): Promise<{ itemRef: WorkItemRef; token: string }> {
+      const result = await store.intake(ref, user("go"));
       expect(result.kind).toBe("started");
-      const claim = await store.claimItem({ leaseMs: 60_000, sessionId });
+      const claim = await store.claimItem({ leaseMs: 60_000, session: ref });
       expect(claim).toBeDefined();
-      return { itemId: claim!.item.id, token: claim!.token };
+      return { itemRef: claim!.item, token: claim!.token };
     }
 
     describe("configs", () => {
@@ -101,7 +107,7 @@ export function describeStoreConformance(
         });
         const config = await store.getAgentConfig(ref);
         expect(config).toMatchObject({
-          id: ref.id,
+          agentConfigId: ref.agentConfigId,
           namespace: ref.namespace,
           inference: { provider: "anthropic", model: "claude-sonnet-5", maxTokens: 8192 },
           systemPrompt: "You are helpful.",
@@ -155,7 +161,7 @@ export function describeStoreConformance(
         });
 
         expect(updated).toMatchObject({
-          id: ref.id,
+          agentConfigId: ref.agentConfigId,
           inference: { provider: "anthropic", model: "old-model", maxTokens: 1024 },
           systemPrompt: "new prompt",
           metadata: { team: "growth" },
@@ -240,7 +246,11 @@ export function describeStoreConformance(
         );
         expect(await store.getAgentConfig({ ...ref, version: 4 })).toBeUndefined();
         expect(
-          await store.getAgentConfig({ namespace: DEFAULT_NAMESPACE, id: "nope", version: 1 }),
+          await store.getAgentConfig({
+            namespace: DEFAULT_NAMESPACE,
+            agentConfigId: "nope",
+            version: 1,
+          }),
         ).toBeUndefined();
       });
 
@@ -259,10 +269,16 @@ export function describeStoreConformance(
       it("treats an unknown or foreign update target as absent", async () => {
         const ref = await newAgent({ namespace: "tenant-a" });
         await expect(
-          store.updateAgentConfig({ namespace: "tenant-a", id: "nope" }, { systemPrompt: "x" }),
+          store.updateAgentConfig(
+            { namespace: "tenant-a", agentConfigId: "nope" },
+            { systemPrompt: "x" },
+          ),
         ).resolves.toBeUndefined();
         await expect(
-          store.updateAgentConfig({ namespace: "tenant-b", id: ref.id }, { systemPrompt: "x" }),
+          store.updateAgentConfig(
+            { namespace: "tenant-b", agentConfigId: ref.agentConfigId },
+            { systemPrompt: "x" },
+          ),
         ).resolves.toBeUndefined();
         expect((await store.getAgentConfig(ref))?.systemPrompt).toBe("s");
       });
@@ -350,33 +366,41 @@ export function describeStoreConformance(
       it("returns undefined for unknown or foreign agent config refs", async () => {
         const ref = await newAgent({ namespace: "tenant-a" });
         expect(
-          await store.getAgentConfig({ namespace: DEFAULT_NAMESPACE, id: "nope" }),
+          await store.getAgentConfig({ namespace: DEFAULT_NAMESPACE, agentConfigId: "nope" }),
         ).toBeUndefined();
-        expect(await store.getAgentConfig({ namespace: "tenant-b", id: ref.id })).toBeUndefined();
         expect(
-          await store.getAgentConfig({ namespace: "tenant-b", id: ref.id, version: 1 }),
+          await store.getAgentConfig({ namespace: "tenant-b", agentConfigId: ref.agentConfigId }),
+        ).toBeUndefined();
+        expect(
+          await store.getAgentConfig({
+            namespace: "tenant-b",
+            agentConfigId: ref.agentConfigId,
+            version: 1,
+          }),
         ).toBeUndefined();
       });
 
       it("returns undefined for unknown or foreign env config refs", async () => {
         const ref = await newEnv({ namespace: "tenant-a" });
         expect(
-          await store.getEnvConfig({ namespace: DEFAULT_NAMESPACE, id: "nope" }),
+          await store.getEnvConfig({ namespace: DEFAULT_NAMESPACE, envConfigId: "nope" }),
         ).toBeUndefined();
-        expect(await store.getEnvConfig({ namespace: "tenant-b", id: ref.id })).toBeUndefined();
+        expect(
+          await store.getEnvConfig({ namespace: "tenant-b", envConfigId: ref.envConfigId }),
+        ).toBeUndefined();
       });
 
       it("treats an unknown or foreign env config update target as absent", async () => {
         const ref = await newEnv({ namespace: "tenant-a", packages: { pip: ["numpy"] } });
         await expect(
           store.updateEnvConfig(
-            { namespace: "tenant-a", id: "nope" },
+            { namespace: "tenant-a", envConfigId: "nope" },
             { packages: { npm: ["zod"] } },
           ),
         ).resolves.toBeUndefined();
         await expect(
           store.updateEnvConfig(
-            { namespace: "tenant-b", id: ref.id },
+            { namespace: "tenant-b", envConfigId: ref.envConfigId },
             { packages: { npm: ["zod"] } },
           ),
         ).resolves.toBeUndefined();
@@ -427,7 +451,7 @@ export function describeStoreConformance(
         ]) {
           await expect(store.updateAgentConfig(ref, req)).rejects.toMatchObject({
             name: "ArchivedError",
-            configId: ref.id,
+            configId: ref.agentConfigId,
           });
         }
         expect(await store.getAgentConfig(ref)).toMatchObject({
@@ -460,9 +484,9 @@ export function describeStoreConformance(
         expect(await store.getAgentConfig(ref)).toEqual(archived);
         expect(
           (await store.listAgentConfigs({ namespace: DEFAULT_NAMESPACE, limit: 10 })).map(
-            (c) => c.id,
+            (c) => c.agentConfigId,
           ),
-        ).toContain(ref.id);
+        ).toContain(ref.agentConfigId);
         // The identity retired, not a snapshot: every version reads back,
         // and each one carries the mark.
         for (const version of [1, 2]) {
@@ -480,13 +504,18 @@ export function describeStoreConformance(
         await store.archiveAgentConfig(agentConfigRef);
 
         await expect(
-          store.createSession({ agentConfigId: agentConfigRef.id, envConfigId: envConfigRef.id }),
+          store.createSession({
+            namespace: DEFAULT_NAMESPACE,
+            agentConfigId: agentConfigRef.agentConfigId,
+            envConfigId: envConfigRef.envConfigId,
+          }),
         ).rejects.toBeInstanceOf(ArchivedError);
         await expect(
           store.createSession({
-            agentConfigId: agentConfigRef.id,
+            namespace: DEFAULT_NAMESPACE,
+            agentConfigId: agentConfigRef.agentConfigId,
             agentConfigVersion: 1,
-            envConfigId: envConfigRef.id,
+            envConfigId: envConfigRef.envConfigId,
           }),
         ).rejects.toBeInstanceOf(ArchivedError);
       });
@@ -494,15 +523,16 @@ export function describeStoreConformance(
       it("lets sessions that already reference it run on", async () => {
         const agentConfigRef = await newAgent({ systemPrompt: "pinned" });
         const envConfigRef = await newEnv();
-        const sessionId = await store.createSession({
-          agentConfigId: agentConfigRef.id,
-          envConfigId: envConfigRef.id,
+        const sessionRef = await store.createSession({
+          namespace: DEFAULT_NAMESPACE,
+          agentConfigId: agentConfigRef.agentConfigId,
+          envConfigId: envConfigRef.envConfigId,
         });
         await store.archiveAgentConfig(agentConfigRef);
 
         // The session still resolves the behavior it pinned, and still runs:
         // archiving stops new references, not existing work.
-        const session = await store.getSession(sessionId);
+        const session = await store.getSession(sessionRef);
         expect(
           (
             await store.getAgentConfig({
@@ -511,14 +541,14 @@ export function describeStoreConformance(
             })
           )?.systemPrompt,
         ).toBe("pinned");
-        const { itemId, token } = await startAndClaim(sessionId);
+        const { itemRef, token } = await startAndClaim(sessionRef);
         await store.commitStep({
-          itemId,
+          itemRef,
           token,
           append: [assistant("still here")],
           next: { kind: "end_run", status: "completed" },
         });
-        expect(await store.readEntries(sessionId)).toHaveLength(2);
+        expect(await store.readEntries(sessionRef)).toHaveLength(2);
       });
 
       it("settles a create/archive race one of the two legal ways", async () => {
@@ -526,7 +556,11 @@ export function describeStoreConformance(
         const envConfigRef = await newEnv();
 
         const [created, archived] = await Promise.allSettled([
-          store.createSession({ agentConfigId: agentConfigRef.id, envConfigId: envConfigRef.id }),
+          store.createSession({
+            namespace: DEFAULT_NAMESPACE,
+            agentConfigId: agentConfigRef.agentConfigId,
+            envConfigId: envConfigRef.envConfigId,
+          }),
           store.archiveAgentConfig(agentConfigRef),
         ]);
 
@@ -542,17 +576,24 @@ export function describeStoreConformance(
         }
         // Whoever won, the door is shut behind them.
         await expect(
-          store.createSession({ agentConfigId: agentConfigRef.id, envConfigId: envConfigRef.id }),
+          store.createSession({
+            namespace: DEFAULT_NAMESPACE,
+            agentConfigId: agentConfigRef.agentConfigId,
+            envConfigId: envConfigRef.envConfigId,
+          }),
         ).rejects.toBeInstanceOf(ArchivedError);
       });
 
       it("treats an unknown or foreign archive target as absent", async () => {
         const ref = await newAgent({ namespace: "tenant-a" });
         expect(
-          await store.archiveAgentConfig({ namespace: "tenant-a", id: "nope" }),
+          await store.archiveAgentConfig({ namespace: "tenant-a", agentConfigId: "nope" }),
         ).toBeUndefined();
         expect(
-          await store.archiveAgentConfig({ namespace: "tenant-b", id: ref.id }),
+          await store.archiveAgentConfig({
+            namespace: "tenant-b",
+            agentConfigId: ref.agentConfigId,
+          }),
         ).toBeUndefined();
         // The foreign archive touched nothing.
         expect(await store.getAgentConfig(ref)).toMatchObject({ namespace: "tenant-a" });
@@ -562,14 +603,14 @@ export function describeStoreConformance(
 
     describe("listing configs", () => {
       /** n configs, each a tick newer than the last, oldest id first. */
-      async function agentConfigs(n: number, namespace?: string): Promise<string[]> {
+      async function agentConfigIds(n: number, namespace?: string): Promise<string[]> {
         const ids: string[] = [];
         for (let i = 0; i < n; i++) {
           const ref = await newAgent({
             inference: { provider: "fake", model: `m${i}` },
             ...(namespace === undefined ? {} : { namespace }),
           });
-          ids.push(ref.id);
+          ids.push(ref.agentConfigId);
           clock.advance(1_000);
         }
         return ids;
@@ -583,32 +624,32 @@ export function describeStoreConformance(
           const page = await store.listAgentConfigs({ namespace, limit, after });
           expect(page.length).toBeLessThanOrEqual(limit);
           if (page.length === 0) return ids;
-          ids.push(...page.map((c) => c.id));
-          after = page[page.length - 1]?.id;
+          ids.push(...page.map((c) => c.agentConfigId));
+          after = page[page.length - 1]?.agentConfigId;
         }
         throw new Error("walk did not terminate");
       }
 
       it("lists a namespace's configs newest first, whole rows", async () => {
-        const [oldest, middle, newest] = await agentConfigs(3);
+        const [oldest, middle, newest] = await agentConfigIds(3);
         const configs = await store.listAgentConfigs({ namespace: DEFAULT_NAMESPACE, limit: 10 });
-        expect(configs.map((c) => c.id)).toEqual([newest, middle, oldest]);
+        expect(configs.map((c) => c.agentConfigId)).toEqual([newest, middle, oldest]);
         // The same shape a get returns — one row mapping, not two.
         expect(configs[0]).toEqual(
-          await store.getAgentConfig({ namespace: DEFAULT_NAMESPACE, id: newest! }),
+          await store.getAgentConfig({ namespace: DEFAULT_NAMESPACE, agentConfigId: newest! }),
         );
       });
 
       it("bounds the page at limit and resumes strictly after the cursor", async () => {
-        const [oldest, middle, newest] = await agentConfigs(3);
+        const [oldest, middle, newest] = await agentConfigIds(3);
         const first = await store.listAgentConfigs({ namespace: DEFAULT_NAMESPACE, limit: 2 });
-        expect(first.map((c) => c.id)).toEqual([newest, middle]);
+        expect(first.map((c) => c.agentConfigId)).toEqual([newest, middle]);
         const second = await store.listAgentConfigs({
           namespace: DEFAULT_NAMESPACE,
           limit: 2,
           after: middle,
         });
-        expect(second.map((c) => c.id)).toEqual([oldest]);
+        expect(second.map((c) => c.agentConfigId)).toEqual([oldest]);
         expect(
           await store.listAgentConfigs({ namespace: DEFAULT_NAMESPACE, limit: 2, after: oldest }),
         ).toEqual([]);
@@ -633,22 +674,22 @@ export function describeStoreConformance(
             after,
           });
           if (page.length === 0) break;
-          walked.push(...page.map((c) => c.id));
-          after = page[page.length - 1]?.id;
+          walked.push(...page.map((c) => c.envConfigId));
+          after = page[page.length - 1]?.envConfigId;
         }
-        expect(walked).toEqual(whole.map((c) => c.id));
+        expect(walked).toEqual(whole.map((c) => c.envConfigId));
       });
 
       it("scopes the list to one namespace — a page walk never crosses the boundary", async () => {
-        const a = await agentConfigs(3, "tenant-a");
-        const b = await agentConfigs(2, "tenant-b");
+        const a = await agentConfigIds(3, "tenant-a");
+        const b = await agentConfigIds(2, "tenant-b");
         expect(await walk("tenant-a", 2)).toEqual([...a].reverse());
         expect(await walk("tenant-b", 2)).toEqual([...b].reverse());
         expect(await store.listAgentConfigs({ namespace: "tenant-c", limit: 10 })).toEqual([]);
       });
 
       it("rejects a cursor it cannot resolve — a foreign one like a nonexistent one", async () => {
-        const [foreign] = await agentConfigs(1, "tenant-b");
+        const [foreign] = await agentConfigIds(1, "tenant-b");
         await expect(
           store.listAgentConfigs({ namespace: "tenant-a", limit: 10, after: "nope" }),
         ).rejects.toThrow("unknown cursor");
@@ -658,10 +699,10 @@ export function describeStoreConformance(
       });
 
       it("lists the two config kinds independently", async () => {
-        await agentConfigs(2);
+        await agentConfigIds(2);
         const envRef = await newEnv();
         const envs = await store.listEnvConfigs({ namespace: DEFAULT_NAMESPACE, limit: 10 });
-        expect(envs.map((c) => c.id)).toEqual([envRef.id]);
+        expect(envs.map((c) => c.envConfigId)).toEqual([envRef.envConfigId]);
         expect(envs[0]).toEqual(await store.getEnvConfig(envRef));
         expect(
           await store.listAgentConfigs({ namespace: DEFAULT_NAMESPACE, limit: 10 }),
@@ -671,9 +712,11 @@ export function describeStoreConformance(
 
     describe("sessions", () => {
       it("round-trips a session", async () => {
-        const sessionId = await newSession();
-        const session = await store.getSession(sessionId);
-        expect(session?.id).toBe(sessionId);
+        const sessionRef = await newSession();
+        expect(sessionRef.namespace).toBe(DEFAULT_NAMESPACE);
+        const session = await store.getSession(sessionRef);
+        expect(session?.sessionId).toBe(sessionRef.sessionId);
+        expect(session?.namespace).toBe(DEFAULT_NAMESPACE);
         expect(session?.agentConfigId).toBeDefined();
         expect(session?.agentConfigVersion).toBe(1);
         expect(session?.envConfigId).toBeDefined();
@@ -686,13 +729,14 @@ export function describeStoreConformance(
         });
         const envConfigRef = await newEnv();
         await store.updateAgentConfig(agentConfigRef, { systemPrompt: "v2", version: 1 });
-        const sessionId = await store.createSession({
-          agentConfigId: agentConfigRef.id,
-          envConfigId: envConfigRef.id,
+        const sessionRef = await store.createSession({
+          namespace: DEFAULT_NAMESPACE,
+          agentConfigId: agentConfigRef.agentConfigId,
+          envConfigId: envConfigRef.envConfigId,
         });
         await store.updateAgentConfig(agentConfigRef, { systemPrompt: "v3", version: 2 });
 
-        const session = await store.getSession(sessionId);
+        const session = await store.getSession(sessionRef);
         expect(session?.agentConfigVersion).toBe(2);
         expect(
           (
@@ -709,53 +753,65 @@ export function describeStoreConformance(
         const envConfigRef = await newEnv();
         await store.updateAgentConfig(agentConfigRef, { systemPrompt: "v2", version: 1 });
 
-        const sessionId = await store.createSession({
-          agentConfigId: agentConfigRef.id,
+        const sessionRef = await store.createSession({
+          namespace: DEFAULT_NAMESPACE,
+          agentConfigId: agentConfigRef.agentConfigId,
           agentConfigVersion: 1,
-          envConfigId: envConfigRef.id,
+          envConfigId: envConfigRef.envConfigId,
         });
 
-        expect((await store.getSession(sessionId))?.agentConfigVersion).toBe(1);
+        expect((await store.getSession(sessionRef))?.agentConfigVersion).toBe(1);
       });
 
       it("bindSandbox: first writer wins, losers learn the winner", async () => {
-        const sessionId = await newSession();
-        expect((await store.getSession(sessionId))?.sandboxId).toBeUndefined();
+        const sessionRef = await newSession();
+        expect((await store.getSession(sessionRef))?.sandboxId).toBeUndefined();
 
-        expect(await store.bindSandbox(sessionId, "sbx_a")).toBe("sbx_a");
+        expect(await store.bindSandbox(sessionRef, "sbx_a")).toBe("sbx_a");
         // The loser's candidate is not recorded; it gets the winner back.
-        expect(await store.bindSandbox(sessionId, "sbx_b")).toBe("sbx_a");
-        expect((await store.getSession(sessionId))?.sandboxId).toBe("sbx_a");
+        expect(await store.bindSandbox(sessionRef, "sbx_b")).toBe("sbx_a");
+        expect((await store.getSession(sessionRef))?.sandboxId).toBe("sbx_a");
       });
 
       it("bindSandbox replaces only the expected previous binding", async () => {
-        const sessionId = await newSession();
-        await store.bindSandbox(sessionId, "sbx_a");
+        const sessionRef = await newSession();
+        await store.bindSandbox(sessionRef, "sbx_a");
 
         // Wrong expectation: nothing written, the current binding returns.
-        expect(await store.bindSandbox(sessionId, "sbx_c", "sbx_b")).toBe("sbx_a");
-        expect((await store.getSession(sessionId))?.sandboxId).toBe("sbx_a");
+        expect(await store.bindSandbox(sessionRef, "sbx_c", "sbx_b")).toBe("sbx_a");
+        expect((await store.getSession(sessionRef))?.sandboxId).toBe("sbx_a");
 
         // Right expectation: the dead binding is replaced.
-        expect(await store.bindSandbox(sessionId, "sbx_c", "sbx_a")).toBe("sbx_c");
-        expect((await store.getSession(sessionId))?.sandboxId).toBe("sbx_c");
+        expect(await store.bindSandbox(sessionRef, "sbx_c", "sbx_a")).toBe("sbx_c");
+        expect((await store.getSession(sessionRef))?.sandboxId).toBe("sbx_c");
       });
 
-      it("bindSandbox rejects an unknown session", async () => {
-        await expect(store.bindSandbox("nope", "sbx_a")).rejects.toThrow("unknown session");
+      it("bindSandbox rejects an unknown or foreign session", async () => {
+        await expect(
+          store.bindSandbox({ namespace: DEFAULT_NAMESPACE, sessionId: "nope" }, "sbx_a"),
+        ).rejects.toThrow("unknown session");
+        const sessionRef = await newSession();
+        await expect(
+          store.bindSandbox({ ...sessionRef, namespace: "tenant-b" }, "sbx_a"),
+        ).rejects.toThrow("unknown session");
       });
 
       it("rejects a session naming an unknown agent config or version", async () => {
         const envConfigRef = await newEnv();
         await expect(
-          store.createSession({ agentConfigId: "nope", envConfigId: envConfigRef.id }),
+          store.createSession({
+            namespace: DEFAULT_NAMESPACE,
+            agentConfigId: "nope",
+            envConfigId: envConfigRef.envConfigId,
+          }),
         ).rejects.toThrow();
         const agentConfigRef = await newAgent();
         await expect(
           store.createSession({
-            agentConfigId: agentConfigRef.id,
+            namespace: DEFAULT_NAMESPACE,
+            agentConfigId: agentConfigRef.agentConfigId,
             agentConfigVersion: 2,
-            envConfigId: envConfigRef.id,
+            envConfigId: envConfigRef.envConfigId,
           }),
         ).rejects.toThrow();
       });
@@ -763,35 +819,53 @@ export function describeStoreConformance(
       it("rejects a session naming an unknown env config", async () => {
         const agentConfigRef = await newAgent();
         await expect(
-          store.createSession({ agentConfigId: agentConfigRef.id, envConfigId: "nope" }),
+          store.createSession({
+            namespace: DEFAULT_NAMESPACE,
+            agentConfigId: agentConfigRef.agentConfigId,
+            envConfigId: "nope",
+          }),
         ).rejects.toThrow();
       });
     });
 
     describe("namespace", () => {
-      it("uses the explicit default namespace for configs while sessions default", async () => {
+      it("stamps every row with the namespace it was created under", async () => {
         const agentConfigRef = await newAgent();
         const envConfigRef = await newEnv();
-        const sessionId = await store.createSession({
-          agentConfigId: agentConfigRef.id,
-          envConfigId: envConfigRef.id,
+        const sessionRef = await store.createSession({
+          namespace: DEFAULT_NAMESPACE,
+          agentConfigId: agentConfigRef.agentConfigId,
+          envConfigId: envConfigRef.envConfigId,
         });
         expect((await store.getAgentConfig(agentConfigRef))?.namespace).toBe(DEFAULT_NAMESPACE);
         expect((await store.getEnvConfig(envConfigRef))?.namespace).toBe(DEFAULT_NAMESPACE);
-        expect((await store.getSession(sessionId))?.namespace).toBe(DEFAULT_NAMESPACE);
+        expect((await store.getSession(sessionRef))?.namespace).toBe(DEFAULT_NAMESPACE);
       });
 
       it("stores an explicit namespace verbatim", async () => {
         const agentConfigRef = await newAgent({ namespace: "tenant-a" });
         const envConfigRef = await newEnv({ namespace: "tenant-a" });
-        const sessionId = await store.createSession({
-          agentConfigId: agentConfigRef.id,
-          envConfigId: envConfigRef.id,
+        const sessionRef = await store.createSession({
           namespace: "tenant-a",
+          agentConfigId: agentConfigRef.agentConfigId,
+          envConfigId: envConfigRef.envConfigId,
         });
+        expect(sessionRef.namespace).toBe("tenant-a");
         expect((await store.getAgentConfig(agentConfigRef))?.namespace).toBe("tenant-a");
         expect((await store.getEnvConfig(envConfigRef))?.namespace).toBe("tenant-a");
-        expect((await store.getSession(sessionId))?.namespace).toBe("tenant-a");
+        expect((await store.getSession(sessionRef))?.namespace).toBe("tenant-a");
+      });
+
+      it("rejects a session create without a namespace at the boundary", async () => {
+        const agentConfigRef = await newAgent();
+        const envConfigRef = await newEnv();
+        await expect(
+          store.createSession({
+            agentConfigId: agentConfigRef.agentConfigId,
+            envConfigId: envConfigRef.envConfigId,
+            // biome-ignore lint/suspicious/noExplicitAny: deliberately incomplete
+          } as any),
+        ).rejects.toThrow();
       });
 
       it("a foreign-namespace config is unknown — sessions and their configs share one namespace", async () => {
@@ -803,84 +877,135 @@ export function describeStoreConformance(
         // error is the same "unknown", so existence never leaks.
         await expect(
           store.createSession({
-            agentConfigId: agentA.id,
-            envConfigId: envB.id,
             namespace: "tenant-a",
+            agentConfigId: agentA.agentConfigId,
+            envConfigId: envB.envConfigId,
           }),
         ).rejects.toThrow("unknown env config");
         await expect(
           store.createSession({
-            agentConfigId: agentA.id,
-            envConfigId: envA.id,
             namespace: "tenant-b",
+            agentConfigId: agentA.agentConfigId,
+            envConfigId: envA.envConfigId,
           }),
         ).rejects.toThrow("unknown agent config");
         // The matched trio is accepted.
         await expect(
           store.createSession({
-            agentConfigId: agentA.id,
-            envConfigId: envA.id,
             namespace: "tenant-a",
+            agentConfigId: agentA.agentConfigId,
+            envConfigId: envA.envConfigId,
           }),
         ).resolves.toBeDefined();
       });
     });
 
+    describe("session scoping", () => {
+      it("a foreign session ref is unknown — gets, reads, and writes all agree", async () => {
+        const sessionRef = await newSession();
+        await store.intake(sessionRef, user("go")); // seed an entry and an item
+        await store.intake(sessionRef, user("queued")); // seed a pending input
+        const foreign: SessionRef = { namespace: "tenant-b", sessionId: sessionRef.sessionId };
+
+        expect(await store.getSession(foreign)).toBeUndefined();
+        expect(await store.readEntries(foreign)).toEqual([]);
+        expect(await store.listItems(foreign)).toEqual([]);
+        expect(await store.pendingInputs(foreign)).toEqual([]);
+        await expect(store.intake(foreign, user("hi"))).rejects.toThrow("unknown session");
+        await expect(store.requestCancel(foreign)).rejects.toThrow("unknown session");
+
+        // The rightful owner still sees everything.
+        expect(await store.readEntries(sessionRef)).toHaveLength(1);
+        expect(await store.listItems(sessionRef)).toHaveLength(1);
+        expect(await store.pendingInputs(sessionRef)).toHaveLength(1);
+      });
+
+      it("a foreign claim filter finds nothing", async () => {
+        const sessionRef = await newSession();
+        await store.intake(sessionRef, user("go"));
+        expect(
+          await store.claimItem({
+            leaseMs: 60_000,
+            session: { ...sessionRef, namespace: "tenant-b" },
+          }),
+        ).toBeUndefined();
+        expect(await store.claimItem({ leaseMs: 60_000, session: sessionRef })).toBeDefined();
+      });
+
+      it("hands the driver its scope on the claimed row", async () => {
+        const sessionRef = await newSession();
+        await store.intake(sessionRef, user("go"));
+        // No filter — the claim starts from nothing; the row must carry
+        // the namespace and parent every later ref needs.
+        const claim = await store.claimItem({ leaseMs: 60_000 });
+        expect(claim?.item).toMatchObject({
+          namespace: sessionRef.namespace,
+          sessionId: sessionRef.sessionId,
+        });
+      });
+    });
+
     describe("intake", () => {
       it("starts a run on an idle session — one entry, one ready inference item", async () => {
-        const sessionId = await newSession();
-        const result = await store.intake(sessionId, user("hi"));
+        const sessionRef = await newSession();
+        const result = await store.intake(sessionRef, user("hi"));
         expect(result.kind).toBe("started");
-        const entries = await store.readEntries(sessionId);
+        const entries = await store.readEntries(sessionRef);
         expect(entries).toHaveLength(1);
         expect(entries[0]).toMatchObject({ type: "message", seq: 0, message: user("hi") });
-        const items = await store.listItems(sessionId);
+        const items = await store.listItems(sessionRef);
         expect(items).toHaveLength(1);
         expect(items[0]).toMatchObject({ type: "inference", status: "ready" });
       });
 
       it("queues on a busy session — a pending input, never a second item", async () => {
-        const sessionId = await newSession();
-        await store.intake(sessionId, user("first"));
-        const result = await store.intake(sessionId, user("second"));
+        const sessionRef = await newSession();
+        await store.intake(sessionRef, user("first"));
+        const result = await store.intake(sessionRef, user("second"));
         expect(result.kind).toBe("queued");
-        expect(await store.listItems(sessionId)).toHaveLength(1);
-        const pending = await store.pendingInputs(sessionId);
+        expect(await store.listItems(sessionRef)).toHaveLength(1);
+        const pending = await store.pendingInputs(sessionRef);
         expect(pending).toHaveLength(1);
         expect(pending[0]?.message).toEqual(user("second"));
         // The queued message is parked, not logged.
-        expect(await store.readEntries(sessionId)).toHaveLength(1);
+        expect(await store.readEntries(sessionRef)).toHaveLength(1);
       });
 
       it("rejects intake for an unknown session", async () => {
-        await expect(store.intake("nope", user("hi"))).rejects.toThrow();
+        await expect(
+          store.intake({ namespace: DEFAULT_NAMESPACE, sessionId: "nope" }, user("hi")),
+        ).rejects.toThrow();
       });
 
       it("admits exactly one starter under concurrent intake", async () => {
-        const sessionId = await newSession();
+        const sessionRef = await newSession();
         const results = await Promise.all(
-          Array.from({ length: 5 }, (_, i) => store.intake(sessionId, user(`m${i}`))),
+          Array.from({ length: 5 }, (_, i) => store.intake(sessionRef, user(`m${i}`))),
         );
         expect(results.filter((r) => r.kind === "started")).toHaveLength(1);
         expect(results.filter((r) => r.kind === "queued")).toHaveLength(4);
-        expect(await store.listItems(sessionId)).toHaveLength(1);
+        expect(await store.listItems(sessionRef)).toHaveLength(1);
       });
     });
 
     describe("claiming", () => {
       it("leases the ready item to exactly one claimer", async () => {
-        const sessionId = await newSession();
-        await store.intake(sessionId, user("go"));
+        const sessionRef = await newSession();
+        await store.intake(sessionRef, user("go"));
         const claim = await store.claimItem({ leaseMs: 60_000 });
-        expect(claim?.item).toMatchObject({ sessionId, type: "inference", status: "leased" });
+        expect(claim?.item).toMatchObject({
+          sessionId: sessionRef.sessionId,
+          type: "inference",
+          status: "leased",
+        });
         expect(claim?.token).toBeTruthy();
         expect(await store.claimItem({ leaseMs: 60_000 })).toBeUndefined();
       });
 
       it("counts attempts: 0 until claimed, incremented by every claim", async () => {
-        const sessionId = await newSession();
-        await store.intake(sessionId, user("go"));
-        expect((await store.listItems(sessionId))[0]?.attempt).toBe(0);
+        const sessionRef = await newSession();
+        await store.intake(sessionRef, user("go"));
+        expect((await store.listItems(sessionRef))[0]?.attempt).toBe(0);
 
         const first = await store.claimItem({ leaseMs: 1_000 });
         expect(first?.item.attempt).toBe(1);
@@ -890,53 +1015,64 @@ export function describeStoreConformance(
         clock.advance(5_000);
         const second = await store.claimItem({ leaseMs: 1_000 });
         expect(second?.item.attempt).toBe(2);
-        expect((await store.listItems(sessionId))[0]?.attempt).toBe(2);
+        expect((await store.listItems(sessionRef))[0]?.attempt).toBe(2);
       });
 
       it("admits exactly one winner under contended claims", async () => {
-        const sessionId = await newSession();
-        await store.intake(sessionId, user("go"));
+        const sessionRef = await newSession();
+        await store.intake(sessionRef, user("go"));
         const claims = await Promise.all(
           Array.from({ length: 8 }, () => store.claimItem({ leaseMs: 60_000 })),
         );
         expect(claims.filter((c) => c !== undefined)).toHaveLength(1);
       });
 
-      it("scopes the claim scan when sessionId is given", async () => {
+      it("scopes the claim scan when a session is given", async () => {
         const s1 = await newSession();
         const s2 = await newSession();
         await store.intake(s1, user("a"));
         await store.intake(s2, user("b"));
-        const claim = await store.claimItem({ leaseMs: 60_000, sessionId: s2 });
-        expect(claim?.item.sessionId).toBe(s2);
+        const claim = await store.claimItem({ leaseMs: 60_000, session: s2 });
+        expect(claim?.item.sessionId).toBe(s2.sessionId);
       });
 
       it("heartbeats only the live lease's token", async () => {
-        const sessionId = await newSession();
-        const { itemId, token } = await startAndClaim(sessionId);
-        expect(await store.heartbeat(itemId, token)).toBe(true);
-        expect(await store.heartbeat(itemId, "forged-token")).toBe(false);
+        const sessionRef = await newSession();
+        const { itemRef, token } = await startAndClaim(sessionRef);
+        expect(await store.heartbeat(itemRef, token)).toBe(true);
+        expect(await store.heartbeat(itemRef, "forged-token")).toBe(false);
+      });
+
+      it("misses a heartbeat addressed through the wrong session or namespace", async () => {
+        const s1 = await newSession();
+        const s2 = await newSession();
+        const { itemRef, token } = await startAndClaim(s1);
+        // The full path is the address: a mismatched parent or a foreign
+        // namespace is unknown, exactly like a missing item.
+        expect(await store.heartbeat({ ...itemRef, sessionId: s2.sessionId }, token)).toBe(false);
+        expect(await store.heartbeat({ ...itemRef, namespace: "tenant-b" }, token)).toBe(false);
+        expect(await store.heartbeat(itemRef, token)).toBe(true);
       });
 
       it("reclaims an expired lease with a fresh token, fencing the old one", async () => {
-        const sessionId = await newSession();
-        const { itemId, token } = await startAndClaim(sessionId);
+        const sessionRef = await newSession();
+        const { itemRef, token } = await startAndClaim(sessionRef);
         clock.advance(120_000);
-        expect(await store.heartbeat(itemId, token)).toBe(false); // lease lost
+        expect(await store.heartbeat(itemRef, token)).toBe(false); // lease lost
         const reclaimed = await store.claimItem({ leaseMs: 60_000 });
-        expect(reclaimed?.item.id).toBe(itemId);
+        expect(reclaimed?.item.itemId).toBe(itemRef.itemId);
         // A re-claim never re-issues the credential — the zombie stays fenced.
         expect(reclaimed?.token).not.toBe(token);
         await expect(
           store.commitStep({
-            itemId,
+            itemRef,
             token,
             append: [assistant("stale work")],
             next: { kind: "end_run", status: "completed" },
           }),
         ).rejects.toThrow(FencedError);
         await store.commitStep({
-          itemId,
+          itemRef,
           token: reclaimed!.token,
           append: [assistant("done")],
           next: { kind: "end_run", status: "completed" },
@@ -944,48 +1080,48 @@ export function describeStoreConformance(
       });
 
       it("transfers authority at the exact expiry instant — expired has one spelling", async () => {
-        const sessionId = await newSession();
-        const { itemId, token } = await startAndClaim(sessionId); // leaseMs 60_000
+        const sessionRef = await newSession();
+        const { itemRef, token } = await startAndClaim(sessionRef); // leaseMs 60_000
         clock.advance(60_000); // now == leaseExpiresAt, exactly
-        expect(await store.heartbeat(itemId, token)).toBe(false); // holder is out…
+        expect(await store.heartbeat(itemRef, token)).toBe(false); // holder is out…
         await expect(
           store.commitStep({
-            itemId,
+            itemRef,
             token,
             append: [assistant("at the wire")],
             next: { kind: "end_run", status: "completed" },
           }),
         ).rejects.toThrow(FencedError);
         const reclaimed = await store.claimItem({ leaseMs: 60_000 }); // …and a claimer is in
-        expect(reclaimed?.item.id).toBe(itemId);
+        expect(reclaimed?.item.itemId).toBe(itemRef.itemId);
       });
 
       it("rejects a commit on an expired lease even before any reclaim", async () => {
-        const sessionId = await newSession();
-        const { itemId, token } = await startAndClaim(sessionId);
+        const sessionRef = await newSession();
+        const { itemRef, token } = await startAndClaim(sessionRef);
         clock.advance(120_000);
         await expect(
           store.commitStep({
-            itemId,
+            itemRef,
             token,
             append: [assistant("late")],
             next: { kind: "end_run", status: "completed" },
           }),
         ).rejects.toThrow(FencedError);
         // The rejected commit rolled back whole — nothing landed.
-        expect(await store.readEntries(sessionId)).toHaveLength(1);
+        expect(await store.readEntries(sessionRef)).toHaveLength(1);
         // After expiry the item's fate belongs to its next claimer.
         const reclaimed = await store.claimItem({ leaseMs: 60_000 });
-        expect(reclaimed?.item.id).toBe(itemId);
+        expect(reclaimed?.item.itemId).toBe(itemRef.itemId);
       });
     });
 
     describe("cancel", () => {
       it("appends a control entry in log order", async () => {
-        const sessionId = await newSession();
-        await store.intake(sessionId, user("go"));
-        await store.requestCancel(sessionId);
-        const entries = await store.readEntries(sessionId);
+        const sessionRef = await newSession();
+        await store.intake(sessionRef, user("go"));
+        await store.requestCancel(sessionRef);
+        const entries = await store.readEntries(sessionRef);
         expect(entries).toHaveLength(2);
         expect(entries[1]).toMatchObject({ type: "control", control: "cancel", seq: 1 });
       });
@@ -993,100 +1129,100 @@ export function describeStoreConformance(
 
     describe("commitStep", () => {
       it("appends output and chains the next item atomically", async () => {
-        const sessionId = await newSession();
-        const { itemId, token } = await startAndClaim(sessionId);
+        const sessionRef = await newSession();
+        const { itemRef, token } = await startAndClaim(sessionRef);
         await store.commitStep({
-          itemId,
+          itemRef,
           token,
           append: [assistant("thinking…")],
           next: { kind: "execute_tools" },
         });
-        const entries = await store.readEntries(sessionId);
+        const entries = await store.readEntries(sessionRef);
         expect(entries.map((e) => e.seq)).toEqual([0, 1]);
-        const items = await store.listItems(sessionId);
+        const items = await store.listItems(sessionRef);
         expect(items).toHaveLength(2);
-        expect(items[0]).toMatchObject({ id: itemId, status: "done" });
+        expect(items[0]).toMatchObject({ itemId: itemRef.itemId, status: "done" });
         expect(items[1]).toMatchObject({ type: "execute_tools", status: "ready" });
       });
 
       it("end_run with no pending inputs leaves the session idle", async () => {
-        const sessionId = await newSession();
-        const { itemId, token } = await startAndClaim(sessionId);
+        const sessionRef = await newSession();
+        const { itemRef, token } = await startAndClaim(sessionRef);
         await store.commitStep({
-          itemId,
+          itemRef,
           token,
           append: [assistant("done")],
           next: { kind: "end_run", status: "completed" },
         });
-        const items = await store.listItems(sessionId);
+        const items = await store.listItems(sessionRef);
         expect(items).toHaveLength(1); // the run's end is the NON-creation of a next item
         expect(items[0]?.status).toBe("done");
         // Idle again: the next intake starts a run.
-        expect((await store.intake(sessionId, user("next"))).kind).toBe("started");
+        expect((await store.intake(sessionRef, user("next"))).kind).toBe("started");
       });
 
       it("end_run auto-chains parked inputs into a new run, in arrival order", async () => {
-        const sessionId = await newSession();
-        const { itemId, token } = await startAndClaim(sessionId);
-        await store.intake(sessionId, user("follow-up 1"));
-        await store.intake(sessionId, user("follow-up 2"));
+        const sessionRef = await newSession();
+        const { itemRef, token } = await startAndClaim(sessionRef);
+        await store.intake(sessionRef, user("follow-up 1"));
+        await store.intake(sessionRef, user("follow-up 2"));
         await store.commitStep({
-          itemId,
+          itemRef,
           token,
           append: [assistant("done")],
           next: { kind: "end_run", status: "completed" },
         });
-        const entries = await store.readEntries(sessionId);
+        const entries = await store.readEntries(sessionRef);
         expect(entries.map((e) => (e.type === "message" ? e.message : e.type))).toEqual([
           user("go"),
           assistant("done"),
           user("follow-up 1"),
           user("follow-up 2"),
         ]);
-        expect(await store.pendingInputs(sessionId)).toHaveLength(0);
-        const items = await store.listItems(sessionId);
+        expect(await store.pendingInputs(sessionRef)).toHaveLength(0);
+        const items = await store.listItems(sessionRef);
         expect(items).toHaveLength(2);
         expect(items[1]).toMatchObject({ type: "inference", status: "ready" });
       });
 
       it("end_run cancelled parks pending inputs instead of chaining", async () => {
-        const sessionId = await newSession();
-        const { itemId, token } = await startAndClaim(sessionId);
-        await store.intake(sessionId, user("queued during run"));
+        const sessionRef = await newSession();
+        const { itemRef, token } = await startAndClaim(sessionRef);
+        await store.intake(sessionRef, user("queued during run"));
         await store.commitStep({
-          itemId,
+          itemRef,
           token,
           append: [],
           next: { kind: "end_run", status: "cancelled" },
         });
-        expect(await store.listItems(sessionId)).toHaveLength(1); // no chain
-        expect(await store.pendingInputs(sessionId)).toHaveLength(1); // parked
+        expect(await store.listItems(sessionRef)).toHaveLength(1); // no chain
+        expect(await store.pendingInputs(sessionRef)).toHaveLength(1); // parked
       });
 
       it("drains consumed inputs atomically with the step", async () => {
-        const sessionId = await newSession();
-        const { itemId, token } = await startAndClaim(sessionId);
-        const queued = await store.intake(sessionId, user("steer!"));
+        const sessionRef = await newSession();
+        const { itemRef, token } = await startAndClaim(sessionRef);
+        const queued = await store.intake(sessionRef, user("steer!"));
         expect(queued.kind).toBe("queued");
         const inputId = queued.kind === "queued" ? queued.inputId : "";
         await store.commitStep({
-          itemId,
+          itemRef,
           token,
           // Drained steering precedes step output.
           append: [user("steer!"), assistant("adjusted")],
           consumeInputs: [inputId],
           next: { kind: "end_run", status: "completed" },
         });
-        expect(await store.pendingInputs(sessionId)).toHaveLength(0);
-        expect((await store.readEntries(sessionId)).map((e) => e.seq)).toEqual([0, 1, 2]);
+        expect(await store.pendingInputs(sessionRef)).toHaveLength(0);
+        expect((await store.readEntries(sessionRef)).map((e) => e.seq)).toEqual([0, 1, 2]);
       });
 
       it("rejects consuming an unknown or already-consumed input", async () => {
-        const sessionId = await newSession();
-        const { itemId, token } = await startAndClaim(sessionId);
+        const sessionRef = await newSession();
+        const { itemRef, token } = await startAndClaim(sessionRef);
         await expect(
           store.commitStep({
-            itemId,
+            itemRef,
             token,
             append: [],
             consumeInputs: ["nope"],
@@ -1096,60 +1232,89 @@ export function describeStoreConformance(
       });
 
       it("resolves an idempotent re-commit of a done item without duplicating", async () => {
-        const sessionId = await newSession();
-        const { itemId, token } = await startAndClaim(sessionId);
+        const sessionRef = await newSession();
+        const { itemRef, token } = await startAndClaim(sessionRef);
         const commit: CommitStepRequest = {
-          itemId,
+          itemRef,
           token,
           append: [assistant("done")],
           next: { kind: "end_run", status: "completed" },
         };
         await store.commitStep(commit);
         await store.commitStep(commit); // crash-after-commit recovery
-        expect(await store.readEntries(sessionId)).toHaveLength(2);
-        expect(await store.listItems(sessionId)).toHaveLength(1);
+        expect(await store.readEntries(sessionRef)).toHaveLength(2);
+        expect(await store.listItems(sessionRef)).toHaveLength(1);
       });
 
       it("rejects a commit for an unknown item", async () => {
         await expect(
           store.commitStep({
-            itemId: "nope",
+            itemRef: { namespace: DEFAULT_NAMESPACE, sessionId: "nope", itemId: "nope" },
             token: "any",
             append: [],
             next: { kind: "inference" },
           }),
         ).rejects.toThrow();
       });
-    });
 
-    describe("the log", () => {
-      it("serves the seq cursor — only entries after the given seq", async () => {
-        const sessionId = await newSession();
-        const { itemId, token } = await startAndClaim(sessionId);
+      it("treats a commit addressed through the wrong session or namespace as unknown", async () => {
+        const s1 = await newSession();
+        const s2 = await newSession();
+        const { itemRef, token } = await startAndClaim(s1);
+        await expect(
+          store.commitStep({
+            itemRef: { ...itemRef, sessionId: s2.sessionId },
+            token,
+            append: [],
+            next: { kind: "end_run", status: "completed" },
+          }),
+        ).rejects.toThrow("unknown item");
+        await expect(
+          store.commitStep({
+            itemRef: { ...itemRef, namespace: "tenant-b" },
+            token,
+            append: [],
+            next: { kind: "end_run", status: "completed" },
+          }),
+        ).rejects.toThrow("unknown item");
+        // The rightful address still commits.
         await store.commitStep({
-          itemId,
+          itemRef,
           token,
           append: [assistant("done")],
           next: { kind: "end_run", status: "completed" },
         });
-        const tail = await store.readEntries(sessionId, 0);
+      });
+    });
+
+    describe("the log", () => {
+      it("serves the seq cursor — only entries after the given seq", async () => {
+        const sessionRef = await newSession();
+        const { itemRef, token } = await startAndClaim(sessionRef);
+        await store.commitStep({
+          itemRef,
+          token,
+          append: [assistant("done")],
+          next: { kind: "end_run", status: "completed" },
+        });
+        const tail = await store.readEntries(sessionRef, 0);
         expect(tail).toHaveLength(1);
         expect(tail[0]?.seq).toBe(1);
-        expect(await store.readEntries(sessionId, 1)).toHaveLength(0);
+        expect(await store.readEntries(sessionRef, 1)).toHaveLength(0);
       });
 
       it("keeps seq gapless and monotonic across every write path", async () => {
-        const sessionId = await newSession();
-        const { itemId, token } = await startAndClaim(sessionId); // seq 0: user message
-        await store.requestCancel(sessionId); // seq 1: control
+        const sessionRef = await newSession();
+        const { itemRef, token } = await startAndClaim(sessionRef); // seq 0: user message
+        await store.requestCancel(sessionRef); // seq 1: control
         await store.commitStep({
-          itemId,
+          itemRef,
           token,
           append: [assistant("stopped")], // seq 2
           next: { kind: "end_run", status: "cancelled" },
         });
-        await store.intake(sessionId, user("again")); // seq 3
-        const entries = await store.readEntries(sessionId);
+        await store.intake(sessionRef, user("again")); // seq 3
+        const entries = await store.readEntries(sessionRef);
         expect(entries.map((e) => e.seq)).toEqual([0, 1, 2, 3]);
       });
     });

--- a/packages/agent/src/driver/ensure-sandbox.ts
+++ b/packages/agent/src/driver/ensure-sandbox.ts
@@ -18,10 +18,10 @@
 // duplicate and joins whoever replaced it first.
 //
 // The composition root closes the driver's `bindTools` dep over this:
-//   bindTools: (sessionId) =>
-//     ensureSandbox(store, provider, sessionId, opts).then(createSandboxTools)
+//   bindTools: (ref) =>
+//     ensureSandbox(store, provider, ref, opts).then(createSandboxTools)
 
-import type { SessionId } from "@funky/core";
+import type { SessionRef } from "@funky/core";
 import {
   type CreateSandboxOptions,
   type Sandbox,
@@ -33,11 +33,11 @@ import type { Store } from "../ports/store";
 export async function ensureSandbox(
   store: Pick<Store, "getSession" | "bindSandbox">,
   provider: SandboxProvider,
-  sessionId: SessionId,
+  ref: SessionRef,
   createOpts?: CreateSandboxOptions,
 ): Promise<Sandbox> {
-  const session = await store.getSession(sessionId);
-  if (!session) throw new Error(`ensureSandbox: unknown session ${sessionId}`);
+  const session = await store.getSession(ref);
+  if (!session) throw new Error(`ensureSandbox: unknown session ${ref.sessionId}`);
   return acquire(session.sandboxId);
 
   async function acquire(bound: string | undefined): Promise<Sandbox> {
@@ -51,9 +51,9 @@ export async function ensureSandbox(
     }
     const created = await provider.create({
       ...createOpts,
-      metadata: { ...createOpts?.metadata, sessionId },
+      metadata: { ...createOpts?.metadata, sessionId: ref.sessionId },
     });
-    const winner = await store.bindSandbox(sessionId, created.sandboxId, bound);
+    const winner = await store.bindSandbox(ref, created.sandboxId, bound);
     if (winner === created.sandboxId) return created;
 
     // Lost the registration race: discard the duplicate and join the

--- a/packages/agent/src/driver/loop.ts
+++ b/packages/agent/src/driver/loop.ts
@@ -30,12 +30,12 @@
 
 import type {
   AgentMessage,
-  ItemId,
   ProviderEvent,
   SessionEntry,
-  SessionId,
+  SessionRef,
   ToolCall,
   ToolSpec,
+  WorkItemRef,
 } from "@funky/core";
 import { buildContext } from "../engine/build-context";
 import { executeTools, interruptedResult, type ToolUpdate } from "../engine/execute-tools";
@@ -75,7 +75,7 @@ export interface DriverDeps extends StepDeps {
    *  so the re-claim sees attempt > 1 and interrupts the batch rather
    *  than retrying the bind — a transient sandbox outage costs the
    *  model one recoverable batch, never a duplicated side effect. */
-  bindTools(sessionId: SessionId): Promise<Map<string, Tool>>;
+  bindTools(ref: SessionRef): Promise<Map<string, Tool>>;
 }
 
 export interface DriverOptions {
@@ -85,7 +85,7 @@ export interface DriverOptions {
    *  Notifier port exists. */
   idlePollMs?: number;
   /** Narrow claims to one session (the driver-per-sandbox topology). */
-  sessionId?: SessionId;
+  session?: SessionRef;
 }
 
 /**
@@ -97,7 +97,7 @@ export async function runDriver(deps: DriverDeps, opts: DriverOptions = {}): Pro
   const leaseMs = opts.leaseMs ?? 60_000;
   const idlePollMs = opts.idlePollMs ?? 1_000;
   while (true) {
-    const claim = await deps.store.claimItem({ leaseMs, sessionId: opts.sessionId });
+    const claim = await deps.store.claimItem({ leaseMs, session: opts.session });
     if (!claim) {
       await sleep(idlePollMs);
       continue;
@@ -110,7 +110,7 @@ export async function runDriver(deps: DriverDeps, opts: DriverOptions = {}): Pro
     // wasted work, never wrong work.
     const tools =
       claim.item.type === "execute_tools" && claim.item.attempt === 1
-        ? await deps.bindTools(claim.item.sessionId)
+        ? await deps.bindTools(claim.item)
         : undefined;
     await runStep(deps, claim, leaseMs, tools);
   }
@@ -133,11 +133,14 @@ export async function runStep(
   tools: Map<string, Tool> = EMPTY_TOOLS,
 ): Promise<void> {
   const { store } = deps;
+  // The claimed row is its own ref: a WorkItemRef for the item-addressed
+  // writes, and structurally a SessionRef for the session-scoped reads —
+  // the claim handed us every scope this step needs.
   const { item, token } = claim;
 
   // Fires only on lease loss — "stop working; this step will not commit".
   const step = new AbortController();
-  const heartbeat = startHeartbeat(store, item.id, token, leaseMs, () => step.abort());
+  const heartbeat = startHeartbeat(store, item, token, leaseMs, () => step.abort());
 
   try {
     // The first beat is awaited: no step work — not even reads — happens
@@ -147,7 +150,7 @@ export async function runStep(
     await heartbeat.validated;
     if (step.signal.aborted) return;
 
-    const entries = bySeq(await store.readEntries(item.sessionId));
+    const entries = bySeq(await store.readEntries(item));
 
     // Claim boundary: a pending cancel ends the run without running the
     // step. Nothing is appended — for an execute_tools item this is the
@@ -156,7 +159,7 @@ export async function runStep(
     // inputs for the next intake instead of chaining.
     if (cancelRequested(entries)) {
       await store.commitStep({
-        itemId: item.id,
+        itemRef: item,
         token,
         append: [],
         next: { kind: "end_run", status: "cancelled" },
@@ -171,18 +174,18 @@ export async function runStep(
     let tail: AgentMessage;
 
     if (item.type === "inference") {
-      const session = await store.getSession(item.sessionId);
+      const session = await store.getSession(item);
       if (!session) throw new Error(`driver: claimed item for unknown session ${item.sessionId}`);
       const config = await store.getAgentConfig({
         namespace: session.namespace,
-        id: session.agentConfigId,
+        agentConfigId: session.agentConfigId,
         version: session.agentConfigVersion,
       });
       if (!config) throw new Error(`driver: session ${item.sessionId} has no agent config`);
       // Drain-at-inference-prep is what makes these inputs steering: they
       // shape this context, ride in this commit before the step's output,
       // and are consumed by it.
-      const pending = await store.pendingInputs(item.sessionId);
+      const pending = await store.pendingInputs(item);
       const steering = pending.map((input) => input.message);
       // config.inference.provider picked the adapter at composition and
       // is not part of the request.
@@ -230,11 +233,11 @@ export async function runStep(
     // control entries can land mid-step — our open item bars intake from
     // appending messages — so the context cannot have grown behind us.
     const lastSeq = entries.length > 0 ? entries[entries.length - 1]?.seq : undefined;
-    const delta = bySeq(await store.readEntries(item.sessionId, lastSeq));
+    const delta = bySeq(await store.readEntries(item, lastSeq));
     const action = nextAction(tail, cancelRequested([...entries, ...delta]));
 
     await store.commitStep({
-      itemId: item.id,
+      itemRef: item,
       token,
       append,
       consumeInputs,
@@ -321,7 +324,7 @@ function toNext(action: Action): CommitStepRequest["next"] {
  */
 function startHeartbeat(
   store: Store,
-  itemId: ItemId,
+  ref: WorkItemRef,
   token: LeaseToken,
   leaseMs: number,
   onLost: () => void,
@@ -332,7 +335,7 @@ function startHeartbeat(
   const beat = async (): Promise<void> => {
     let alive = false;
     try {
-      alive = await store.heartbeat(itemId, token);
+      alive = await store.heartbeat(ref, token);
     } catch {
       alive = false;
     }

--- a/packages/agent/src/ports/store.ts
+++ b/packages/agent/src/ports/store.ts
@@ -11,17 +11,17 @@ import type {
   EnvConfigRef,
   InputId,
   IntakeResult,
-  ItemId,
   ListAgentConfigsRequest,
   ListEnvConfigsRequest,
   PendingInput,
   Session,
   SessionEntry,
-  SessionId,
+  SessionRef,
   UpdateAgentConfigRequest,
   UpdateEnvConfigRequest,
   UserMessage,
   WorkItem,
+  WorkItemRef,
 } from "@funky/core";
 import type { RunEndStatus } from "../engine/next-action";
 
@@ -50,6 +50,15 @@ import type { RunEndStatus } from "../engine/next-action";
  * transaction handle. Any backend with multi-record ACID transactions,
  * CAS claiming, per-session monotonic seq, and unique constraints can
  * implement it; the conformance suite keeps that honest.
+ *
+ * Addressing is by namespace-scoped ref throughout (the config refs,
+ * SessionRef, WorkItemRef): the namespace is part of the address, not a
+ * filter, and a foreign row answers exactly like a nonexistent one —
+ * undefined from gets, empty from list reads, "unknown" from write
+ * paths. WorkItemRef carries its parent sessionId too, and a mismatched
+ * parent is foreign the same way. The api builds refs from its
+ * gateway-derived namespace; the driver builds them from the claimed
+ * item's own fields, and never decides on them.
  */
 export interface Store {
   // --- configs ---
@@ -102,37 +111,38 @@ export interface Store {
 
   // --- sessions ---
 
-  /** Pins the requested agent version, or the latest when omitted. Rejects
-   *  unknown configs or versions, with namespace-scoped checks so foreign ids
+  /** Create a session. Namespace must be specified. Pins the requested agent
+   *  version, or the latest when omitted. Rejects unknown configs or versions,
+   *  with namespace-scoped checks so foreign ids
    *  remain indistinguishable from nonexistent ones, and an archived agent
    *  config with ArchivedError. Archiving and creating are serialized on the
    *  agent config row: a session either commits before the archive or sees
    *  it — never lands after one. */
-  createSession(req: CreateSessionRequest): Promise<SessionId>;
-  getSession(id: SessionId): Promise<Session | undefined>;
+  createSession(req: CreateSessionRequest): Promise<SessionRef>;
+  getSession(ref: SessionRef): Promise<Session | undefined>;
   /** Register the session's one sandbox: a compare-and-set on the
    *  binding — fills a null binding when `previous` is omitted, or
    *  replaces exactly `previous` when the caller is recovering a dead
    *  sandbox. Returns the bound id either way: the atomic pick that
    *  keeps every claimer executing in one workspace — a racer whose
    *  candidate lost learns the winner and discards its own (see
-   *  driver/ensure-sandbox.ts). Rejects an unknown session. */
-  bindSandbox(sessionId: SessionId, sandboxId: string, previous?: string): Promise<string>;
+   *  driver/ensure-sandbox.ts). Rejects an unknown or foreign session. */
+  bindSandbox(ref: SessionRef, sandboxId: string, previous?: string): Promise<string>;
 
   // --- reads — table-shaped; reads need no atomicity ---
 
   /** `after` is a seq cursor: only entries with seq > after. */
-  readEntries(sessionId: SessionId, after?: number): Promise<SessionEntry[]>;
+  readEntries(ref: SessionRef, after?: number): Promise<SessionEntry[]>;
   /** Inspection and audit; workers get items through claimItem. */
-  listItems(sessionId: SessionId): Promise<WorkItem[]>;
-  pendingInputs(sessionId: SessionId): Promise<PendingInput[]>;
+  listItems(ref: SessionRef): Promise<WorkItem[]>;
+  pendingInputs(ref: SessionRef): Promise<PendingInput[]>;
 
   // --- worker coordination ---
 
   /**
    * Atomically lease one ready item (CAS / SKIP LOCKED semantics);
    * undefined = no work. No type filter — workers dispatch on the
-   * claimed item's type. sessionId narrows the scan for the (deferred)
+   * claimed item's type. session narrows the scan for the (deferred)
    * driver-per-sandbox topology.
    *
    * The returned token is the fencing credential, minted by the store
@@ -140,16 +150,16 @@ export interface Store {
    * caller discipline. A re-claim of the same item always issues a new
    * token, so a previous holder's zombie is fenced by construction.
    */
-  claimItem(req: { leaseMs: number; sessionId?: SessionId }): Promise<Claim | undefined>;
+  claimItem(req: { leaseMs: number; session?: SessionRef }): Promise<Claim | undefined>;
 
   /**
    * Extend the lease by the duration chosen at claim; false = lease
-   * lost, the driver must abort its step. itemId addresses the item;
+   * lost, the driver must abort its step. The ref addresses the item;
    * the token authorizes the write. (A progress-checkpoint payload was
    * cut 2026-08-12 — it returns with its first reader, shaped by that
    * reader's needs.)
    */
-  heartbeat(itemId: ItemId, token: LeaseToken): Promise<boolean>;
+  heartbeat(ref: WorkItemRef, token: LeaseToken): Promise<boolean>;
 
   /**
    * Appends a cancel ControlEntry to the log — nothing else. Workers
@@ -157,7 +167,7 @@ export interface Store {
    * cancel addresses (one landing after a run's terminal message
    * addresses a run that no longer exists and is ignored).
    */
-  requestCancel(sessionId: SessionId): Promise<void>;
+  requestCancel(ref: SessionRef): Promise<void>;
 
   // --- write paths — one transaction each ---
 
@@ -168,7 +178,7 @@ export interface Store {
    * input steers or follows up is decided by which boundary drains it,
    * never by the message itself.
    */
-  intake(sessionId: SessionId, message: UserMessage): Promise<IntakeResult>;
+  intake(ref: SessionRef, message: UserMessage): Promise<IntakeResult>;
 
   /**
    * The driver's write path: append the step's output, drain any
@@ -234,8 +244,10 @@ export interface Claim {
 }
 
 export interface CommitStepRequest {
-  itemId: ItemId;
-  /** The claim's credential — itemId addresses, the token authorizes. */
+  // Named itemRef, not item: Claim.item is the full row, and reusing the
+  // name for a ref would make the claim/commit pair lie about its shape.
+  itemRef: WorkItemRef;
+  /** The claim's credential — itemRef addresses, the token authorizes. */
   token: LeaseToken;
   /** Payloads — the store mints envelopes. Drained steering precedes step output. */
   append: AgentMessage[];

--- a/packages/agent/test/ensure-sandbox.test.ts
+++ b/packages/agent/test/ensure-sandbox.test.ts
@@ -4,7 +4,7 @@
 // replace a binding only when the provider says it is definitively gone.
 
 import { describe, expect, test } from "vitest";
-import type { Session } from "@funky/core";
+import type { Session, SessionRef } from "@funky/core";
 import { ensureSandbox } from "../src/driver/ensure-sandbox";
 import {
   type CreateSandboxOptions,
@@ -39,10 +39,12 @@ function fakeProvider(opts?: { deadIds?: string[]; connectError?: Error }) {
   return { provider, calls, killed: () => killed };
 }
 
+const s1: SessionRef = { namespace: "default", sessionId: "s1" };
+
 function fakeStore(opts?: { sandboxId?: string; winner?: string }) {
   const binds: { candidate: string; previous?: string }[] = [];
   const session: Session = {
-    id: "s1",
+    sessionId: "s1",
     agentConfigId: "a1",
     agentConfigVersion: 1,
     envConfigId: "e1",
@@ -52,8 +54,9 @@ function fakeStore(opts?: { sandboxId?: string; winner?: string }) {
   };
   return {
     binds,
-    getSession: async (id: string) => (id === "s1" ? session : undefined),
-    bindSandbox: async (_sessionId: string, candidate: string, previous?: string) => {
+    getSession: async (ref: SessionRef) =>
+      ref.namespace === "default" && ref.sessionId === "s1" ? session : undefined,
+    bindSandbox: async (_ref: SessionRef, candidate: string, previous?: string) => {
       binds.push({ candidate, previous });
       return opts?.winner ?? candidate;
     },
@@ -65,7 +68,7 @@ describe("ensureSandbox", () => {
     const store = fakeStore({ sandboxId: "sbx_bound" });
     const { provider, calls } = fakeProvider();
 
-    const sandbox = await ensureSandbox(store, provider, "s1");
+    const sandbox = await ensureSandbox(store, provider, s1);
     expect(sandbox.sandboxId).toBe("sbx_bound");
     expect(calls.connect).toEqual(["sbx_bound"]);
     expect(calls.create).toEqual([]);
@@ -74,14 +77,16 @@ describe("ensureSandbox", () => {
 
   test("throws on an unknown session", async () => {
     const { provider } = fakeProvider();
-    await expect(ensureSandbox(fakeStore(), provider, "nope")).rejects.toThrow("unknown session");
+    await expect(
+      ensureSandbox(fakeStore(), provider, { namespace: "default", sessionId: "nope" }),
+    ).rejects.toThrow("unknown session");
   });
 
   test("creates, stamps the session into metadata, and registers", async () => {
     const store = fakeStore();
     const { provider, calls, killed } = fakeProvider();
 
-    const sandbox = await ensureSandbox(store, provider, "s1", {
+    const sandbox = await ensureSandbox(store, provider, s1, {
       timeoutMs: 60_000,
       network: { type: "none" },
       metadata: { tier: "test" },
@@ -103,7 +108,7 @@ describe("ensureSandbox", () => {
     const store = fakeStore({ winner: "sbx_theirs" });
     const { provider, calls, killed } = fakeProvider();
 
-    const sandbox = await ensureSandbox(store, provider, "s1");
+    const sandbox = await ensureSandbox(store, provider, s1);
     expect(sandbox.sandboxId).toBe("sbx_theirs");
     expect(store.binds).toEqual([{ candidate: "sbx_created", previous: undefined }]);
     expect(killed()).toBe(1);
@@ -114,7 +119,7 @@ describe("ensureSandbox", () => {
     const store = fakeStore({ sandboxId: "sbx_dead" });
     const { provider, calls, killed } = fakeProvider({ deadIds: ["sbx_dead"] });
 
-    const sandbox = await ensureSandbox(store, provider, "s1");
+    const sandbox = await ensureSandbox(store, provider, s1);
     expect(sandbox.sandboxId).toBe("sbx_created");
     expect(calls.connect).toEqual(["sbx_dead"]);
     // The CAS names the dead binding it expects to replace.
@@ -126,7 +131,7 @@ describe("ensureSandbox", () => {
     const store = fakeStore({ sandboxId: "sbx_dead", winner: "sbx_theirs" });
     const { provider, calls, killed } = fakeProvider({ deadIds: ["sbx_dead"] });
 
-    const sandbox = await ensureSandbox(store, provider, "s1");
+    const sandbox = await ensureSandbox(store, provider, s1);
     expect(sandbox.sandboxId).toBe("sbx_theirs");
     expect(store.binds).toEqual([{ candidate: "sbx_created", previous: "sbx_dead" }]);
     expect(killed()).toBe(1);
@@ -137,7 +142,7 @@ describe("ensureSandbox", () => {
     const store = fakeStore({ sandboxId: "sbx_bound" });
     const { provider, calls } = fakeProvider({ connectError: new Error("fetch failed") });
 
-    await expect(ensureSandbox(store, provider, "s1")).rejects.toThrow("fetch failed");
+    await expect(ensureSandbox(store, provider, s1)).rejects.toThrow("fetch failed");
     expect(calls.create).toEqual([]);
     expect(store.binds).toEqual([]);
   });

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -42,12 +42,18 @@ export type InputId = string;
 // The tenancy boundary, driven by the managed service's trusted gateway
 // (an OSS deployment runs single-tenant). Ownership is exactly-one and
 // lives as a fact on the three ownable row types — decided at create and
-// immutable. Config creation requires that ownership explicitly; sessions
-// still resolve absence to DEFAULT_NAMESPACE.
-// Work items, entries, and pending inputs derive theirs through sessionId;
-// the worker and the driver never read it. The store guarantees a session
-// and its configs share one namespace, and scopes config references by the
-// namespace they carry; a foreign config is "unknown" — indistinguishable
+// immutable. Every create requires that ownership explicitly; resolving
+// a default is the api gateway's job (DEFAULT_NAMESPACE below), never
+// the store's.
+// In this vocabulary, entries and pending inputs carry no namespace —
+// theirs rides on the SessionRef that addresses them (adapters still
+// store a copy as the partition key). Work items DO carry it here: a
+// claim is the one read that starts from nothing, so the claimed row
+// itself must hand the driver the scope its later refs carry. The
+// driver only echoes that namespace back into refs — tenancy decisions
+// stay at the api's gateway. The store guarantees a session and its
+// configs share one namespace, and scopes every reference by the
+// namespace it carries; a foreign row is "unknown" — indistinguishable
 // from nonexistent, so nothing leaks.
 export const DEFAULT_NAMESPACE = "default";
 
@@ -67,7 +73,7 @@ export const DEFAULT_NAMESPACE = "default";
 /** A namespace-scoped reference to an agent config. */
 export const AgentConfigRef = z.object({
   namespace: z.string().min(1),
-  id: z.string().min(1),
+  agentConfigId: z.string().min(1),
 });
 export type AgentConfigRef = z.infer<typeof AgentConfigRef>;
 
@@ -102,8 +108,8 @@ export const UpdateAgentConfigRequest = z.object({
 });
 export type UpdateAgentConfigRequest = z.infer<typeof UpdateAgentConfigRequest>;
 
-export const AgentConfig = CreateAgentConfigRequest.extend({
-  id: z.string(),
+export const AgentConfig = AgentConfigRef.extend({
+  ...CreateAgentConfigRequest.omit({ namespace: true }).shape,
   version: z.number().int().min(1),
   createdAt: z.iso.datetime(),
   updatedAt: z.iso.datetime(),
@@ -118,7 +124,7 @@ export type AgentConfig = z.infer<typeof AgentConfig>;
 /** A namespace-scoped reference to an env config. */
 export const EnvConfigRef = z.object({
   namespace: z.string().min(1),
-  id: z.string().min(1),
+  envConfigId: z.string().min(1),
 });
 export type EnvConfigRef = z.infer<typeof EnvConfigRef>;
 
@@ -148,8 +154,8 @@ export const UpdateEnvConfigRequest = z.object({
 });
 export type UpdateEnvConfigRequest = z.infer<typeof UpdateEnvConfigRequest>;
 
-export const EnvConfig = CreateEnvConfigRequest.extend({
-  id: z.string(),
+export const EnvConfig = EnvConfigRef.extend({
+  ...CreateEnvConfigRequest.omit({ namespace: true }).shape,
   // Materialized at create — resolved decisions, not restatable defaults:
   network: NetworkPolicy, // absence resolved to { type: "unrestricted" }
   packages: Packages, // absence resolved to {}
@@ -159,22 +165,28 @@ export type EnvConfig = z.infer<typeof EnvConfig>;
 
 // --- sessions ---
 
+/** A namespace-scoped reference to a session. */
+export const SessionRef = z.object({
+  namespace: z.string().min(1),
+  sessionId: z.string().min(1),
+});
+export type SessionRef = z.infer<typeof SessionRef>;
+
 export const CreateSessionRequest = z.object({
+  namespace: z.string().min(1),
   agentConfigId: z.string(),
   // Omit to pin the latest version at creation time.
   agentConfigVersion: z.number().int().min(1).optional(),
   envConfigId: z.string(),
-  // Explicit, not derived from the configs: deriving would let a leaked
-  // foreign config id pull a session into the wrong namespace. The store
-  // enforces the match instead.
-  namespace: z.string().min(1).optional(),
   metadata: JsonValue.optional(),
 });
 export type CreateSessionRequest = z.infer<typeof CreateSessionRequest>;
 
-export const Session = CreateSessionRequest.extend({
-  id: z.string(),
-  namespace: z.string().min(1), // materialized: absence resolved to DEFAULT_NAMESPACE
+// The row is its own ref, like WorkItem: the key comes first, and the
+// request's fields ride in verbatim minus namespace, which the key
+// already carries — every field declared exactly once.
+export const Session = SessionRef.extend({
+  ...CreateSessionRequest.omit({ namespace: true }).shape,
   // Materialized from the request or the agent config's latest version.
   agentConfigVersion: z.number().int().min(1),
   // The session's one workspace, registered by the driver's first
@@ -192,9 +204,16 @@ export type ItemType = z.infer<typeof ItemType>;
 export const ItemStatus = z.enum(["ready", "leased", "done"]);
 export type ItemStatus = z.infer<typeof ItemStatus>;
 
-export const WorkItem = z.object({
-  id: z.string(),
-  sessionId: z.string(),
+/**
+ * A reference to a work item — the full path to the row: namespace,
+ * parent session, item.
+ */
+export const WorkItemRef = SessionRef.extend({
+  itemId: z.string().min(1),
+});
+export type WorkItemRef = z.infer<typeof WorkItemRef>;
+
+export const WorkItem = WorkItemRef.extend({
   type: ItemType,
   status: ItemStatus,
   // Times claimed (claimItem increments; 0 = never claimed). attempt > 1

--- a/packages/core/test/store.test.ts
+++ b/packages/core/test/store.test.ts
@@ -13,9 +13,11 @@ import {
   ListEnvConfigsRequest,
   PendingInput,
   Session,
+  SessionRef,
   UpdateAgentConfigRequest,
   UpdateEnvConfigRequest,
   WorkItem,
+  WorkItemRef,
 } from "../src/store";
 
 const roundTrip = <T>(schema: { parse: (v: unknown) => T }, value: unknown): T =>
@@ -24,7 +26,7 @@ const roundTrip = <T>(schema: { parse: (v: unknown) => T }, value: unknown): T =
 describe("configs", () => {
   it("round-trips a stored agent config", () => {
     const config = {
-      id: "ac1",
+      agentConfigId: "ac1",
       inference: {
         provider: "anthropic",
         model: "claude-sonnet-5",
@@ -60,13 +62,19 @@ describe("configs", () => {
   });
 
   it("validates current and versioned agent config references", () => {
-    expect(AgentConfigRef.safeParse({ namespace: "tenant-a", id: "ac1" }).success).toBe(true);
-    expect(AgentConfigRef.safeParse({ namespace: "tenant-a", id: "" }).success).toBe(false);
+    expect(AgentConfigRef.safeParse({ namespace: "tenant-a", agentConfigId: "ac1" }).success).toBe(
+      true,
+    );
+    expect(AgentConfigRef.safeParse({ namespace: "tenant-a", agentConfigId: "" }).success).toBe(
+      false,
+    );
     expect(
-      AgentConfigVersionRef.safeParse({ namespace: "tenant-a", id: "ac1", version: 2 }).success,
+      AgentConfigVersionRef.safeParse({ namespace: "tenant-a", agentConfigId: "ac1", version: 2 })
+        .success,
     ).toBe(true);
     expect(
-      AgentConfigVersionRef.safeParse({ namespace: "tenant-a", id: "ac1", version: 0 }).success,
+      AgentConfigVersionRef.safeParse({ namespace: "tenant-a", agentConfigId: "ac1", version: 0 })
+        .success,
     ).toBe(false);
   });
 
@@ -82,7 +90,7 @@ describe("configs", () => {
 
   it("round-trips a stored agent config with no sampling overrides — absence is the stored form", () => {
     const config = {
-      id: "ac1",
+      agentConfigId: "ac1",
       inference: { provider: "fake", model: "scripted" },
       systemPrompt: "s",
       namespace: "default",
@@ -95,7 +103,7 @@ describe("configs", () => {
 
   it("rejects null sampling params — absence has exactly one spelling", () => {
     const result = AgentConfig.safeParse({
-      id: "ac1",
+      agentConfigId: "ac1",
       inference: { provider: "anthropic", model: "m", maxTokens: null, temperature: null },
       systemPrompt: "s",
       createdAt: "2026-08-11T12:00:00Z",
@@ -126,7 +134,7 @@ describe("configs", () => {
 
   it("round-trips an archived agent config — the mark is a timestamp, not a flag", () => {
     const config = {
-      id: "ac1",
+      agentConfigId: "ac1",
       inference: { provider: "fake", model: "scripted" },
       systemPrompt: "s",
       namespace: "default",
@@ -140,7 +148,7 @@ describe("configs", () => {
 
   it("rejects a null or boolean archivedAt — absence is spelled by absence", () => {
     const config = {
-      id: "ac1",
+      agentConfigId: "ac1",
       inference: { provider: "fake", model: "scripted" },
       systemPrompt: "s",
       namespace: "default",
@@ -156,7 +164,7 @@ describe("configs", () => {
 describe("env configs", () => {
   it("round-trips a stored env config with the full recipe spine", () => {
     const config = {
-      id: "ec1",
+      envConfigId: "ec1",
       network: { type: "allowlist", domains: ["api.anthropic.com", "pypi.org"] },
       packages: { pip: ["pandas==2.2.0", "numpy"], npm: ["express@4.18.0"] },
       namespace: "tenant-a",
@@ -184,9 +192,11 @@ describe("env configs", () => {
   });
 
   it("validates namespace-scoped env config references", () => {
-    expect(EnvConfigRef.safeParse({ namespace: "tenant-a", id: "ec1" }).success).toBe(true);
-    expect(EnvConfigRef.safeParse({ namespace: "tenant-a", id: "" }).success).toBe(false);
-    expect(EnvConfigRef.safeParse({ namespace: "", id: "ec1" }).success).toBe(false);
+    expect(EnvConfigRef.safeParse({ namespace: "tenant-a", envConfigId: "ec1" }).success).toBe(
+      true,
+    );
+    expect(EnvConfigRef.safeParse({ namespace: "tenant-a", envConfigId: "" }).success).toBe(false);
+    expect(EnvConfigRef.safeParse({ namespace: "", envConfigId: "ec1" }).success).toBe(false);
   });
 
   it("validates namespaced env config pagination", () => {
@@ -226,7 +236,7 @@ describe("env configs", () => {
 
   it("rejects a stored env config missing network — materialized decisions must be present", () => {
     const result = EnvConfig.safeParse({
-      id: "ec1",
+      envConfigId: "ec1",
       namespace: "tenant-a",
       packages: {},
       createdAt: "2026-08-11T12:00:00Z",
@@ -238,19 +248,19 @@ describe("env configs", () => {
 describe("sessions", () => {
   it("round-trips a stored session — no metadata means no metadata key", () => {
     const session = {
-      id: "s1",
+      namespace: "default",
+      sessionId: "s1",
       agentConfigId: "ac1",
       agentConfigVersion: 2,
       envConfigId: "ec1",
-      namespace: "default",
       createdAt: "2026-08-11T12:00:00Z",
     };
     expect(roundTrip(Session, session)).toEqual(session);
   });
 
-  it("rejects a stored session missing namespace — materialized decisions must be present", () => {
+  it("rejects a stored session missing namespace — the row is its own ref", () => {
     const result = Session.safeParse({
-      id: "s1",
+      sessionId: "s1",
       agentConfigId: "ac1",
       agentConfigVersion: 1,
       envConfigId: "ec1",
@@ -259,19 +269,32 @@ describe("sessions", () => {
     expect(result.success).toBe(false);
   });
 
+  it("validates namespace-scoped session references", () => {
+    expect(SessionRef.safeParse({ namespace: "tenant-a", sessionId: "s1" }).success).toBe(true);
+    expect(SessionRef.safeParse({ namespace: "tenant-a", sessionId: "" }).success).toBe(false);
+    expect(SessionRef.safeParse({ namespace: "", sessionId: "s1" }).success).toBe(false);
+  });
+
+  it("requires an explicit namespace when creating a session", () => {
+    expect(
+      CreateSessionRequest.safeParse({ agentConfigId: "ac1", envConfigId: "ec1" }).success,
+    ).toBe(false);
+  });
+
   it("rejects a create request without an agent config id", () => {
-    const result = CreateSessionRequest.safeParse({ envConfigId: "ec1" });
+    const result = CreateSessionRequest.safeParse({ namespace: "default", envConfigId: "ec1" });
     expect(result.success).toBe(false);
   });
 
   it("rejects a create request without an env config id — every session names its world", () => {
-    const result = CreateSessionRequest.safeParse({ agentConfigId: "ac1" });
+    const result = CreateSessionRequest.safeParse({ namespace: "default", agentConfigId: "ac1" });
     expect(result.success).toBe(false);
   });
 
   it("accepts an optional positive agent config version", () => {
     expect(
       CreateSessionRequest.safeParse({
+        namespace: "default",
         agentConfigId: "ac1",
         agentConfigVersion: 2,
         envConfigId: "ec1",
@@ -279,6 +302,7 @@ describe("sessions", () => {
     ).toBe(true);
     expect(
       CreateSessionRequest.safeParse({
+        namespace: "default",
         agentConfigId: "ac1",
         agentConfigVersion: 0,
         envConfigId: "ec1",
@@ -288,15 +312,31 @@ describe("sessions", () => {
 });
 
 describe("work items", () => {
-  it("round-trips a work item", () => {
-    const item = { id: "i1", sessionId: "s1", type: "inference", status: "ready", attempt: 0 };
+  it("round-trips a work item — the row is its own ref", () => {
+    const item = {
+      namespace: "default",
+      sessionId: "s1",
+      itemId: "i1",
+      type: "inference",
+      status: "ready",
+      attempt: 0,
+    };
     expect(roundTrip(WorkItem, item)).toEqual(item);
+  });
+
+  it("validates the full-path work item reference", () => {
+    expect(
+      WorkItemRef.safeParse({ namespace: "tenant-a", sessionId: "s1", itemId: "i1" }).success,
+    ).toBe(true);
+    // The parent session is part of the address, not an optional detail.
+    expect(WorkItemRef.safeParse({ namespace: "tenant-a", itemId: "i1" }).success).toBe(false);
   });
 
   it("rejects an unknown item type", () => {
     const result = WorkItem.safeParse({
-      id: "i1",
+      namespace: "default",
       sessionId: "s1",
+      itemId: "i1",
       type: "provision",
       status: "ready",
     });


### PR DESCRIPTION
Completes the ref vocabulary started in #132 and #133. Every row type is now addressed by a namespace-scoped ref, and the row IS its own ref — `SessionRef` and `WorkItemRef` join the config refs, and the config refs name their id (`agentConfigId`, `envConfigId`) so no ref carries a bare `id`.

`WorkItemRef` is the full path — namespace, parent session, item — so a mismatched parent reads as foreign exactly like a missing row, the same way a foreign namespace does.

## Store

Every table is keyed by its full path, namespace leading, with the child copies made structural by composite FKs so they can never diverge. That is also the partition key a future `PARTITION BY` needs on every table, which is why no bare-id `UNIQUE` survives anywhere.

Work items carry the namespace in the port vocabulary too, unlike entries and pending inputs: a claim is the one read that starts from nothing, so the claimed row has to hand the driver the scope its later refs carry. The driver only echoes it back — it never decides tenancy.

## Namespace as request input

Namespace moves out of the gateway header and into the request: create bodies carry it, id-addressed routes take `?namespace=`, and absence resolves to `DEFAULT_NAMESPACE` for single-tenant self-deploys. The api's token is a root credential, so tenant authorization belongs to the managed layer above it. `FUNKY_NAMESPACE_SOURCE` and `X-Funky-Namespace` are gone; the format bound that guarded the header moves to `NamespaceQuery`, where it is load-bearing — namespace is a PK component on every table, and an unbounded value overflows the btree tuple limit.

The wire keeps `id` as the resource id, mapping the ref's qualified name at the boundary.

## Schema

Edited in place rather than migrated — nothing is deployed yet, so the schema is still a description rather than a history.

## Verification

- `pnpm typecheck`, the unit suite (340 tests), and `prettier --check` are green.
- The opt-in e2e suite passes 3/3 against a real model, real E2B sandboxes, and a real postgres — including the SIGKILL-mid-tool-execution recovery and the stack e2e's SSE reconnect across a `kill -9`. Sandbox cleanup ran clean afterward, with no orphans left behind.
- The migration was applied to an empty postgres through the real `migrate.ts` entrypoint; all seven tables come up with the intended composite primary keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)