### PR TITLE
Add environment config archive endpoint

### DIFF
--- a/apps/api/src/routes/env-configs.ts
+++ b/apps/api/src/routes/env-configs.ts
@@ -1,5 +1,6 @@
 // apps/api/src/routes/env-configs.ts
-// The env-config resource — sandbox recipes updated in place. Thin:
+// The env-config resource — sandbox recipes updated in place until archive,
+// their terminal state. Thin:
 // validate the request shape → Store call → wire row, where the wire
 // mapping only renames the ref's qualified id to the resource's `id`.
 // Namespace is part of the request: the create body carries it — the
@@ -7,14 +8,14 @@
 // ?namespace= (see agent-configs.ts and common.ts NamespaceQuery).
 import { Hono } from "hono";
 import { CreateEnvConfigRequest, type EnvConfig, UpdateEnvConfigRequest } from "@funky/core";
-import type { Store } from "@funky/agent";
+import { ArchivedError, type Store } from "@funky/agent";
 import { errorResponse } from "../http";
 import { ListQuery, NamespaceQuery, page, validate } from "./common";
 
 /** The slice of the harness Store this resource needs. */
 export type EnvConfigStore = Pick<
   Store,
-  "createEnvConfig" | "getEnvConfig" | "updateEnvConfig" | "listEnvConfigs"
+  "createEnvConfig" | "getEnvConfig" | "updateEnvConfig" | "archiveEnvConfig" | "listEnvConfigs"
 >;
 
 type Env = { Variables: { requestId: string } };
@@ -74,16 +75,35 @@ export function envConfigRoutes(store: EnvConfigStore) {
     async (c) => {
       const id = c.req.param("id");
       const { namespace } = c.req.valid("query");
-      const config = await store.updateEnvConfig(
-        { namespace, envConfigId: id },
-        c.req.valid("json"),
-      );
-      if (!config) {
-        return errorResponse(c, 404, "not_found_error", `no env config ${id}`);
+      try {
+        const config = await store.updateEnvConfig(
+          { namespace, envConfigId: id },
+          c.req.valid("json"),
+        );
+        if (!config) {
+          return errorResponse(c, 404, "not_found_error", `no env config ${id}`);
+        }
+        return c.json(wire(config));
+      } catch (err) {
+        if (err instanceof ArchivedError) {
+          return errorResponse(c, 409, "conflict_error", err.message);
+        }
+        throw err;
       }
-      return c.json(wire(config));
     },
   );
+
+  // Archive retires the recipe without deleting it. With no unarchive,
+  // repeating the transition is a 200 carrying the original archivedAt.
+  r.post("/:id/archive", validate("query", NamespaceQuery), async (c) => {
+    const id = c.req.param("id");
+    const { namespace } = c.req.valid("query");
+    const config = await store.archiveEnvConfig({ namespace, envConfigId: id });
+    if (!config) {
+      return errorResponse(c, 404, "not_found_error", `no env config ${id}`);
+    }
+    return c.json(wire(config));
+  });
 
   return r;
 }

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -74,9 +74,9 @@ export function sessionRoutes(store: SessionStore, pacing: StreamPacing) {
       session = await store.getSession(ref);
       if (!session) throw new Error(`session ${ref.sessionId} missing after create`);
     } catch (err) {
-      // An archived agent config exists and is readable — it just cannot
-      // be referenced by anything new. That is a conflict with its
-      // terminal state (409), not a malformed request (400).
+      // An archived config exists and is readable — it just cannot be
+      // referenced by anything new. That is a conflict with its terminal
+      // state (409), not a malformed request (400).
       if (err instanceof ArchivedError) {
         return errorResponse(c, 409, "conflict_error", err.message);
       }

--- a/apps/api/test/env-configs.test.ts
+++ b/apps/api/test/env-configs.test.ts
@@ -198,6 +198,67 @@ describe("POST /v1/env-configs/:id", () => {
   });
 });
 
+describe("POST /v1/env-configs/:id/archive", () => {
+  it("archives the config and returns the unchanged recipe with its mark", async () => {
+    const created = await (
+      await post(app, "/v1/env-configs", {
+        namespace: "default",
+        network: { type: "none" },
+        packages: { pip: ["numpy"] },
+      })
+    ).json();
+
+    const res = await post(app, `/v1/env-configs/${created.id}/archive`);
+    expect(res.status).toBe(200);
+    const archived = await res.json();
+    expect(archived).toMatchObject({ ...created, archivedAt: expect.any(String) });
+
+    const fetched = await get(app, `/v1/env-configs/${created.id}`);
+    expect(fetched.status).toBe(200);
+    expect(await fetched.json()).toEqual(archived);
+  });
+
+  it("is idempotent and returns the first archivedAt", async () => {
+    const created = await (await post(app, "/v1/env-configs", {})).json();
+    const first = await (await post(app, `/v1/env-configs/${created.id}/archive`)).json();
+    const again = await post(app, `/v1/env-configs/${created.id}/archive`);
+
+    expect(again.status).toBe(200);
+    expect(await again.json()).toEqual(first);
+  });
+
+  it("409s a later mutation while an empty update remains a read", async () => {
+    const created = await (await post(app, "/v1/env-configs", {})).json();
+    const archived = await (await post(app, `/v1/env-configs/${created.id}/archive`)).json();
+
+    const mutation = await post(app, `/v1/env-configs/${created.id}`, {
+      packages: { npm: ["zod@4"] },
+    });
+    expect(mutation.status).toBe(409);
+    const error = (await mutation.json()).error;
+    expect(error.type).toBe("conflict_error");
+    expect(error.message).toBe(`env config default/${created.id} is archived`);
+
+    const read = await post(app, `/v1/env-configs/${created.id}`, {});
+    expect(read.status).toBe(200);
+    expect(await read.json()).toEqual(archived);
+  });
+
+  it("404s unknown and foreign ids without archiving the owned config", async () => {
+    expect((await post(app, "/v1/env-configs/nope/archive?namespace=arch-a")).status).toBe(404);
+
+    const created = await (
+      await post(app, "/v1/env-configs", { namespace: "arch-a", packages: { pip: ["numpy"] } })
+    ).json();
+    const foreign = await post(app, `/v1/env-configs/${created.id}/archive?namespace=arch-b`);
+    expect(foreign.status).toBe(404);
+    expect((await foreign.json()).error.type).toBe("not_found_error");
+
+    const own = await (await get(app, `/v1/env-configs/${created.id}?namespace=arch-a`)).json();
+    expect("archivedAt" in own).toBe(false);
+  });
+});
+
 describe("namespace scoping", () => {
   it("creates in the namespace the request names and scopes reads by the query", async () => {
     const res = await post(app, "/v1/env-configs", { namespace: "tenant-a" });

--- a/apps/api/test/sessions.test.ts
+++ b/apps/api/test/sessions.test.ts
@@ -151,6 +151,23 @@ describe("POST /v1/sessions", () => {
     expect((await message.json()).kind).toBe("started");
   });
 
+  it("409s an archived env config, while sessions with its snapshot keep working", async () => {
+    const configs = await seedConfigs(app);
+    const create = { namespace: "default", ...configs };
+    const sessionId = (await (await post(app, "/v1/sessions", create)).json()).id;
+    expect((await post(app, `/v1/env-configs/${configs.envConfigId}/archive`)).status).toBe(200);
+
+    const res = await post(app, "/v1/sessions", create);
+    expect(res.status).toBe(409);
+    const error = (await res.json()).error;
+    expect(error.type).toBe("conflict_error");
+    expect(error.message).toBe(`env config default/${configs.envConfigId} is archived`);
+
+    const message = await post(app, `/v1/sessions/${sessionId}/messages`, { content: "hi" });
+    expect(message.status).toBe(202);
+    expect((await message.json()).kind).toBe("started");
+  });
+
   it("400s a foreign-namespace config identically to a dangling one", async () => {
     const configs = await seedConfigs(app, "tenant-a");
     const res = await post(app, "/v1/sessions", { namespace: "tenant-b", ...configs });

--- a/packages/adapters/migrations/20260820000000_init/migration.sql
+++ b/packages/adapters/migrations/20260820000000_init/migration.sql
@@ -56,6 +56,9 @@ CREATE TABLE env_configs (
   packages jsonb NOT NULL,
   metadata jsonb,
   created_at timestamptz NOT NULL,
+  -- Retires the recipe without deleting it. Existing sessions have their
+  -- own copy; NULL means no archive event, and the mark is never cleared.
+  archived_at timestamptz,
   PRIMARY KEY (namespace, id)
 );
 

--- a/packages/adapters/src/store/pg.ts
+++ b/packages/adapters/src/store/pg.ts
@@ -8,16 +8,13 @@
 //   per-session log stays gapless and monotonic.
 // - Lock order is item → session everywhere an item is involved; no path
 //   takes session → item, so no cycle exists.
-// - createSession holds a FOR SHARE lock on its agent config row until it
-//   commits, and archiveAgentConfig's UPDATE takes that row exclusively:
-//   the two serialize, so no session is born against an archived config.
-//   Archive touches nothing else, so this adds no cycle either.
-// - createSession takes the same FOR SHARE on its env config row, held to
-//   the insert, so the snapshot it copies is a committed state and a
-//   racing updateEnvConfig lands strictly before or after it — never
-//   inside. Shared mode: concurrent creates never wait on each other, only
-//   an env update does. Lock order is agent → env, and nothing takes env
-//   → agent, so this adds no cycle either.
+// - createSession holds FOR SHARE locks on both config rows until it
+//   commits, while each archive method's UPDATE takes its row exclusively:
+//   the operations serialize, so no session is born against either archived
+//   config. The env lock also makes the recipe snapshot a committed state:
+//   a racing updateEnvConfig lands strictly before or after it — never
+//   inside. Shared mode lets concurrent creates proceed together. Lock order
+//   is agent → env, and no path takes env → agent, so no cycle exists.
 // - claimItem uses FOR UPDATE SKIP LOCKED: contended claimers never
 //   queue behind each other, exactly one wins a given item.
 // - Fencing is token + live lease, symmetric across heartbeat and
@@ -140,6 +137,7 @@ const toEnvConfig = (row: typeof envConfigs.$inferSelect): EnvConfig =>
     namespace: row.namespace,
     ...unwrapped(row.metadata),
     createdAt: iso(row.createdAt),
+    ...(row.archivedAt === null ? {} : { archivedAt: iso(row.archivedAt) }),
   });
 
 export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
@@ -346,7 +344,9 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         if (current === undefined) return undefined;
         // Archived outranks the version verdict: it is terminal, so
         // "retry with the current version" would be a lie.
-        if (current.archivedAt !== null) throw new ArchivedError(agentConfigId);
+        if (current.archivedAt !== null) {
+          throw new ArchivedError({ namespace, agentConfigId });
+        }
         if (parsed.version !== undefined) {
           throw new VersionConflictError(parsed.version, current.version);
         }
@@ -418,6 +418,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       const { envConfigId, namespace } = EnvConfigRef.parse(ref);
       const parsed = UpdateEnvConfigRequest.parse(req);
       const scope = and(eq(envConfigs.id, envConfigId), eq(envConfigs.namespace, namespace));
+      const mutable = and(scope, isNull(envConfigs.archivedAt));
       const updates = {
         ...(parsed.network === undefined ? {} : { network: parsed.network }),
         ...(parsed.packages === undefined ? {} : { packages: parsed.packages }),
@@ -429,8 +430,38 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         return row === undefined ? undefined : toEnvConfig(row);
       }
 
-      const [row] = await db.update(envConfigs).set(updates).where(scope).returning();
-      return row === undefined ? undefined : toEnvConfig(row);
+      const [row] = await db.update(envConfigs).set(updates).where(mutable).returning();
+      if (row !== undefined) return toEnvConfig(row);
+
+      // An unmatched mutation is either unknown/foreign or archived. Rows
+      // are never deleted, so this read resolves the verdict without a race;
+      // archive is terminal and therefore always outranks the write.
+      const [current] = await db
+        .select({ archivedAt: envConfigs.archivedAt })
+        .from(envConfigs)
+        .where(scope);
+      if (current === undefined) return undefined;
+      if (current.archivedAt !== null) {
+        throw new ArchivedError({ namespace, envConfigId });
+      }
+      throw new Error(`env config ${envConfigId} was not updated`);
+    },
+
+    async archiveEnvConfig(ref) {
+      const { envConfigId, namespace } = EnvConfigRef.parse(ref);
+      const scope = and(eq(envConfigs.id, envConfigId), eq(envConfigs.namespace, namespace));
+      return db.transaction(async (tx) => {
+        // Only the first caller stamps the row. A repeat (or racing archive)
+        // leaves the original time untouched, then reads the same terminal
+        // state back. The UPDATE's row lock also serializes with the shared
+        // lock held by createSession while it copies an active recipe.
+        await tx
+          .update(envConfigs)
+          .set({ archivedAt: now() })
+          .where(and(scope, isNull(envConfigs.archivedAt)));
+        const [row] = await tx.select().from(envConfigs).where(scope);
+        return row === undefined ? undefined : toEnvConfig(row);
+      });
     },
 
     async listEnvConfigs(req) {
@@ -465,18 +496,19 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       // config is "unknown" — indistinguishable from nonexistent, so nothing
       // leaks.
       //
-      // Archive is the one fact that CAN change under a check, so the agent
-      // row is read FOR SHARE and the lock held to the insert: a concurrent
-      // archive either waits behind this transaction or is already committed
-      // and read here. "New sessions cannot reference an archived config" is
-      // therefore structural, not a window between a check and a write.
+      // Archive is the one terminal fact that CAN change under these checks,
+      // so both config rows are read FOR SHARE and the locks held through the
+      // insert. A concurrent archive waits behind this transaction or is
+      // already committed and read here. "New sessions cannot reference an
+      // archived config" is therefore structural, not a check/write window.
       //
       // The env recipe is the other mutable fact, and it is not merely
       // checked but COPIED (core/store.ts EnvConfigSnapshot): env configs
       // update in place, so a session that reloaded one could have its world
-      // reshaped mid-run. The same FOR SHARE makes the copy a committed
-      // state — a racing update waits behind this insert or is already in
-      // it — and nothing reads env_configs for this session again.
+      // reshaped mid-run. The env lock also makes the copy a committed state
+      // — a racing update waits behind this insert or is already in it — and
+      // nothing reads env_configs for this session again. Agent → env is the
+      // global lock order; neither archive path takes the other config row.
       await db.transaction(async (tx) => {
         const [agent] = await tx
           .select({ version: agentConfigVersions.version, archivedAt: agentConfigs.archivedAt })
@@ -487,13 +519,22 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
           )
           .for("share", { of: agentConfigs });
         if (!agent) throw new Error(`unknown agent config: ${parsed.agentConfigId}`);
-        if (agent.archivedAt !== null) throw new ArchivedError(parsed.agentConfigId);
+        if (agent.archivedAt !== null) {
+          throw new ArchivedError({ namespace, agentConfigId: parsed.agentConfigId });
+        }
         const [env] = await tx
-          .select({ network: envConfigs.network, packages: envConfigs.packages })
+          .select({
+            network: envConfigs.network,
+            packages: envConfigs.packages,
+            archivedAt: envConfigs.archivedAt,
+          })
           .from(envConfigs)
           .where(and(eq(envConfigs.id, parsed.envConfigId), eq(envConfigs.namespace, namespace)))
-          .for("share");
+          .for("share", { of: envConfigs });
         if (!env) throw new Error(`unknown env config: ${parsed.envConfigId}`);
+        if (env.archivedAt !== null) {
+          throw new ArchivedError({ namespace, envConfigId: parsed.envConfigId });
+        }
         await tx.insert(sessions).values({
           id,
           agentConfigId: parsed.agentConfigId,

--- a/packages/adapters/src/store/schema.ts
+++ b/packages/adapters/src/store/schema.ts
@@ -91,6 +91,9 @@ export const envConfigs = pgTable(
     packages: jsonb("packages").$type<Packages>().notNull(),
     metadata: jsonb("metadata").$type<WrappedJson>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+    // The terminal state, set once: null = active. Existing sessions use
+    // their snapshot, while this mark closes the recipe to new sessions.
+    archivedAt: timestamp("archived_at", { withTimezone: true }),
   },
   (t) => [primaryKey({ columns: [t.namespace, t.id] })],
 );

--- a/packages/adapters/test/store-conformance.ts
+++ b/packages/adapters/test/store-conformance.ts
@@ -451,7 +451,9 @@ export function describeStoreConformance(
         ]) {
           await expect(store.updateAgentConfig(ref, req)).rejects.toMatchObject({
             name: "ArchivedError",
+            namespace: ref.namespace,
             configId: ref.agentConfigId,
+            configKind: "agent",
           });
         }
         expect(await store.getAgentConfig(ref)).toMatchObject({
@@ -598,6 +600,143 @@ export function describeStoreConformance(
         // The foreign archive touched nothing.
         expect(await store.getAgentConfig(ref)).toMatchObject({ namespace: "tenant-a" });
         expect("archivedAt" in (await store.getAgentConfig(ref))!).toBe(false);
+      });
+    });
+
+    describe("archiving env configs", () => {
+      it("marks the config archived without changing its recipe", async () => {
+        const ref = await newEnv({
+          network: { type: "allowlist", domains: ["pypi.org"] },
+          packages: { pip: ["numpy"] },
+          metadata: { stage: "final" },
+        });
+        const before = await store.getEnvConfig(ref);
+        clock.advance(1_000);
+
+        const archived = await store.archiveEnvConfig(ref);
+
+        expect(archived).toMatchObject({ ...before, archivedAt: expect.any(String) });
+        expect(await store.getEnvConfig(ref)).toEqual(archived);
+      });
+
+      it("stores absence as absence — an active config has no archivedAt key", async () => {
+        const config = await store.getEnvConfig(await newEnv());
+        expect(config).toBeDefined();
+        expect("archivedAt" in config!).toBe(false);
+      });
+
+      it("is idempotent and preserves the first archive time", async () => {
+        const ref = await newEnv();
+        const first = await store.archiveEnvConfig(ref);
+        clock.advance(1_000);
+        const second = await store.archiveEnvConfig(ref);
+
+        expect(second).toEqual(first);
+        expect(second?.archivedAt).toBe(first?.archivedAt);
+      });
+
+      it("makes every recipe mutation fail with a namespace-scoped ArchivedError", async () => {
+        const ref = await newEnv({ packages: { pip: ["numpy"] } });
+        await store.archiveEnvConfig(ref);
+
+        for (const req of [
+          { network: { type: "none" } as const },
+          { packages: { npm: ["zod@4"] } },
+          { metadata: { stage: "after" } },
+        ]) {
+          await expect(store.updateEnvConfig(ref, req)).rejects.toMatchObject({
+            name: "ArchivedError",
+            namespace: ref.namespace,
+            configId: ref.envConfigId,
+            configKind: "env",
+          });
+        }
+        expect((await store.getEnvConfig(ref))?.packages).toEqual({ pip: ["numpy"] });
+      });
+
+      it("keeps an empty update a read and keeps get and list readable", async () => {
+        const ref = await newEnv();
+        const archived = await store.archiveEnvConfig(ref);
+
+        expect(await store.updateEnvConfig(ref, {})).toEqual(archived);
+        expect(await store.getEnvConfig(ref)).toEqual(archived);
+        expect(
+          (await store.listEnvConfigs({ namespace: DEFAULT_NAMESPACE, limit: 10 })).map(
+            (c) => c.envConfigId,
+          ),
+        ).toContain(ref.envConfigId);
+      });
+
+      it("refuses new sessions but leaves an existing session's snapshot runnable", async () => {
+        const agentConfigRef = await newAgent();
+        const envConfigRef = await newEnv({
+          network: { type: "none" },
+          packages: { pip: ["numpy"] },
+        });
+        const create = {
+          namespace: DEFAULT_NAMESPACE,
+          agentConfigId: agentConfigRef.agentConfigId,
+          envConfigId: envConfigRef.envConfigId,
+        };
+        const sessionRef = await store.createSession(create);
+        await store.archiveEnvConfig(envConfigRef);
+
+        await expect(store.createSession(create)).rejects.toMatchObject({
+          name: "ArchivedError",
+          namespace: envConfigRef.namespace,
+          configId: envConfigRef.envConfigId,
+          configKind: "env",
+        });
+        expect((await store.getSession(sessionRef))?.envConfigSnapshot).toEqual({
+          network: { type: "none" },
+          packages: { pip: ["numpy"] },
+        });
+
+        const { itemRef, token } = await startAndClaim(sessionRef);
+        await store.commitStep({
+          itemRef,
+          token,
+          append: [assistant("still here")],
+          next: { kind: "end_run", status: "completed" },
+        });
+        expect(await store.readEntries(sessionRef)).toHaveLength(2);
+      });
+
+      it("settles a create/archive race without admitting a session afterward", async () => {
+        const agentConfigRef = await newAgent();
+        const envConfigRef = await newEnv();
+        const create = {
+          namespace: DEFAULT_NAMESPACE,
+          agentConfigId: agentConfigRef.agentConfigId,
+          envConfigId: envConfigRef.envConfigId,
+        };
+
+        const [created, archived] = await Promise.allSettled([
+          store.createSession(create),
+          store.archiveEnvConfig(envConfigRef),
+        ]);
+
+        expect(archived.status).toBe("fulfilled");
+        if (created.status === "fulfilled") {
+          expect(await store.getSession(created.value)).toBeDefined();
+        } else {
+          expect(created.reason).toBeInstanceOf(ArchivedError);
+        }
+        await expect(store.createSession(create)).rejects.toBeInstanceOf(ArchivedError);
+      });
+
+      it("treats an unknown or foreign archive target as absent", async () => {
+        const ref = await newEnv({ namespace: "tenant-a" });
+        expect(
+          await store.archiveEnvConfig({ namespace: "tenant-a", envConfigId: "nope" }),
+        ).toBeUndefined();
+        expect(
+          await store.archiveEnvConfig({ namespace: "tenant-b", envConfigId: ref.envConfigId }),
+        ).toBeUndefined();
+
+        const own = await store.getEnvConfig(ref);
+        expect(own).toMatchObject({ namespace: "tenant-a" });
+        expect("archivedAt" in own!).toBe(false);
       });
     });
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -27,4 +27,4 @@ export type {
   SandboxProvider,
 } from "./ports/sandbox-provider";
 export { ArchivedError, FencedError, VersionConflictError } from "./ports/store";
-export type { Claim, CommitStepRequest, LeaseToken, Store } from "./ports/store";
+export type { Claim, CommitStepRequest, ConfigKind, LeaseToken, Store } from "./ports/store";

--- a/packages/agent/src/ports/store.ts
+++ b/packages/agent/src/ports/store.ts
@@ -105,12 +105,22 @@ export interface Store {
    * is immutable and carried by the ref. An unknown or foreign ref is
    * indistinguishable from absence and returns undefined.
    *
+   * An archived config is read-only: a mutation throws ArchivedError. An
+   * empty request remains a read and returns the archived row unchanged.
+   *
    * In place means exactly that: there is no version history, and this
    * reaches no existing session. Sessions carry their own copy of the
    * recipe (createSession), so an update changes only what sessions
    * created after it will provision from.
    */
   updateEnvConfig(ref: EnvConfigRef, req: UpdateEnvConfigRequest): Promise<EnvConfig | undefined>;
+  /**
+   * Archive one namespace's environment config. The row stays readable and
+   * sessions that already copied its recipe keep running; future writes and
+   * references from new sessions are refused. There is no unarchive, making
+   * repeat calls idempotent: they return the original archivedAt.
+   */
+  archiveEnvConfig(ref: EnvConfigRef): Promise<EnvConfig | undefined>;
   /** One namespace's env configs, newest first — see ListEnvConfigsRequest. */
   listEnvConfigs(req: ListEnvConfigsRequest): Promise<EnvConfig[]>;
 
@@ -124,11 +134,11 @@ export interface Store {
    *  would let an edit reshape a running session's world. Namespace must
    *  be specified. Rejects unknown configs or versions with
    *  namespace-scoped checks, so foreign ids remain indistinguishable from
-   *  nonexistent ones, and an archived agent config with ArchivedError.
-   *  Archiving and creating are serialized on the agent config row: a
-   *  session either commits before the archive or sees it — never lands
-   *  after one. The env config row is read under the same discipline, so
-   *  the copy is always of a committed state. */
+   *  nonexistent ones, and either archived config with ArchivedError.
+   *  Archiving and creating are serialized on each config row: a session
+   *  either commits before an archive or sees it — never lands after one.
+   *  The env config row is read under the same discipline, so the copy is
+   *  always of a committed, active state. */
   createSession(req: CreateSessionRequest): Promise<SessionRef>;
   getSession(ref: SessionRef): Promise<Session | undefined>;
   /** Register the session's one sandbox: a compare-and-set on the
@@ -221,14 +231,25 @@ export class FencedError extends Error {
   }
 }
 
+export type ConfigKind = "agent" | "env";
+
 /**
- * Thrown when a write targets an archived config. Terminal, unlike
- * VersionConflictError: no retry of this request can ever succeed.
+ * Thrown when a mutation or new reference targets an archived config.
+ * Terminal, unlike VersionConflictError: no retry can ever succeed.
  */
 export class ArchivedError extends Error {
-  constructor(readonly configId: ConfigId) {
-    super(`agent config ${configId} is archived`);
+  readonly namespace: string;
+  readonly configId: ConfigId;
+  readonly configKind: ConfigKind;
+
+  constructor(ref: AgentConfigRef | EnvConfigRef) {
+    const configKind = "agentConfigId" in ref ? "agent" : "env";
+    const configId = "agentConfigId" in ref ? ref.agentConfigId : ref.envConfigId;
+    super(`${configKind} config ${ref.namespace}/${configId} is archived`);
     this.name = "ArchivedError";
+    this.namespace = ref.namespace;
+    this.configId = configId;
+    this.configKind = configKind;
   }
 }
 

--- a/packages/agent/test/store-port.test.ts
+++ b/packages/agent/test/store-port.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { ArchivedError } from "../src";
+
+describe("Store port errors", () => {
+  it("identifies the namespace and kind of config that is archived", () => {
+    expect(new ArchivedError({ namespace: "tenant-a", agentConfigId: "ac1" })).toMatchObject({
+      name: "ArchivedError",
+      namespace: "tenant-a",
+      configId: "ac1",
+      configKind: "agent",
+      message: "agent config tenant-a/ac1 is archived",
+    });
+    expect(new ArchivedError({ namespace: "tenant-b", envConfigId: "ec1" })).toMatchObject({
+      name: "ArchivedError",
+      namespace: "tenant-b",
+      configId: "ec1",
+      configKind: "env",
+      message: "env config tenant-b/ec1 is archived",
+    });
+  });
+});

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -68,11 +68,11 @@ export const DEFAULT_NAMESPACE = "default";
 // config id beside the copy for provenance rather than resolution. Either
 // way, a later edit cannot reshape a run already under way.
 //
-// Archive is the one terminal transition: it retires an agent config
-// without deleting it — the row stays readable and its versions stay
-// resolvable (sessions that pinned one keep running), but it accepts no
-// further update and no new session may reference it. There is no
-// unarchive, so nothing here spells one.
+// Archive is the one terminal transition: it retires either config without
+// deleting it. The row stays readable, and an agent config's versions stay
+// resolvable; sessions that already pinned the agent version and copied the
+// env recipe keep running. What stops is further update and use by a new
+// session. There is no unarchive, so nothing here spells one.
 
 /** A namespace-scoped reference to an agent config. */
 export const AgentConfigRef = z.object({
@@ -186,6 +186,9 @@ export const EnvConfig = EnvConfigRef.extend({
   ...EnvConfigSnapshot.shape,
   metadata: JsonValue.optional(),
   createdAt: z.iso.datetime(),
+  // Set once when the recipe is retired. Absence is the active state;
+  // archive is terminal, so there is no boolean state to toggle back.
+  archivedAt: z.iso.datetime().optional(),
 });
 export type EnvConfig = z.infer<typeof EnvConfig>;
 

--- a/packages/core/test/store.test.ts
+++ b/packages/core/test/store.test.ts
@@ -175,6 +175,30 @@ describe("env configs", () => {
     expect(roundTrip(EnvConfig, config)).toEqual(config);
   });
 
+  it("round-trips an archived env config — the mark is a timestamp, not a flag", () => {
+    const config = {
+      envConfigId: "ec1",
+      network: { type: "none" },
+      packages: {},
+      namespace: "tenant-a",
+      createdAt: "2026-08-11T12:00:00Z",
+      archivedAt: "2026-08-13T12:00:00Z",
+    };
+    expect(roundTrip(EnvConfig, config)).toEqual(config);
+  });
+
+  it("rejects a null or boolean env config archivedAt — absence is spelled by absence", () => {
+    const config = {
+      envConfigId: "ec1",
+      network: { type: "none" },
+      packages: {},
+      namespace: "tenant-a",
+      createdAt: "2026-08-11T12:00:00Z",
+    };
+    expect(EnvConfig.safeParse({ ...config, archivedAt: null }).success).toBe(false);
+    expect(EnvConfig.safeParse({ ...config, archivedAt: true }).success).toBe(false);
+  });
+
   it("rejects a flat package list — specs are keyed by their package manager", () => {
     const result = CreateEnvConfigRequest.safeParse({
       namespace: "tenant-a",
@@ -295,7 +319,7 @@ describe("sessions", () => {
     }
     // The row is the recipe plus its envelope, nothing else.
     expect(Object.keys(EnvConfig.shape).sort()).toEqual(
-      [...recipe, "namespace", "envConfigId", "metadata", "createdAt"].sort(),
+      [...recipe, "namespace", "envConfigId", "metadata", "createdAt", "archivedAt"].sort(),
     );
   });
 


### PR DESCRIPTION
Adds terminal, idempotent archiving for environment configs across the core/store contracts, PostgreSQL schema and adapter, and `POST /v1/env-configs/:id/archive`. Archived configs remain readable, reject mutations and new sessions with namespace-scoped errors, and preserve existing session snapshots; row locks serialize session creation with archive. Adds schema, conformance, API, session, namespace-isolation, idempotency, and create/archive race coverage. Validation passed with formatting, typecheck, all package tests, and production builds.