### PR TITLE
Add the session list endpoint

### DIFF
--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -23,12 +23,18 @@ import { z } from "zod";
 import { CreateSessionRequest, type Session, UserMessage, type WorkItem } from "@funky/core";
 import { ArchivedError, type Store } from "@funky/agent";
 import { errorResponse } from "../http";
-import { NamespaceQuery, validate } from "./common";
+import { ListQuery, NamespaceQuery, page, validate } from "./common";
 
 /** The slice of the harness Store this resource needs. */
 export type SessionStore = Pick<
   Store,
-  "createSession" | "getSession" | "intake" | "requestCancel" | "readEntries" | "listItems"
+  | "createSession"
+  | "getSession"
+  | "listSessions"
+  | "intake"
+  | "requestCancel"
+  | "readEntries"
+  | "listItems"
 >;
 
 /** SSE tail pacing — from config in production, shrunk by tests. */
@@ -88,6 +94,23 @@ export function sessionRoutes(store: SessionStore, pacing: StreamPacing) {
       throw err;
     }
     return c.json(wire(session), 201);
+  });
+
+  // list → one page of this namespace's rows, newest first. The store
+  // is asked for limit + 1: the extra row is hasMore (see page()).
+  r.get("/", validate("query", ListQuery), async (c) => {
+    const { namespace, limit, after } = c.req.valid("query");
+    try {
+      const rows = await store.listSessions({ namespace, limit: limit + 1, after });
+      return c.json(page(rows.map(wire), limit));
+    } catch (err) {
+      // A cursor the store can't resolve — foreign or made-up, the same
+      // "unknown" either way — is the client's mistake, so 400 not 500.
+      if (err instanceof Error && err.message.startsWith("unknown cursor")) {
+        return errorResponse(c, 400, "invalid_request_error", err.message);
+      }
+      throw err;
+    }
   });
 
   r.get("/:id", validate("query", NamespaceQuery), async (c) => {

--- a/apps/api/test/sessions.test.ts
+++ b/apps/api/test/sessions.test.ts
@@ -159,6 +159,81 @@ describe("POST /v1/sessions", () => {
   });
 });
 
+describe("GET /v1/sessions", () => {
+  // Every list test gets its own tenant, so the page it reads contains
+  // exactly the rows it created — the store's namespace scoping IS the
+  // isolation. Order is asserted against the list itself, never against
+  // creation order: the store's clock is real wall time here, so rows
+  // created back to back can share a timestamp. That the order is
+  // newest-first is pinned in the store conformance suite, which owns
+  // an injected clock.
+  async function seed(tenant: string, n: number): Promise<string[]> {
+    const ids: string[] = [];
+    for (let i = 0; i < n; i++) ids.push(await seedSession(app, tenant));
+    return ids;
+  }
+
+  it("returns the namespace's rows in one page, whole rows, hasMore false", async () => {
+    const ids = await seed("list-one", 3);
+    const res = await get(app, "/v1/sessions?namespace=list-one");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.map((s: { id: string }) => s.id).sort()).toEqual([...ids].sort());
+    expect(body.hasMore).toBe(false);
+    expect(body.lastId).toBe(body.data[2].id);
+    // A listed row is the same row a get returns.
+    const one = await get(app, `/v1/sessions/${ids[0]}?namespace=list-one`);
+    expect(body.data).toContainEqual(await one.json());
+  });
+
+  it("pages with limit and after: the walk equals the whole list", async () => {
+    await seed("list-page", 3);
+    const whole = await (await get(app, "/v1/sessions?namespace=list-page")).json();
+
+    const first = await (await get(app, "/v1/sessions?namespace=list-page&limit=2")).json();
+    expect(first.data).toHaveLength(2);
+    expect(first.hasMore).toBe(true); // the over-fetched row, not a guess
+    expect(first.lastId).toBe(first.data[1].id);
+
+    const second = await (
+      await get(app, `/v1/sessions?namespace=list-page&limit=2&after=${first.lastId}`)
+    ).json();
+    expect(second.data).toHaveLength(1);
+    expect(second.hasMore).toBe(false);
+
+    expect([...first.data, ...second.data]).toEqual(whole.data);
+  });
+
+  it("answers an empty namespace with an empty page and no cursor", async () => {
+    const body = await (await get(app, "/v1/sessions?namespace=list-empty")).json();
+    expect(body).toEqual({ data: [], hasMore: false });
+  });
+
+  it("never crosses the namespace boundary", async () => {
+    const mine = await seed("list-mine", 2);
+    await seed("list-theirs", 1);
+    const body = await (await get(app, "/v1/sessions?namespace=list-mine")).json();
+    expect(body.data.map((s: { id: string }) => s.id).sort()).toEqual([...mine].sort());
+  });
+
+  it("400s a limit outside the bounds and a non-numeric one", async () => {
+    for (const q of ["limit=0", "limit=101", "limit=abc", "limit=1.5"]) {
+      const res = await get(app, `/v1/sessions?namespace=list-one&${q}`);
+      expect(res.status).toBe(400);
+      expect((await res.json()).error.type).toBe("invalid_request_error");
+    }
+  });
+
+  it("400s a cursor the store can't resolve — foreign like made-up", async () => {
+    const [foreign] = await seed("list-cursor-b", 1);
+    for (const after of ["nope", foreign]) {
+      const res = await get(app, `/v1/sessions?namespace=list-cursor-a&after=${after}`);
+      expect(res.status).toBe(400);
+      expect((await res.json()).error.type).toBe("invalid_request_error");
+    }
+  });
+});
+
 describe("GET /v1/sessions/:id", () => {
   it("404s unknown and foreign sessions alike", async () => {
     expect((await get(app, "/v1/sessions/nope")).status).toBe(404);

--- a/packages/adapters/migrations/20260820000000_init/migration.sql
+++ b/packages/adapters/migrations/20260820000000_init/migration.sql
@@ -85,6 +85,16 @@ CREATE TABLE sessions (
   FOREIGN KEY (namespace, env_config_id) REFERENCES env_configs (namespace, id)
 );
 
+-- The list scan's index (Store.listSessions). The PK's second column is a
+-- random id, so it cannot order by time: without this, a page reads and
+-- sorts the namespace's whole history to return one screenful, and the
+-- keyset cursor buys nothing. Sessions is the one listed table that grows
+-- without bound — the configs beside it are a small fixed set, which is
+-- why only this one carries the index. Ascending by choice: a leading
+-- equality on namespace lets the newest-first order walk it backwards, so
+-- one index serves both directions.
+CREATE INDEX sessions_list_scan ON sessions (namespace, created_at, id);
+
 CREATE TABLE session_entries (
   namespace text NOT NULL,
   session_id text NOT NULL,

--- a/packages/adapters/src/store/pg.ts
+++ b/packages/adapters/src/store/pg.ts
@@ -51,6 +51,7 @@ import {
   type JsonValue,
   ListAgentConfigsRequest,
   ListEnvConfigsRequest,
+  ListSessionsRequest,
   PendingInput,
   Session,
   SessionEntry,
@@ -142,6 +143,19 @@ const toEnvConfig = (row: typeof envConfigs.$inferSelect): EnvConfig =>
     createdAt: iso(row.createdAt),
   });
 
+const toSession = (row: typeof sessions.$inferSelect): Session =>
+  Session.parse({
+    sessionId: row.id,
+    agentConfigId: row.agentConfigId,
+    agentConfigVersion: row.agentConfigVersion,
+    envConfigId: row.envConfigId,
+    envConfigSnapshot: row.envConfigSnapshot,
+    namespace: row.namespace,
+    ...(row.sandboxId ? { sandboxId: row.sandboxId } : {}),
+    ...unwrapped(row.metadata),
+    createdAt: iso(row.createdAt),
+  });
+
 export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
   const now = opts.now ?? (() => new Date());
 
@@ -155,7 +169,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
   }
 
   /**
-   * The config lists' page predicate: everything strictly older than the
+   * Every list's page predicate: everything strictly older than the
    * cursor row in (created_at, id) order — a row-value comparison, so the
    * tie-break is one comparison, not a hand-unrolled OR. The cursor is
    * looked up under the caller's `scope`, which makes a foreign id
@@ -163,7 +177,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
    * newest (and drizzle's and() drops it).
    */
   async function olderThanCursor(
-    table: typeof agentConfigs | typeof envConfigs,
+    table: typeof agentConfigs | typeof envConfigs | typeof sessions,
     scope: SQL,
     after: string | undefined,
   ): Promise<SQL | undefined> {
@@ -517,18 +531,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         .select()
         .from(sessions)
         .where(and(eq(sessions.id, sessionId), eq(sessions.namespace, namespace)));
-      if (!row) return undefined;
-      return Session.parse({
-        sessionId: row.id,
-        agentConfigId: row.agentConfigId,
-        agentConfigVersion: row.agentConfigVersion,
-        envConfigId: row.envConfigId,
-        envConfigSnapshot: row.envConfigSnapshot,
-        namespace: row.namespace,
-        ...(row.sandboxId ? { sandboxId: row.sandboxId } : {}),
-        ...unwrapped(row.metadata),
-        createdAt: iso(row.createdAt),
-      });
+      return row === undefined ? undefined : toSession(row);
     },
 
     async bindSandbox(ref, sandboxId, previous) {
@@ -547,6 +550,19 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       const [row] = await db.select({ sandboxId: sessions.sandboxId }).from(sessions).where(scope);
       if (!row?.sandboxId) throw new Error(`unknown session: ${sessionId}`);
       return row.sandboxId;
+    },
+
+    async listSessions(req) {
+      const parsed = ListSessionsRequest.parse(req);
+      const scope = eq(sessions.namespace, parsed.namespace);
+      const page = await olderThanCursor(sessions, scope, parsed.after);
+      const rows = await db
+        .select()
+        .from(sessions)
+        .where(and(scope, page))
+        .orderBy(desc(sessions.createdAt), desc(sessions.id))
+        .limit(parsed.limit);
+      return rows.map(toSession);
     },
 
     async readEntries(ref, after) {

--- a/packages/adapters/src/store/schema.ts
+++ b/packages/adapters/src/store/schema.ts
@@ -129,6 +129,15 @@ export const sessions = pgTable(
       columns: [t.namespace, t.envConfigId],
       foreignColumns: [envConfigs.namespace, envConfigs.id],
     }),
+    // The list scan's index (pg.ts listSessions). The PK's second column
+    // is a random id, so it cannot order by time: without this, a page
+    // reads and sorts the namespace's whole history to return one
+    // screenful and the keyset cursor buys nothing. Sessions is the one
+    // listed table that grows without bound — the configs beside it are
+    // a small fixed set, which is why only this one carries the index.
+    // Ascending by choice: a leading equality on namespace lets the
+    // newest-first order walk it backwards, so one index serves both.
+    index("sessions_list_scan").on(t.namespace, t.createdAt, t.id),
   ],
 );
 

--- a/packages/adapters/test/store-conformance.ts
+++ b/packages/adapters/test/store-conformance.ts
@@ -12,6 +12,7 @@ import {
   type AssistantMessage,
   type CreateAgentConfigRequest,
   type CreateEnvConfigRequest,
+  type CreateSessionRequest,
   DEFAULT_NAMESPACE,
   type EnvConfigRef,
   type SessionRef,
@@ -73,15 +74,20 @@ export function describeStoreConformance(
       });
     }
 
-    async function newSession(): Promise<SessionRef> {
+    async function newSession(overrides: Partial<CreateSessionRequest> = {}): Promise<SessionRef> {
+      // A session and its configs always share one namespace, so the
+      // override steers all three, not just the session.
+      const namespace = overrides.namespace ?? DEFAULT_NAMESPACE;
       const agentConfigRef = await newAgent({
+        namespace,
         inference: { provider: "fake", model: "scripted" },
       });
-      const envConfigRef = await newEnv();
+      const envConfigRef = await newEnv({ namespace });
       return store.createSession({
-        namespace: DEFAULT_NAMESPACE,
+        namespace,
         agentConfigId: agentConfigRef.agentConfigId,
         envConfigId: envConfigRef.envConfigId,
+        ...overrides,
       });
     }
 
@@ -907,6 +913,88 @@ export function describeStoreConformance(
             envConfigId: "nope",
           }),
         ).rejects.toThrow();
+      });
+    });
+
+    describe("listing sessions", () => {
+      /** n sessions, each a tick newer than the last, oldest id first. */
+      async function sessionIds(n: number, namespace?: string): Promise<string[]> {
+        const ids: string[] = [];
+        for (let i = 0; i < n; i++) {
+          const ref = await newSession(namespace === undefined ? {} : { namespace });
+          ids.push(ref.sessionId);
+          clock.advance(1_000);
+        }
+        return ids;
+      }
+
+      /** Walk the whole list one small page at a time. */
+      async function walk(namespace: string, limit: number): Promise<string[]> {
+        const ids: string[] = [];
+        let after: string | undefined;
+        for (let guard = 0; guard < 20; guard++) {
+          const page = await store.listSessions({ namespace, limit, after });
+          expect(page.length).toBeLessThanOrEqual(limit);
+          if (page.length === 0) return ids;
+          ids.push(...page.map((s) => s.sessionId));
+          after = page[page.length - 1]?.sessionId;
+        }
+        throw new Error("walk did not terminate");
+      }
+
+      it("lists a namespace's sessions newest first, whole rows", async () => {
+        const [oldest, middle, newest] = await sessionIds(3);
+        const list = await store.listSessions({ namespace: DEFAULT_NAMESPACE, limit: 10 });
+        expect(list.map((s) => s.sessionId)).toEqual([newest, middle, oldest]);
+        // The same shape a get returns — one row mapping, not two.
+        expect(list[0]).toEqual(
+          await store.getSession({ namespace: DEFAULT_NAMESPACE, sessionId: newest! }),
+        );
+      });
+
+      it("bounds the page at limit and resumes strictly after the cursor", async () => {
+        const [oldest, middle, newest] = await sessionIds(3);
+        const first = await store.listSessions({ namespace: DEFAULT_NAMESPACE, limit: 2 });
+        expect(first.map((s) => s.sessionId)).toEqual([newest, middle]);
+        const second = await store.listSessions({
+          namespace: DEFAULT_NAMESPACE,
+          limit: 2,
+          after: middle,
+        });
+        expect(second.map((s) => s.sessionId)).toEqual([oldest]);
+        expect(
+          await store.listSessions({ namespace: DEFAULT_NAMESPACE, limit: 2, after: oldest }),
+        ).toEqual([]);
+      });
+
+      it("pages an unadvanced clock without dropping or duplicating a row", async () => {
+        // No clock advance: created_at ties are likely, so this pins the
+        // (createdAt, id) key's total order — walking in pages must equal
+        // the whole list exactly.
+        for (let i = 0; i < 5; i++) {
+          await newSession();
+        }
+        const whole = await store.listSessions({ namespace: DEFAULT_NAMESPACE, limit: 10 });
+        expect(whole).toHaveLength(5);
+        expect(await walk(DEFAULT_NAMESPACE, 2)).toEqual(whole.map((s) => s.sessionId));
+      });
+
+      it("scopes the list to one namespace — a page walk never crosses the boundary", async () => {
+        const a = await sessionIds(3, "tenant-a");
+        const b = await sessionIds(2, "tenant-b");
+        expect(await walk("tenant-a", 2)).toEqual([...a].reverse());
+        expect(await walk("tenant-b", 2)).toEqual([...b].reverse());
+        expect(await store.listSessions({ namespace: "tenant-c", limit: 10 })).toEqual([]);
+      });
+
+      it("rejects a cursor it cannot resolve — a foreign one like a nonexistent one", async () => {
+        const [foreign] = await sessionIds(1, "tenant-b");
+        await expect(
+          store.listSessions({ namespace: "tenant-a", limit: 10, after: "nope" }),
+        ).rejects.toThrow("unknown cursor");
+        await expect(
+          store.listSessions({ namespace: "tenant-a", limit: 10, after: foreign }),
+        ).rejects.toThrow("unknown cursor");
       });
     });
 

--- a/packages/agent/src/ports/store.ts
+++ b/packages/agent/src/ports/store.ts
@@ -13,6 +13,7 @@ import type {
   IntakeResult,
   ListAgentConfigsRequest,
   ListEnvConfigsRequest,
+  ListSessionsRequest,
   PendingInput,
   Session,
   SessionEntry,
@@ -139,6 +140,8 @@ export interface Store {
    *  candidate lost learns the winner and discards its own (see
    *  driver/ensure-sandbox.ts). Rejects an unknown or foreign session. */
   bindSandbox(ref: SessionRef, sandboxId: string, previous?: string): Promise<string>;
+  /** One namespace's sessions, newest first — see ListSessionsRequest. */
+  listSessions(req: ListSessionsRequest): Promise<Session[]>;
 
   // --- reads — table-shaped; reads need no atomicity ---
 

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -198,6 +198,14 @@ export const SessionRef = z.object({
 });
 export type SessionRef = z.infer<typeof SessionRef>;
 
+/** Lists one namespace's sessions with keyset pagination. */
+export const ListSessionsRequest = z.object({
+  namespace: z.string().min(1),
+  limit: z.number().int().min(1),
+  after: z.string().min(1).optional(),
+});
+export type ListSessionsRequest = z.infer<typeof ListSessionsRequest>;
+
 export const CreateSessionRequest = z.object({
   namespace: z.string().min(1),
   agentConfigId: z.string(),


### PR DESCRIPTION
Sessions were the one row type with no collection read: `listSessions` adds it across core, the Store port, the pg adapter, and `GET /v1/sessions`, shaped exactly like the two config lists so no two resources page differently. The adapter carries a `(namespace, created_at, id)` index the config tables don't — the sessions PK's second column is a random id, so without one every page sorts the namespace's whole history and the keyset cursor buys nothing; measured at 20k rows it turns a 267-buffer seq scan plus top-N sort into a 3-buffer backward index scan. `getSession` was mapping its row inline, so list and get now share one `toSession`. Neither a title nor a status field lands here — status is derived from the work-item log rather than stored, and a first-class title only earns its place when the platform reads it, which the config lists would want before sessions do. Covered by five new store-conformance tests and six route tests; typecheck, prettier, and all 360 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
