### PR TITLE
Snapshot the env config recipe onto the session at create

### DIFF
--- a/apps/api/test/sessions.test.ts
+++ b/apps/api/test/sessions.test.ts
@@ -74,6 +74,34 @@ describe("POST /v1/sessions", () => {
     expect(body.envConfigId).toBe(configs.envConfigId);
     expect(body.namespace).toBe("default");
     expect(typeof body.id).toBe("string");
+    // The recipe rides along resolved: the wire shows the world this
+    // session will provision, not a pointer to a row that can change.
+    expect(body.envConfigSnapshot).toEqual({
+      network: { type: "unrestricted" },
+      packages: {},
+    });
+  });
+
+  it("returns the snapshot the session was created with, not the env config's current state", async () => {
+    const agent = await (
+      await post(app, "/v1/agent-configs", {
+        inference: { provider: "fake", model: "m" },
+        systemPrompt: "s",
+      })
+    ).json();
+    const env = await (await post(app, "/v1/env-configs", { network: { type: "none" } })).json();
+    const created = await (
+      await post(app, "/v1/sessions", { agentConfigId: agent.id, envConfigId: env.id })
+    ).json();
+
+    const updated = await post(app, `/v1/env-configs/${env.id}`, {
+      network: { type: "allowlist", domains: ["example.com"] },
+    });
+    expect(updated.status).toBe(200);
+
+    const read = await (await get(app, `/v1/sessions/${created.id}`)).json();
+    expect(read.envConfigSnapshot.network).toEqual({ type: "none" });
+    expect(read.envConfigId).toBe(env.id); // provenance survives the edit
   });
 
   it("defaults the namespace when the body omits it", async () => {

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -38,17 +38,16 @@ const deps: DriverDeps = {
   }),
   toolSpecs: sandboxToolSpecs,
   // Ensure-on-claim: the loop calls this only for an execute_tools item
-  // that will actually execute. The session's env config is the sandbox
-  // recipe — its resolved network policy rides into create. The session
-  // row is its own ref, and structurally contains its env config's.
+  // that will actually execute. The sandbox recipe is the snapshot the
+  // session copied at create, not the env config row it names: env configs
+  // update in place, so reloading one could reshape a running session's
+  // world. The session carries everything provisioning needs.
   bindTools: async (ref) => {
     const session = await store.getSession(ref);
     if (!session) throw new Error(`worker: unknown session ${ref.sessionId}`);
-    const env = await store.getEnvConfig(session);
-    if (!env) throw new Error(`worker: session ${ref.sessionId} has no env config`);
     const sandbox = await ensureSandbox(store, sandboxes, ref, {
       timeoutMs: cfg.sandboxTimeoutMs,
-      network: env.network,
+      network: session.envConfigSnapshot.network,
     });
     return createSandboxTools(sandbox);
   },

--- a/packages/adapters/migrations/20260820000000_init/migration.sql
+++ b/packages/adapters/migrations/20260820000000_init/migration.sql
@@ -67,6 +67,11 @@ CREATE TABLE sessions (
   -- composite FK below makes that behavior snapshot durable.
   agent_config_version integer NOT NULL,
   env_config_id text NOT NULL,
+  -- The env recipe resolved at create (core/store.ts EnvConfigSnapshot).
+  -- Env configs update in place, so there is no version to pin: the copy
+  -- is what makes a session's world deterministic. Provisioning reads
+  -- this; env_config_id stays for provenance, never for a reload.
+  env_config_snapshot jsonb NOT NULL,
   -- The session's one workspace; null until the driver's first
   -- execute_tools claim registers it (Store.bindSandbox, set-if-null).
   sandbox_id text,

--- a/packages/adapters/src/store/pg.ts
+++ b/packages/adapters/src/store/pg.ts
@@ -12,6 +12,12 @@
 //   commits, and archiveAgentConfig's UPDATE takes that row exclusively:
 //   the two serialize, so no session is born against an archived config.
 //   Archive touches nothing else, so this adds no cycle either.
+// - createSession takes the same FOR SHARE on its env config row, held to
+//   the insert, so the snapshot it copies is a committed state and a
+//   racing updateEnvConfig lands strictly before or after it — never
+//   inside. Shared mode: concurrent creates never wait on each other, only
+//   an env update does. Lock order is agent → env, and nothing takes env
+//   → agent, so this adds no cycle either.
 // - claimItem uses FOR UPDATE SKIP LOCKED: contended claimers never
 //   queue behind each other, exactly one wins a given item.
 // - Fencing is token + live lease, symmetric across heartbeat and
@@ -40,6 +46,7 @@ import {
   CreateSessionRequest,
   EnvConfig,
   EnvConfigRef,
+  EnvConfigSnapshot,
   IntakeResult,
   type JsonValue,
   ListAgentConfigsRequest,
@@ -463,6 +470,13 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       // archive either waits behind this transaction or is already committed
       // and read here. "New sessions cannot reference an archived config" is
       // therefore structural, not a window between a check and a write.
+      //
+      // The env recipe is the other mutable fact, and it is not merely
+      // checked but COPIED (core/store.ts EnvConfigSnapshot): env configs
+      // update in place, so a session that reloaded one could have its world
+      // reshaped mid-run. The same FOR SHARE makes the copy a committed
+      // state — a racing update waits behind this insert or is already in
+      // it — and nothing reads env_configs for this session again.
       await db.transaction(async (tx) => {
         const [agent] = await tx
           .select({ version: agentConfigVersions.version, archivedAt: agentConfigs.archivedAt })
@@ -475,15 +489,20 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         if (!agent) throw new Error(`unknown agent config: ${parsed.agentConfigId}`);
         if (agent.archivedAt !== null) throw new ArchivedError(parsed.agentConfigId);
         const [env] = await tx
-          .select({ id: envConfigs.id })
+          .select({ network: envConfigs.network, packages: envConfigs.packages })
           .from(envConfigs)
-          .where(and(eq(envConfigs.id, parsed.envConfigId), eq(envConfigs.namespace, namespace)));
+          .where(and(eq(envConfigs.id, parsed.envConfigId), eq(envConfigs.namespace, namespace)))
+          .for("share");
         if (!env) throw new Error(`unknown env config: ${parsed.envConfigId}`);
         await tx.insert(sessions).values({
           id,
           agentConfigId: parsed.agentConfigId,
           agentConfigVersion: agent.version,
           envConfigId: parsed.envConfigId,
+          envConfigSnapshot: EnvConfigSnapshot.parse({
+            network: env.network,
+            packages: env.packages,
+          }),
           namespace,
           metadata: wrap(parsed.metadata),
           createdAt: now(),
@@ -504,6 +523,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         agentConfigId: row.agentConfigId,
         agentConfigVersion: row.agentConfigVersion,
         envConfigId: row.envConfigId,
+        envConfigSnapshot: row.envConfigSnapshot,
         namespace: row.namespace,
         ...(row.sandboxId ? { sandboxId: row.sandboxId } : {}),
         ...unwrapped(row.metadata),

--- a/packages/adapters/src/store/schema.ts
+++ b/packages/adapters/src/store/schema.ts
@@ -25,6 +25,7 @@ import {
   uniqueIndex,
 } from "drizzle-orm/pg-core";
 import type {
+  EnvConfigSnapshot,
   InferenceConfig,
   JsonValue,
   NetworkPolicy,
@@ -104,6 +105,9 @@ export const sessions = pgTable(
     // composite FK below makes every session's behavior snapshot durable.
     agentConfigVersion: integer("agent_config_version").notNull(),
     envConfigId: text("env_config_id").notNull(),
+    // The env recipe resolved at create (core/store.ts EnvConfigSnapshot).
+    // Provisioning reads this, never the mutable env_configs row.
+    envConfigSnapshot: jsonb("env_config_snapshot").$type<EnvConfigSnapshot>().notNull(),
     // The session's one workspace; null until bindSandbox registers it.
     sandboxId: text("sandbox_id"),
     metadata: jsonb("metadata").$type<WrappedJson>(),

--- a/packages/adapters/test/env-snapshot-provisioning.test.ts
+++ b/packages/adapters/test/env-snapshot-provisioning.test.ts
@@ -1,0 +1,128 @@
+// The env config snapshot end to end: the real pg store, the real
+// ensureSandbox, and a fake provider that records what each create was
+// asked to enforce. The invariant under test is the whole point of the
+// snapshot — an env config edit reaches sessions created after it and
+// nothing else, including across a sandbox replacement, which is the one
+// moment a running session provisions a second time.
+
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { DEFAULT_NAMESPACE, type NetworkPolicy, type SessionRef } from "@funky/core";
+import {
+  type CreateSandboxOptions,
+  ensureSandbox,
+  type Sandbox,
+  SandboxNotFoundError,
+  type SandboxProvider,
+  type Store,
+} from "@funky/agent";
+import { createPgStore, type StoreDb } from "../src";
+import { storeDdl } from "./store-ddl";
+
+let client: PGlite;
+let store: Store;
+
+beforeAll(async () => {
+  client = new PGlite();
+  await client.exec(storeDdl);
+  store = createPgStore(drizzle({ client }) as unknown as StoreDb);
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+/** Hands out a fresh id per create, and can declare any id dead so the
+ *  next acquire has to replace it — the sandbox-restart path. */
+function fakeProvider() {
+  const created: CreateSandboxOptions[] = [];
+  const dead = new Set<string>();
+  let n = 0;
+  const provider: SandboxProvider = {
+    create: async (opts) => {
+      created.push(opts ?? {});
+      return { sandboxId: `sbx_${++n}`, kill: async () => {} } as Sandbox;
+    },
+    connect: async (sandboxId) => {
+      if (dead.has(sandboxId)) throw new SandboxNotFoundError(`${sandboxId} is gone`);
+      return { sandboxId } as Sandbox;
+    },
+    list: async () => [],
+  };
+  return { provider, created, kill: (id: string) => dead.add(id) };
+}
+
+/** What the worker's bindTools does: read the session, provision from
+ *  the snapshot it carries. Deliberately never touches getEnvConfig. */
+async function provision(
+  ref: SessionRef,
+  provider: SandboxProvider,
+): Promise<{ sandboxId: string; network: NetworkPolicy }> {
+  const session = await store.getSession(ref);
+  if (!session) throw new Error("no session");
+  const sandbox = await ensureSandbox(store, provider, ref, {
+    network: session.envConfigSnapshot.network,
+  });
+  return { sandboxId: sandbox.sandboxId, network: session.envConfigSnapshot.network };
+}
+
+describe("provisioning from the session's env snapshot", () => {
+  it("holds session 1 to its own recipe across an env update and a sandbox restart", async () => {
+    const agent = await store.createAgentConfig({
+      namespace: DEFAULT_NAMESPACE,
+      inference: { provider: "fake", model: "m" },
+      systemPrompt: "s",
+    });
+    const env = await store.createEnvConfig({
+      namespace: DEFAULT_NAMESPACE,
+      network: { type: "none" },
+      packages: { pip: ["numpy"] },
+    });
+    const newSession = () =>
+      store.createSession({
+        namespace: DEFAULT_NAMESPACE,
+        agentConfigId: agent.agentConfigId,
+        envConfigId: env.envConfigId,
+      });
+
+    // 1. session 1 exists and has provisioned once.
+    const s1 = await newSession();
+    const { provider, created, kill } = fakeProvider();
+    const first = await provision(s1, provider);
+    expect(first.network).toEqual({ type: "none" });
+    expect(created[0]?.network).toEqual({ type: "none" });
+
+    // 2. the env config is updated underneath it.
+    await store.updateEnvConfig(env, {
+      network: { type: "allowlist", domains: ["example.com"] },
+      packages: { npm: ["zod"] },
+    });
+
+    // 3. session 1's sandbox dies; the next claim must replace it. The
+    //    replacement is provisioned from the snapshot, not the new recipe.
+    kill(first.sandboxId);
+    const replaced = await provision(s1, provider);
+    expect(replaced.sandboxId).not.toBe(first.sandboxId); // really a new sandbox
+    expect(created[1]?.network).toEqual({ type: "none" });
+    expect((await store.getSession(s1))?.envConfigSnapshot).toEqual({
+      network: { type: "none" },
+      packages: { pip: ["numpy"] },
+    });
+
+    // 4. session 2, created after the update, gets the new recipe.
+    const s2 = await newSession();
+    const second = await provision(s2, provider);
+    expect(second.network).toEqual({ type: "allowlist", domains: ["example.com"] });
+    expect(created[2]?.network).toEqual({ type: "allowlist", domains: ["example.com"] });
+    expect((await store.getSession(s2))?.envConfigSnapshot).toEqual({
+      network: { type: "allowlist", domains: ["example.com"] },
+      packages: { npm: ["zod"] },
+    });
+
+    // Reconnecting a live sandbox provisions nothing at all — three
+    // creates across the whole scenario, never a fourth.
+    await provision(s1, provider);
+    expect(created).toHaveLength(3);
+  });
+});

--- a/packages/adapters/test/store-conformance.ts
+++ b/packages/adapters/test/store-conformance.ts
@@ -722,6 +722,88 @@ export function describeStoreConformance(
         expect(session?.envConfigId).toBeDefined();
       });
 
+      // Env configs update in place — there is no version to pin — so the
+      // session copies the resolved recipe instead. These four cases are
+      // the whole contract: what is copied, that an edit cannot reach back
+      // through it, that a later session sees the edit, and that the copy
+      // is of a real row in the caller's own namespace.
+      describe("env config snapshot", () => {
+        it("copies the env config's resolved recipe at create", async () => {
+          const agentConfigRef = await newAgent();
+          const envConfigRef = await newEnv({
+            network: { type: "allowlist", domains: ["pypi.org"] },
+            packages: { pip: ["numpy"] },
+          });
+          const sessionRef = await store.createSession({
+            namespace: DEFAULT_NAMESPACE,
+            agentConfigId: agentConfigRef.agentConfigId,
+            envConfigId: envConfigRef.envConfigId,
+          });
+          expect((await store.getSession(sessionRef))?.envConfigSnapshot).toEqual({
+            network: { type: "allowlist", domains: ["pypi.org"] },
+            packages: { pip: ["numpy"] },
+          });
+        });
+
+        // The materialized defaults are decisions too: the snapshot copies
+        // what the env config resolved, never the request that made it.
+        it("copies the materialized defaults, not the create request", async () => {
+          const sessionRef = await newSession(); // newEnv() states neither field
+          expect((await store.getSession(sessionRef))?.envConfigSnapshot).toEqual({
+            network: { type: "unrestricted" },
+            packages: {},
+          });
+        });
+
+        it("does not change under a later env config update", async () => {
+          const agentConfigRef = await newAgent();
+          const envConfigRef = await newEnv({ network: { type: "none" } });
+          const before = await store.createSession({
+            namespace: DEFAULT_NAMESPACE,
+            agentConfigId: agentConfigRef.agentConfigId,
+            envConfigId: envConfigRef.envConfigId,
+          });
+
+          await store.updateEnvConfig(envConfigRef, {
+            network: { type: "allowlist", domains: ["example.com"] },
+            packages: { npm: ["zod"] },
+          });
+
+          // The running session's world is the one it was born with…
+          expect((await store.getSession(before))?.envConfigSnapshot).toEqual({
+            network: { type: "none" },
+            packages: {},
+          });
+          // …and the next session gets the edit.
+          const after = await store.createSession({
+            namespace: DEFAULT_NAMESPACE,
+            agentConfigId: agentConfigRef.agentConfigId,
+            envConfigId: envConfigRef.envConfigId,
+          });
+          expect((await store.getSession(after))?.envConfigSnapshot).toEqual({
+            network: { type: "allowlist", domains: ["example.com"] },
+            packages: { npm: ["zod"] },
+          });
+          // The env config itself is untouched by either session.
+          expect((await store.getEnvConfig(envConfigRef))?.network).toEqual({
+            type: "allowlist",
+            domains: ["example.com"],
+          });
+        });
+
+        it("has nothing to copy from a foreign env config — the create fails", async () => {
+          const agentConfigRef = await newAgent({ namespace: "tenant-a" });
+          const foreignEnv = await newEnv({ namespace: "tenant-b" });
+          await expect(
+            store.createSession({
+              namespace: "tenant-a",
+              agentConfigId: agentConfigRef.agentConfigId,
+              envConfigId: foreignEnv.envConfigId,
+            }),
+          ).rejects.toThrow("unknown env config");
+        });
+      });
+
       it("pins the latest agent version when the session is created", async () => {
         const agentConfigRef = await newAgent({
           inference: { provider: "fake", model: "m1" },

--- a/packages/agent/src/ports/store.ts
+++ b/packages/agent/src/ports/store.ts
@@ -104,6 +104,11 @@ export interface Store {
    * fields are preserved; an empty request is a read-like no-op. Namespace
    * is immutable and carried by the ref. An unknown or foreign ref is
    * indistinguishable from absence and returns undefined.
+   *
+   * In place means exactly that: there is no version history, and this
+   * reaches no existing session. Sessions carry their own copy of the
+   * recipe (createSession), so an update changes only what sessions
+   * created after it will provision from.
    */
   updateEnvConfig(ref: EnvConfigRef, req: UpdateEnvConfigRequest): Promise<EnvConfig | undefined>;
   /** One namespace's env configs, newest first — see ListEnvConfigsRequest. */
@@ -111,13 +116,19 @@ export interface Store {
 
   // --- sessions ---
 
-  /** Create a session. Namespace must be specified. Pins the requested agent
-   *  version, or the latest when omitted. Rejects unknown configs or versions,
-   *  with namespace-scoped checks so foreign ids
-   *  remain indistinguishable from nonexistent ones, and an archived agent
-   *  config with ArchivedError. Archiving and creating are serialized on the
-   *  agent config row: a session either commits before the archive or sees
-   *  it — never lands after one. */
+  /** Create a session, making both configs durable against later edits:
+   *  PINS the requested agent version (or the latest when omitted), and
+   *  COPIES the env config's resolved recipe onto the row as
+   *  envConfigSnapshot — env configs update in place, so there is no
+   *  version to pin, and an implementation that stored only the reference
+   *  would let an edit reshape a running session's world. Namespace must
+   *  be specified. Rejects unknown configs or versions with
+   *  namespace-scoped checks, so foreign ids remain indistinguishable from
+   *  nonexistent ones, and an archived agent config with ArchivedError.
+   *  Archiving and creating are serialized on the agent config row: a
+   *  session either commits before the archive or sees it — never lands
+   *  after one. The env config row is read under the same discipline, so
+   *  the copy is always of a committed state. */
   createSession(req: CreateSessionRequest): Promise<SessionRef>;
   getSession(ref: SessionRef): Promise<Session | undefined>;
   /** Register the session's one sandbox: a compare-and-set on the

--- a/packages/agent/test/ensure-sandbox.test.ts
+++ b/packages/agent/test/ensure-sandbox.test.ts
@@ -48,6 +48,7 @@ function fakeStore(opts?: { sandboxId?: string; winner?: string }) {
     agentConfigId: "a1",
     agentConfigVersion: 1,
     envConfigId: "e1",
+    envConfigSnapshot: { network: { type: "unrestricted" }, packages: {} },
     namespace: "default",
     createdAt: "2026-08-18T00:00:00.000Z",
     ...(opts?.sandboxId ? { sandboxId: opts.sandboxId } : {}),

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -60,9 +60,13 @@ export const DEFAULT_NAMESPACE = "default";
 // --- configs ---
 
 // Agent configs are mutable, with a monotonic version used for optional
-// optimistic concurrency. Env configs update in place. Sessions pin the
-// latest concrete agent version at creation, while retaining an env config
-// reference.
+// optimistic concurrency. Env configs update in place. Both being mutable,
+// a session has to make each one durable at creation — by a different
+// mechanism, because only one of them leaves something immutable to point
+// at. It PINS the agent config's concrete version, and COPIES the env
+// config's resolved recipe (EnvConfigSnapshot below), keeping the env
+// config id beside the copy for provenance rather than resolution. Either
+// way, a later edit cannot reshape a run already under way.
 //
 // Archive is the one terminal transition: it retires an agent config
 // without deleting it — the row stays readable and its versions stay
@@ -136,29 +140,51 @@ export const ListEnvConfigsRequest = z.object({
 });
 export type ListEnvConfigsRequest = z.infer<typeof ListEnvConfigsRequest>;
 
-export const CreateEnvConfigRequest = z.object({
-  namespace: z.string().min(1),
-  network: NetworkPolicy.optional(),
+/**
+ * The recipe proper — the fields that describe the world, resolved, with
+ * no envelope around them. Declared once here and derived from in every
+ * direction: optional in the create and update requests (absence is a
+ * default to resolve), required on the stored row, and required in the
+ * copy a session carries. A capability promoted into the recipe therefore
+ * cannot be half-wired — it becomes requestable, storable, and
+ * snapshotted in one edit — and no session can provision from a recipe
+ * that quietly lost a field.
+ *
+ * A session stores this by COPY rather than by reference: env configs
+ * update in place, so there is no immutable version to pin the way a
+ * session pins one agent config version. The copy is what makes a
+ * session's world deterministic — a later edit can never reshape a run
+ * already under way. envConfigId stays beside it for provenance; nothing
+ * reads through it to provision.
+ */
+export const EnvConfigSnapshot = z.object({
+  network: NetworkPolicy, // absence resolved to { type: "unrestricted" }
   // Presence is guaranteed at create() or creation fails — missing deps
   // surface at provision, not mid-session.
-  packages: Packages.optional(),
+  packages: Packages, // absence resolved to {}
+});
+export type EnvConfigSnapshot = z.infer<typeof EnvConfigSnapshot>;
+
+// The recipe arrives partial and is stored materialized: every field a
+// request may omit is one the store resolves to a decision at create.
+export const CreateEnvConfigRequest = z.object({
+  namespace: z.string().min(1),
+  ...EnvConfigSnapshot.partial().shape,
   metadata: JsonValue.optional(),
 });
 export type CreateEnvConfigRequest = z.infer<typeof CreateEnvConfigRequest>;
 
 /** An in-place partial update; omission preserves the stored field. */
 export const UpdateEnvConfigRequest = z.object({
-  network: NetworkPolicy.optional(),
-  packages: Packages.optional(),
+  ...EnvConfigSnapshot.partial().shape,
   metadata: JsonValue.optional(),
 });
 export type UpdateEnvConfigRequest = z.infer<typeof UpdateEnvConfigRequest>;
 
 export const EnvConfig = EnvConfigRef.extend({
-  ...CreateEnvConfigRequest.omit({ namespace: true }).shape,
-  // Materialized at create — resolved decisions, not restatable defaults:
-  network: NetworkPolicy, // absence resolved to { type: "unrestricted" }
-  packages: Packages, // absence resolved to {}
+  // Materialized at create — resolved decisions, not restatable defaults.
+  ...EnvConfigSnapshot.shape,
+  metadata: JsonValue.optional(),
   createdAt: z.iso.datetime(),
 });
 export type EnvConfig = z.infer<typeof EnvConfig>;
@@ -189,6 +215,10 @@ export const Session = SessionRef.extend({
   ...CreateSessionRequest.omit({ namespace: true }).shape,
   // Materialized from the request or the agent config's latest version.
   agentConfigVersion: z.number().int().min(1),
+  // The env recipe as it read at create (EnvConfigSnapshot above). A
+  // resolved decision, materialized like the version above it, so it is
+  // always present — never restated from the env config row.
+  envConfigSnapshot: EnvConfigSnapshot,
   // The session's one workspace, registered by the driver's first
   // execute_tools claim (Store.bindSandbox); absent until then.
   sandboxId: z.string().optional(),

--- a/packages/core/test/store.test.ts
+++ b/packages/core/test/store.test.ts
@@ -8,6 +8,7 @@ import {
   CreateSessionRequest,
   EnvConfig,
   EnvConfigRef,
+  EnvConfigSnapshot,
   IntakeResult,
   ListAgentConfigsRequest,
   ListEnvConfigsRequest,
@@ -253,9 +254,61 @@ describe("sessions", () => {
       agentConfigId: "ac1",
       agentConfigVersion: 2,
       envConfigId: "ec1",
+      envConfigSnapshot: {
+        network: { type: "allowlist", domains: ["pypi.org"] },
+        packages: { pip: ["numpy"] },
+      },
       createdAt: "2026-08-11T12:00:00Z",
     };
     expect(roundTrip(Session, session)).toEqual(session);
+  });
+
+  // The recipe is copied, not referenced: env configs update in place, so
+  // a session that resolved one at read time could change under a running
+  // run. The snapshot is a resolved decision, so it is never absent.
+  it("rejects a stored session missing its env config snapshot", () => {
+    const result = Session.safeParse({
+      namespace: "default",
+      sessionId: "s1",
+      agentConfigId: "ac1",
+      agentConfigVersion: 1,
+      envConfigId: "ec1",
+      createdAt: "2026-08-11T12:00:00Z",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // The guard against the drift this derivation exists to prevent: if
+  // anyone re-hand-lists these shapes, a recipe field added in one place
+  // and forgotten in another fails here rather than at provision time.
+  it("derives every env config shape from the one recipe declaration", () => {
+    const recipe = Object.keys(EnvConfigSnapshot.shape) as (keyof EnvConfigSnapshot)[];
+    expect(recipe).toEqual(["network", "packages"]);
+    for (const field of recipe) {
+      // Optional in both requests — absence is a default to resolve…
+      expect(CreateEnvConfigRequest.shape[field].safeParse(undefined).success).toBe(true);
+      expect(UpdateEnvConfigRequest.shape[field].safeParse(undefined).success).toBe(true);
+      // …required on the stored row, which holds decisions, not rules…
+      expect(EnvConfig.shape[field].safeParse(undefined).success).toBe(false);
+      // …and required in the copy a session provisions from.
+      expect(Session.shape.envConfigSnapshot.shape[field].safeParse(undefined).success).toBe(false);
+    }
+    // The row is the recipe plus its envelope, nothing else.
+    expect(Object.keys(EnvConfig.shape).sort()).toEqual(
+      [...recipe, "namespace", "envConfigId", "metadata", "createdAt"].sort(),
+    );
+  });
+
+  it("requires both halves of the recipe in a snapshot", () => {
+    expect(EnvConfigSnapshot.safeParse({ network: { type: "none" }, packages: {} }).success).toBe(
+      true,
+    );
+    expect(EnvConfigSnapshot.safeParse({ network: { type: "none" } }).success).toBe(false);
+    expect(EnvConfigSnapshot.safeParse({ packages: {} }).success).toBe(false);
+    // Intent, not mechanism — an unknown policy shape is not a recipe.
+    expect(EnvConfigSnapshot.safeParse({ network: { type: "vpn" }, packages: {} }).success).toBe(
+      false,
+    );
   });
 
   it("rejects a stored session missing namespace — the row is its own ref", () => {
@@ -264,6 +317,7 @@ describe("sessions", () => {
       agentConfigId: "ac1",
       agentConfigVersion: 1,
       envConfigId: "ec1",
+      envConfigSnapshot: { network: { type: "unrestricted" }, packages: {} },
       createdAt: "2026-08-11T12:00:00Z",
     });
     expect(result.success).toBe(false);


### PR DESCRIPTION
Env configs update in place, so a session that resolved one at provision time could have its world reshaped mid-run. That is not hypothetical: `ensureSandbox` provisions a second time whenever a sandbox dies and has to be replaced, so an edit landing between the first create and the replacement would silently move a running session to a different network policy.

Sessions now COPY the env config's resolved recipe into `sessions.env_config_snapshot` at create, alongside the agent version they already PIN. Both configs are mutable, so a session has to make each one durable at creation — by a different mechanism, because only the agent config leaves something immutable to point at. `envConfigId` stays beside the copy for provenance; nothing reads through it to provision.

## The recipe, declared once

`EnvConfigSnapshot` is the recipe proper — the fields that describe the world, with no envelope around them — and every other env shape is derived from it: optional in the create and update requests (absence is a default to resolve), required on the stored row, required in the copy a session carries. A capability promoted into the recipe becomes requestable, storable, and snapshotted in one edit, so it cannot be half-wired.

## Store

`createSession` reads the env row `FOR SHARE` and holds it to the insert, so the copy is always of a committed state and a racing `updateEnvConfig` lands strictly before or after it, never inside. Shared mode, so concurrent creates never wait on each other — only an env update does. Lock order is agent → env, and nothing takes env → agent, so this adds no cycle.

The port jsdoc now states the copy as contract rather than leaving it to the pg adapter: `createSession` documents PIN-and-COPY, and `updateEnvConfig` documents what "in place" means for sessions that already exist — it reaches none of them.

## Schema

Edited in place rather than migrated, per the convention in #135 — nothing is deployed yet, so the schema is still a description rather than a history.

## Verification

- `pnpm typecheck`, the unit suite (340 tests), and `prettier --check` are green.
- The store conformance suite pins the four cases that are the whole contract: what is copied, that a later edit cannot reach back through it, that a later session sees the edit, and that the copy is of a real row in the caller's own namespace.
- A new adapters integration test (`env-snapshot-provisioning.test.ts`) runs the invariant end to end over the real pg store and the real `ensureSandbox` — including the sandbox-replacement path, where the replacement is provisioned from the snapshot and not the edited recipe.
- Not run: the opt-in e2e suite (real model, real E2B) and the network-postgres conformance binding. PGlite serializes concurrency away, so the `FOR SHARE` serialization argument above is structural — it is not exercised under true contention by anything in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
