### PR TITLE
Add the session archive endpoint

### DIFF
--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -1,10 +1,10 @@
 // apps/api/src/routes/sessions.ts
-// The sessions resource — the intake half of the Store port, plus the
-// inspection reads. Every route under /:id resolves ownership once at
-// the top with a namespace-scoped get: the store answers a foreign
-// session exactly like a nonexistent one, so no route compares
-// namespaces by hand. The row the get returns is its own SessionRef, so
-// it addresses every later call.
+// The sessions resource — lifecycle, intake, and inspection reads. Every
+// non-archive route under /:id resolves ownership once at the top with a
+// namespace-scoped get: the store answers a foreign session exactly like a
+// nonexistent one, so no route compares namespaces by hand. The row the get
+// returns is its own SessionRef, so it addresses every later call. Archive
+// delegates that same scoped absence rule directly to the atomic transition.
 //
 // Namespace is part of the request (the caller holds the root token;
 // tenant authorization lives in the managed layer above): the create
@@ -12,16 +12,16 @@
 // every id-addressed route takes ?namespace=, defaulting for
 // single-tenant self-deploys (common.ts NamespaceQuery).
 //
-// The api writes nothing itself: intake and requestCancel are the only
-// mutations, both Store transactions. Whether a message starts a run or
-// queues as a pending input is intake's in-transaction branch — the
-// IntakeResult (started | queued) is returned verbatim, and both answer
-// 202: the work itself happens in a worker, asynchronously.
+// The api writes nothing itself: archiveSession, intake, and requestCancel
+// are Store transactions. Whether a message starts a run or queues as a
+// pending input is intake's in-transaction branch — the IntakeResult
+// (started | queued) is returned verbatim, and both answer 202: the work
+// itself happens in a worker, asynchronously.
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { z } from "zod";
 import { CreateSessionRequest, type Session, UserMessage, type WorkItem } from "@funky/core";
-import { ArchivedError, type Store } from "@funky/agent";
+import { ArchivedError, SessionNotIdleError, type Store } from "@funky/agent";
 import { errorResponse } from "../http";
 import { ListQuery, NamespaceQuery, page, validate } from "./common";
 
@@ -30,6 +30,7 @@ export type SessionStore = Pick<
   Store,
   | "createSession"
   | "getSession"
+  | "archiveSession"
   | "listSessions"
   | "intake"
   | "requestCancel"
@@ -50,6 +51,16 @@ type Env = { Variables: { requestId: string } };
 // The core request, with the body's namespace defaulted the same way
 // the query's is (common.ts NamespaceQuery).
 const CreateSessionBody = CreateSessionRequest.extend(NamespaceQuery.shape);
+
+// Spelled include_archived: snake_case is the wire's shape for a
+// multi-word query switch. Avoid z.coerce.boolean(): JavaScript truthiness
+// would parse "false" as true, so the two spellings are an enum.
+const SessionListQuery = ListQuery.extend({
+  include_archived: z
+    .enum(["true", "false"])
+    .transform((value) => value === "true")
+    .optional(),
+});
 
 /** Store row → wire resource: the ref's qualified id becomes the
  *  resource's `id`; everything else — namespace included — rides
@@ -98,10 +109,15 @@ export function sessionRoutes(store: SessionStore, pacing: StreamPacing) {
 
   // list → one page of this namespace's rows, newest first. The store
   // is asked for limit + 1: the extra row is hasMore (see page()).
-  r.get("/", validate("query", ListQuery), async (c) => {
-    const { namespace, limit, after } = c.req.valid("query");
+  r.get("/", validate("query", SessionListQuery), async (c) => {
+    const { namespace, limit, after, include_archived: includeArchived } = c.req.valid("query");
     try {
-      const rows = await store.listSessions({ namespace, limit: limit + 1, after });
+      const rows = await store.listSessions({
+        namespace,
+        limit: limit + 1,
+        after,
+        includeArchived,
+      });
       return c.json(page(rows.map(wire), limit));
     } catch (err) {
       // A cursor the store can't resolve — foreign or made-up, the same
@@ -119,6 +135,28 @@ export function sessionRoutes(store: SessionStore, pacing: StreamPacing) {
     return c.json(wire(session));
   });
 
+  // Archive is permanent and idempotent. It keeps the row and history
+  // readable, removes it from the default list, and closes every client
+  // write. The store serializes this transition with intake and refuses it
+  // while the open-item liveness bit says the session is running. An input
+  // parked by a cancelled run is flushed into the log by that same
+  // transaction, so a message queued before the archive shows up in
+  // /entries afterwards.
+  r.post("/:id/archive", validate("query", NamespaceQuery), async (c) => {
+    const id = c.req.param("id");
+    const { namespace } = c.req.valid("query");
+    try {
+      const session = await store.archiveSession({ namespace, sessionId: id });
+      if (session === undefined) return notFound(c);
+      return c.json(wire(session));
+    } catch (err) {
+      if (err instanceof SessionNotIdleError) {
+        return errorResponse(c, 409, "conflict_error", err.message);
+      }
+      throw err;
+    }
+  });
+
   r.post(
     "/:id/messages",
     validate("query", NamespaceQuery),
@@ -131,7 +169,14 @@ export function sessionRoutes(store: SessionStore, pacing: StreamPacing) {
         role: "user",
         content: typeof content === "string" ? [{ type: "text", text: content }] : content,
       };
-      return c.json(await store.intake(session, message), 202);
+      try {
+        return c.json(await store.intake(session, message), 202);
+      } catch (err) {
+        if (err instanceof ArchivedError) {
+          return errorResponse(c, 409, "conflict_error", err.message);
+        }
+        throw err;
+      }
     },
   );
 
@@ -140,8 +185,15 @@ export function sessionRoutes(store: SessionStore, pacing: StreamPacing) {
     if (!session) return notFound(c);
     // Appends a control entry; the worker answers it at a step boundary,
     // so cancellation is accepted here, not completed.
-    await store.requestCancel(session);
-    return c.body(null, 202);
+    try {
+      await store.requestCancel(session);
+      return c.body(null, 202);
+    } catch (err) {
+      if (err instanceof ArchivedError) {
+        return errorResponse(c, 409, "conflict_error", err.message);
+      }
+      throw err;
+    }
   });
 
   r.get("/:id/entries", validate("query", EntriesQuery), async (c) => {
@@ -167,8 +219,9 @@ export function sessionRoutes(store: SessionStore, pacing: StreamPacing) {
   // stream. Polling, not LISTEN/NOTIFY, by ratified decision: a
   // Notifier would change latency inside this loop, never the wire.
   //
-  // The stream has no server-side end — sessions don't terminate. The
-  // client hangs up; `aborted` stops the loop.
+  // The stream has no server-side EOF marker. Archive preserves the log and
+  // prevents future writes, but does not close an HTTP response already in
+  // flight; the client hangs up and `aborted` stops the loop.
   r.get("/:id/stream", validate("query", EntriesQuery), async (c) => {
     const session = await owned(c, c.req.valid("query").namespace);
     if (!session) return notFound(c);

--- a/apps/api/test/sessions.test.ts
+++ b/apps/api/test/sessions.test.ts
@@ -233,8 +233,30 @@ describe("GET /v1/sessions", () => {
     expect(body.data.map((s: { id: string }) => s.id).sort()).toEqual([...mine].sort());
   });
 
+  // The switch is an enum, not z.coerce.boolean(): JS truthiness would read
+  // the string "false" as true, so this is the case that pins it.
+  it("treats include_archived=false as the default, not as truthy", async () => {
+    const [archived, active] = await seed("list-false", 2);
+    expect((await post(app, `/v1/sessions/${archived}/archive?namespace=list-false`)).status).toBe(
+      200,
+    );
+
+    for (const q of ["", "&include_archived=false"]) {
+      const body = await (await get(app, `/v1/sessions?namespace=list-false${q}`)).json();
+      expect(body.data.map((s: { id: string }) => s.id)).toEqual([active]);
+    }
+  });
+
   it("400s a limit outside the bounds and a non-numeric one", async () => {
     for (const q of ["limit=0", "limit=101", "limit=abc", "limit=1.5"]) {
+      const res = await get(app, `/v1/sessions?namespace=list-one&${q}`);
+      expect(res.status).toBe(400);
+      expect((await res.json()).error.type).toBe("invalid_request_error");
+    }
+  });
+
+  it("400s an include_archived that is neither spelling", async () => {
+    for (const q of ["include_archived=1", "include_archived=yes", "include_archived=TRUE"]) {
       const res = await get(app, `/v1/sessions?namespace=list-one&${q}`);
       expect(res.status).toBe(400);
       expect((await res.json()).error.type).toBe("invalid_request_error");
@@ -258,6 +280,97 @@ describe("GET /v1/sessions/:id", () => {
     const sessionId = await seedSession(app, "tenant-a");
     expect((await get(app, `/v1/sessions/${sessionId}?namespace=tenant-b`)).status).toBe(404);
     expect((await get(app, `/v1/sessions/${sessionId}?namespace=tenant-a`)).status).toBe(200);
+  });
+});
+
+describe("POST /v1/sessions/:id/archive", () => {
+  it("archives an idle session, keeps it readable, and closes client writes", async () => {
+    const namespace = "archive-idle";
+    const sessionId = await seedSession(app, namespace);
+
+    const res = await post(app, `/v1/sessions/${sessionId}/archive?namespace=${namespace}`);
+    expect(res.status).toBe(200);
+    const archived = await res.json();
+    expect(archived).toMatchObject({
+      id: sessionId,
+      namespace,
+      archivedAt: expect.any(String),
+    });
+
+    const read = await get(app, `/v1/sessions/${sessionId}?namespace=${namespace}`);
+    expect(await read.json()).toEqual(archived);
+
+    const message = await post(app, `/v1/sessions/${sessionId}/messages?namespace=${namespace}`, {
+      content: "too late",
+    });
+    expect(message.status).toBe(409);
+    expect((await message.json()).error.message).toBe(
+      `session ${namespace}/${sessionId} is archived`,
+    );
+    expect(
+      (await post(app, `/v1/sessions/${sessionId}/cancel?namespace=${namespace}`)).status,
+    ).toBe(409);
+  });
+
+  it("is idempotent and preserves the first archivedAt", async () => {
+    const namespace = "archive-repeat";
+    const sessionId = await seedSession(app, namespace);
+    const path = `/v1/sessions/${sessionId}/archive?namespace=${namespace}`;
+
+    const first = await (await post(app, path)).json();
+    const second = await post(app, path);
+    expect(second.status).toBe(200);
+    expect(await second.json()).toEqual(first);
+  });
+
+  it("409s while the session has an active run", async () => {
+    const namespace = "archive-running";
+    const sessionId = await seedSession(app, namespace);
+    await post(app, `/v1/sessions/${sessionId}/messages?namespace=${namespace}`, {
+      content: "start",
+    });
+
+    const res = await post(app, `/v1/sessions/${sessionId}/archive?namespace=${namespace}`);
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toMatchObject({
+      type: "conflict_error",
+      message: `session ${namespace}/${sessionId} is not idle`,
+    });
+    const session = await (
+      await get(app, `/v1/sessions/${sessionId}?namespace=${namespace}`)
+    ).json();
+    expect("archivedAt" in session).toBe(false);
+  });
+
+  it("drops archived sessions from the default list and includes them explicitly", async () => {
+    const namespace = "archive-list";
+    const archivedId = await seedSession(app, namespace);
+    const activeId = await seedSession(app, namespace);
+    await post(app, `/v1/sessions/${archivedId}/archive?namespace=${namespace}`);
+
+    const active = await (await get(app, `/v1/sessions?namespace=${namespace}`)).json();
+    expect(active.data.map((session: { id: string }) => session.id)).toEqual([activeId]);
+
+    const all = await (
+      await get(app, `/v1/sessions?namespace=${namespace}&include_archived=true`)
+    ).json();
+    expect(all.data.map((session: { id: string }) => session.id).sort()).toEqual(
+      [archivedId, activeId].sort(),
+    );
+    expect(all.data.find((session: { id: string }) => session.id === archivedId)).toMatchObject({
+      archivedAt: expect.any(String),
+    });
+  });
+
+  it("404s unknown and foreign archive targets without touching the owned row", async () => {
+    expect((await post(app, "/v1/sessions/nope/archive?namespace=archive-a")).status).toBe(404);
+
+    const sessionId = await seedSession(app, "archive-a");
+    expect((await post(app, `/v1/sessions/${sessionId}/archive?namespace=archive-b`)).status).toBe(
+      404,
+    );
+    const own = await (await get(app, `/v1/sessions/${sessionId}?namespace=archive-a`)).json();
+    expect("archivedAt" in own).toBe(false);
   });
 });
 

--- a/packages/adapters/migrations/20260820000000_init/migration.sql
+++ b/packages/adapters/migrations/20260820000000_init/migration.sql
@@ -80,6 +80,9 @@ CREATE TABLE sessions (
   sandbox_id text,
   metadata jsonb,
   created_at timestamptz NOT NULL,
+  -- Terminal lifecycle mark. The history stays readable, but the
+  -- session accepts no new client writes; NULL means active.
+  archived_at timestamptz,
   PRIMARY KEY (namespace, id),
   -- Same-namespace, structural, on both references: the pinned version
   -- and the env recipe must live in the session's own namespace.
@@ -97,6 +100,12 @@ CREATE TABLE sessions (
 -- equality on namespace lets the newest-first order walk it backwards, so
 -- one index serves both directions.
 CREATE INDEX sessions_list_scan ON sessions (namespace, created_at, id);
+-- The default list omits archived rows, so it gets its own partial index —
+-- the active scan stays bounded once archived history dominates. The full
+-- index above serves includeArchived=true; the cursor is a PK lookup that
+-- never filters on archived_at, so paging survives an archive mid-walk.
+CREATE INDEX sessions_active_list_scan
+  ON sessions (namespace, created_at, id) WHERE archived_at IS NULL;
 
 CREATE TABLE session_entries (
   namespace text NOT NULL,

--- a/packages/adapters/src/store/pg.ts
+++ b/packages/adapters/src/store/pg.ts
@@ -9,12 +9,16 @@
 // - Lock order is item → session everywhere an item is involved; no path
 //   takes session → item, so no cycle exists.
 // - createSession holds FOR SHARE locks on both config rows until it
-//   commits, while each archive method's UPDATE takes its row exclusively:
-//   the operations serialize, so no session is born against either archived
-//   config. The env lock also makes the recipe snapshot a committed state:
-//   a racing updateEnvConfig lands strictly before or after it — never
-//   inside. Shared mode lets concurrent creates proceed together. Lock order
-//   is agent → env, and no path takes env → agent, so no cycle exists.
+//   commits, while each config archive method's UPDATE takes its row
+//   exclusively: the operations serialize, so no session is born against
+//   either archived config. The env lock also makes the recipe snapshot a
+//   committed state: a racing updateEnvConfig lands strictly before or after
+//   it — never inside. Shared mode lets concurrent creates proceed together.
+//   Lock order is agent → env, and no path takes env → agent, so no cycle
+//   exists.
+// - archiveSession, intake, and the liveness-changing half of commitStep
+//   serialize on the session row. Archive sees either idle or one open item,
+//   never a stale gap between checking and stamping the terminal state.
 // - claimItem uses FOR UPDATE SKIP LOCKED: contended claimers never
 //   queue behind each other, exactly one wins a given item.
 // - Fencing is token + live lease, symmetric across heartbeat and
@@ -63,6 +67,7 @@ import {
   ArchivedError,
   type CommitStepRequest,
   FencedError,
+  SessionNotIdleError,
   type Store,
   VersionConflictError,
 } from "@funky/agent";
@@ -152,18 +157,27 @@ const toSession = (row: typeof sessions.$inferSelect): Session =>
     ...(row.sandboxId ? { sandboxId: row.sandboxId } : {}),
     ...unwrapped(row.metadata),
     createdAt: iso(row.createdAt),
+    ...(row.archivedAt === null ? {} : { archivedAt: iso(row.archivedAt) }),
   });
 
 export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
   const now = opts.now ?? (() => new Date());
 
-  async function lockSession(tx: Tx, ref: SessionRef): Promise<void> {
-    const rows = await tx
-      .select({ id: sessions.id })
+  async function lockSession(tx: Tx, ref: SessionRef): Promise<{ archivedAt: Date | null }> {
+    const [row] = await tx
+      .select({ archivedAt: sessions.archivedAt })
       .from(sessions)
       .where(and(eq(sessions.id, ref.sessionId), eq(sessions.namespace, ref.namespace)))
       .for("update");
-    if (rows.length === 0) throw new Error(`unknown session: ${ref.sessionId}`);
+    if (row === undefined) throw new Error(`unknown session: ${ref.sessionId}`);
+    return row;
+  }
+
+  async function lockActiveSession(tx: Tx, ref: SessionRef): Promise<void> {
+    const row = await lockSession(tx, ref);
+    if (row.archivedAt !== null) {
+      throw ArchivedError.forSession(ref);
+    }
   }
 
   /**
@@ -359,7 +373,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         // Archived outranks the version verdict: it is terminal, so
         // "retry with the current version" would be a lie.
         if (current.archivedAt !== null) {
-          throw new ArchivedError({ namespace, agentConfigId });
+          throw ArchivedError.forAgentConfig({ namespace, agentConfigId });
         }
         if (parsed.version !== undefined) {
           throw new VersionConflictError(parsed.version, current.version);
@@ -456,7 +470,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         .where(scope);
       if (current === undefined) return undefined;
       if (current.archivedAt !== null) {
-        throw new ArchivedError({ namespace, envConfigId });
+        throw ArchivedError.forEnvConfig({ namespace, envConfigId });
       }
       throw new Error(`env config ${envConfigId} was not updated`);
     },
@@ -534,7 +548,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
           .for("share", { of: agentConfigs });
         if (!agent) throw new Error(`unknown agent config: ${parsed.agentConfigId}`);
         if (agent.archivedAt !== null) {
-          throw new ArchivedError({ namespace, agentConfigId: parsed.agentConfigId });
+          throw ArchivedError.forAgentConfig({ namespace, agentConfigId: parsed.agentConfigId });
         }
         const [env] = await tx
           .select({
@@ -547,7 +561,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
           .for("share", { of: envConfigs });
         if (!env) throw new Error(`unknown env config: ${parsed.envConfigId}`);
         if (env.archivedAt !== null) {
-          throw new ArchivedError({ namespace, envConfigId: parsed.envConfigId });
+          throw ArchivedError.forEnvConfig({ namespace, envConfigId: parsed.envConfigId });
         }
         await tx.insert(sessions).values({
           id,
@@ -575,6 +589,68 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       return row === undefined ? undefined : toSession(row);
     },
 
+    async archiveSession(ref) {
+      const { namespace, sessionId } = SessionRef.parse(ref);
+      const scope = and(eq(sessions.id, sessionId), eq(sessions.namespace, namespace));
+      return db.transaction(async (tx) => {
+        // Every transition that creates or resolves the one open item holds
+        // this same row lock. Archive therefore observes one committed state:
+        // idle and archivable, or running and refused — never a check/write
+        // window in which intake can start a run behind it.
+        const [current] = await tx.select().from(sessions).where(scope).for("update");
+        if (current === undefined) return undefined;
+        if (current.archivedAt !== null) return toSession(current);
+
+        const [open] = await tx
+          .select({ id: workItems.id })
+          .from(workItems)
+          .where(
+            and(
+              eq(workItems.namespace, namespace),
+              eq(workItems.sessionId, sessionId),
+              ne(workItems.status, "done"),
+            ),
+          )
+          .limit(1);
+        if (open !== undefined) throw new SessionNotIdleError({ namespace, sessionId });
+
+        // A cancelled run parks its pending inputs for the next intake, and
+        // archive guarantees there is no next one. Flush them into the log —
+        // end_run's append-and-delete without the chained item — so a message
+        // the api already accepted becomes history instead of a row nothing
+        // can ever read. The session lock appendEntries requires is held.
+        const parked = await tx
+          .select()
+          .from(pendingInputs)
+          .where(
+            and(eq(pendingInputs.namespace, namespace), eq(pendingInputs.sessionId, sessionId)),
+          )
+          .orderBy(asc(pendingInputs.ord));
+        if (parked.length > 0) {
+          await appendEntries(
+            tx,
+            { namespace, sessionId },
+            parked.map((p) => ({ type: "message", message: p.message })),
+          );
+          await tx
+            .delete(pendingInputs)
+            .where(
+              and(eq(pendingInputs.namespace, namespace), eq(pendingInputs.sessionId, sessionId)),
+            );
+        }
+
+        const [archived] = await tx
+          .update(sessions)
+          .set({ archivedAt: now() })
+          .where(and(scope, isNull(sessions.archivedAt)))
+          .returning();
+        if (archived === undefined) {
+          throw new Error(`session ${sessionId} was not archived`);
+        }
+        return toSession(archived);
+      });
+    },
+
     async bindSandbox(ref, sandboxId, previous) {
       const { namespace, sessionId } = SessionRef.parse(ref);
       const scope = and(eq(sessions.id, sessionId), eq(sessions.namespace, namespace));
@@ -585,11 +661,16 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       const [bound] = await db
         .update(sessions)
         .set({ sandboxId })
-        .where(and(scope, expected))
+        .where(and(scope, isNull(sessions.archivedAt), expected))
         .returning({ sandboxId: sessions.sandboxId });
       if (bound?.sandboxId) return bound.sandboxId;
-      const [row] = await db.select({ sandboxId: sessions.sandboxId }).from(sessions).where(scope);
-      if (!row?.sandboxId) throw new Error(`unknown session: ${sessionId}`);
+      const [row] = await db
+        .select({ sandboxId: sessions.sandboxId, archivedAt: sessions.archivedAt })
+        .from(sessions)
+        .where(scope);
+      if (row === undefined) throw new Error(`unknown session: ${sessionId}`);
+      if (row.archivedAt !== null) throw ArchivedError.forSession({ namespace, sessionId });
+      if (!row.sandboxId) throw new Error(`unknown session: ${sessionId}`);
       return row.sandboxId;
     },
 
@@ -600,7 +681,13 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       const rows = await db
         .select()
         .from(sessions)
-        .where(and(scope, page))
+        .where(
+          and(
+            scope,
+            parsed.includeArchived === true ? undefined : isNull(sessions.archivedAt),
+            page,
+          ),
+        )
         .orderBy(desc(sessions.createdAt), desc(sessions.id))
         .limit(parsed.limit);
       return rows.map(toSession);
@@ -762,7 +849,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
     async requestCancel(ref) {
       const parsed = SessionRef.parse(ref);
       await db.transaction(async (tx) => {
-        await lockSession(tx, parsed);
+        await lockActiveSession(tx, parsed);
         await appendEntries(tx, parsed, [{ type: "control", control: "cancel" }]);
       });
     },
@@ -771,7 +858,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
       const { namespace, sessionId } = SessionRef.parse(ref);
       const msg = UserMessage.parse(message);
       return db.transaction(async (tx) => {
-        await lockSession(tx, { namespace, sessionId }); // the race referee
+        await lockActiveSession(tx, { namespace, sessionId }); // the race referee
         const open = await tx
           .select({ id: workItems.id })
           .from(workItems)

--- a/packages/adapters/src/store/schema.ts
+++ b/packages/adapters/src/store/schema.ts
@@ -115,6 +115,9 @@ export const sessions = pgTable(
     sandboxId: text("sandbox_id"),
     metadata: jsonb("metadata").$type<WrappedJson>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+    // Terminal, permanent lifecycle mark. Archived sessions keep their
+    // history but reject every new client-side mutation.
+    archivedAt: timestamp("archived_at", { withTimezone: true }),
   },
   (t) => [
     primaryKey({ columns: [t.namespace, t.id] }),
@@ -141,6 +144,11 @@ export const sessions = pgTable(
     // Ascending by choice: a leading equality on namespace lets the
     // newest-first order walk it backwards, so one index serves both.
     index("sessions_list_scan").on(t.namespace, t.createdAt, t.id),
+    // The default list omits archived rows; this partial twin keeps that
+    // scan bounded once archived history dominates the table.
+    index("sessions_active_list_scan")
+      .on(t.namespace, t.createdAt, t.id)
+      .where(sql`${t.archivedAt} is null`),
   ],
 );
 

--- a/packages/adapters/test/store-conformance.ts
+++ b/packages/adapters/test/store-conformance.ts
@@ -23,6 +23,7 @@ import {
   ArchivedError,
   type CommitStepRequest,
   FencedError,
+  SessionNotIdleError,
   type Store,
   VersionConflictError,
 } from "@funky/agent";
@@ -458,8 +459,8 @@ export function describeStoreConformance(
           await expect(store.updateAgentConfig(ref, req)).rejects.toMatchObject({
             name: "ArchivedError",
             namespace: ref.namespace,
-            configId: ref.agentConfigId,
-            configKind: "agent",
+            resourceId: ref.agentConfigId,
+            resourceKind: "agent",
           });
         }
         expect(await store.getAgentConfig(ref)).toMatchObject({
@@ -653,8 +654,8 @@ export function describeStoreConformance(
           await expect(store.updateEnvConfig(ref, req)).rejects.toMatchObject({
             name: "ArchivedError",
             namespace: ref.namespace,
-            configId: ref.envConfigId,
-            configKind: "env",
+            resourceId: ref.envConfigId,
+            resourceKind: "env",
           });
         }
         expect((await store.getEnvConfig(ref))?.packages).toEqual({ pip: ["numpy"] });
@@ -690,8 +691,8 @@ export function describeStoreConformance(
         await expect(store.createSession(create)).rejects.toMatchObject({
           name: "ArchivedError",
           namespace: envConfigRef.namespace,
-          configId: envConfigRef.envConfigId,
-          configKind: "env",
+          resourceId: envConfigRef.envConfigId,
+          resourceKind: "env",
         });
         expect((await store.getSession(sessionRef))?.envConfigSnapshot).toEqual({
           network: { type: "none" },
@@ -1052,6 +1053,148 @@ export function describeStoreConformance(
             envConfigId: "nope",
           }),
         ).rejects.toThrow();
+      });
+    });
+
+    describe("archiving sessions", () => {
+      it("marks an idle session archived without changing its durable inputs", async () => {
+        const ref = await newSession({ metadata: { purpose: "audit" } });
+        const before = await store.getSession(ref);
+        clock.advance(1_000);
+
+        const archived = await store.archiveSession(ref);
+
+        expect(archived).toMatchObject({ ...before, archivedAt: expect.any(String) });
+        expect(await store.getSession(ref)).toEqual(archived);
+      });
+
+      it("stores active as absence and preserves the first archive time", async () => {
+        const ref = await newSession();
+        const active = await store.getSession(ref);
+        expect(active).toBeDefined();
+        expect("archivedAt" in active!).toBe(false);
+
+        const first = await store.archiveSession(ref);
+        clock.advance(1_000);
+        const second = await store.archiveSession(ref);
+        expect(second).toEqual(first);
+        expect(second?.archivedAt).toBe(first?.archivedAt);
+      });
+
+      it("makes client-side session writes read-only while history remains readable", async () => {
+        const ref = await newSession();
+        await store.requestCancel(ref); // history survives the transition
+        const entries = await store.readEntries(ref);
+        const archived = await store.archiveSession(ref);
+
+        await expect(store.intake(ref, user("after"))).rejects.toMatchObject({
+          name: "ArchivedError",
+          namespace: ref.namespace,
+          resourceId: ref.sessionId,
+          resourceKind: "session",
+        });
+        await expect(store.requestCancel(ref)).rejects.toBeInstanceOf(ArchivedError);
+        await expect(store.bindSandbox(ref, "sbx_after")).rejects.toBeInstanceOf(ArchivedError);
+        expect(await store.getSession(ref)).toEqual(archived);
+        expect(await store.readEntries(ref)).toEqual(entries);
+      });
+
+      it("refuses archive while an open item says the session is not idle", async () => {
+        const ref = await newSession();
+        const { itemRef, token } = await startAndClaim(ref);
+
+        await expect(store.archiveSession(ref)).rejects.toMatchObject({
+          name: "SessionNotIdleError",
+          namespace: ref.namespace,
+          sessionId: ref.sessionId,
+        });
+        expect("archivedAt" in (await store.getSession(ref))!).toBe(false);
+
+        await store.commitStep({
+          itemRef,
+          token,
+          append: [assistant("done")],
+          next: { kind: "end_run", status: "completed" },
+        });
+        await expect(store.archiveSession(ref)).resolves.toMatchObject({
+          archivedAt: expect.any(String),
+        });
+      });
+
+      it("drains inputs parked by a cancelled run into the log", async () => {
+        const ref = await newSession();
+        const { itemRef, token } = await startAndClaim(ref);
+        const queued = await store.intake(ref, user("queued during run"));
+        expect(queued.kind).toBe("queued");
+        await store.commitStep({
+          itemRef,
+          token,
+          append: [],
+          next: { kind: "end_run", status: "cancelled" },
+        });
+        expect(await store.pendingInputs(ref)).toHaveLength(1); // waiting on an intake
+
+        await store.archiveSession(ref); // the intake it waits for can never come
+
+        expect(await store.pendingInputs(ref)).toEqual([]);
+        const entries = await store.readEntries(ref);
+        expect(entries.at(-1)).toMatchObject({
+          type: "message",
+          message: user("queued during run"),
+        });
+        expect(await store.listItems(ref)).toHaveLength(1); // drained, never chained
+      });
+
+      it("serializes archive with intake into exactly one legal winner", async () => {
+        const ref = await newSession();
+        const [archive, intake] = await Promise.allSettled([
+          store.archiveSession(ref),
+          store.intake(ref, user("race")),
+        ]);
+
+        if (archive.status === "fulfilled") {
+          expect(intake).toMatchObject({ reason: expect.any(ArchivedError) });
+          expect(await store.getSession(ref)).toEqual(archive.value);
+        } else {
+          expect(archive.reason).toBeInstanceOf(SessionNotIdleError);
+          expect(intake).toMatchObject({ status: "fulfilled", value: { kind: "started" } });
+          expect("archivedAt" in (await store.getSession(ref))!).toBe(false);
+        }
+      });
+
+      it("hides archived rows from the default list and includes them on request", async () => {
+        const archivedRef = await newSession();
+        clock.advance(1_000);
+        const activeRef = await newSession();
+        await store.archiveSession(archivedRef);
+
+        const active = await store.listSessions({ namespace: DEFAULT_NAMESPACE, limit: 10 });
+        expect(active.map((session) => session.sessionId)).toContain(activeRef.sessionId);
+        expect(active.map((session) => session.sessionId)).not.toContain(archivedRef.sessionId);
+
+        const all = await store.listSessions({
+          namespace: DEFAULT_NAMESPACE,
+          limit: 10,
+          includeArchived: true,
+        });
+        expect(all.map((session) => session.sessionId)).toEqual([
+          activeRef.sessionId,
+          archivedRef.sessionId,
+        ]);
+        expect(all.find((session) => session.sessionId === archivedRef.sessionId)).toEqual(
+          await store.getSession(archivedRef),
+        );
+      });
+
+      it("treats an unknown or foreign archive target as absent", async () => {
+        const ref = await newSession({ namespace: "tenant-a" });
+        expect(
+          await store.archiveSession({ namespace: "tenant-a", sessionId: "nope" }),
+        ).toBeUndefined();
+        expect(
+          await store.archiveSession({ namespace: "tenant-b", sessionId: ref.sessionId }),
+        ).toBeUndefined();
+        expect("archivedAt" in (await store.getSession(ref))!).toBe(false);
       });
     });
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -26,5 +26,16 @@ export type {
   SandboxInfo,
   SandboxProvider,
 } from "./ports/sandbox-provider";
-export { ArchivedError, FencedError, VersionConflictError } from "./ports/store";
-export type { Claim, CommitStepRequest, ConfigKind, LeaseToken, Store } from "./ports/store";
+export {
+  ArchivedError,
+  FencedError,
+  SessionNotIdleError,
+  VersionConflictError,
+} from "./ports/store";
+export type {
+  ArchivedResourceKind,
+  Claim,
+  CommitStepRequest,
+  LeaseToken,
+  Store,
+} from "./ports/store";

--- a/packages/agent/src/ports/store.ts
+++ b/packages/agent/src/ports/store.ts
@@ -3,7 +3,6 @@ import type {
   AgentConfigRef,
   AgentConfigVersionRef,
   AgentMessage,
-  ConfigId,
   CreateAgentConfigRequest,
   CreateEnvConfigRequest,
   CreateSessionRequest,
@@ -32,10 +31,11 @@ import type { RunEndStatus } from "../engine/next-action";
  * pending inputs in one transaction, and splitting the interface would
  * lie about that atomicity.
  *
- * Two write paths, two callers: the api calls intake, the driver calls
- * commitStep. They are the only status mutations in the system, and work
- * items are born only inside their transactions — which is why there is
- * no createWorkItem.
+ * Two run write paths, two callers: the api calls intake, the driver calls
+ * commitStep. They are the only run-status mutations in the system, and
+ * work items are born only inside their transactions — which is why there
+ * is no createWorkItem. archiveSession is the separate terminal lifecycle
+ * transition and may land only while neither path has left an open item.
  *
  * The load-bearing invariant: at most one open (non-done) item per
  * session. "Busy" IS an open item's existence, and a run's end is the
@@ -142,15 +142,31 @@ export interface Store {
    *  always of a committed, active state. */
   createSession(req: CreateSessionRequest): Promise<SessionRef>;
   getSession(ref: SessionRef): Promise<Session | undefined>;
+  /**
+   * Permanently archive an idle session. The row and its history remain
+   * readable, but intake, cancellation, and sandbox rebinding become
+   * read-only conflicts. A non-done work item is the session's running
+   * state, so attempting the transition while one exists throws
+   * SessionNotIdleError. A cancelled run parks its pending inputs for the
+   * next intake and archive guarantees there is no next one, so the
+   * transition drains them into the log — appended as entries in arrival
+   * order, chaining nothing. The archive check and intake/commit transitions
+   * serialize on the session row: archive cannot race a session from idle
+   * into running. Repeating an archive is an idempotent read of the first
+   * archivedAt; unknown and foreign refs return undefined.
+   */
+  archiveSession(ref: SessionRef): Promise<Session | undefined>;
   /** Register the session's one sandbox: a compare-and-set on the
    *  binding — fills a null binding when `previous` is omitted, or
    *  replaces exactly `previous` when the caller is recovering a dead
    *  sandbox. Returns the bound id either way: the atomic pick that
    *  keeps every claimer executing in one workspace — a racer whose
    *  candidate lost learns the winner and discards its own (see
-   *  driver/ensure-sandbox.ts). Rejects an unknown or foreign session. */
+   *  driver/ensure-sandbox.ts). Rejects an unknown, foreign, or archived
+   *  session. */
   bindSandbox(ref: SessionRef, sandboxId: string, previous?: string): Promise<string>;
-  /** One namespace's sessions, newest first — see ListSessionsRequest. */
+  /** One namespace's active sessions, newest first. includeArchived opts
+   *  terminal rows back in — see ListSessionsRequest. */
   listSessions(req: ListSessionsRequest): Promise<Session[]>;
 
   // --- reads — table-shaped; reads need no atomicity ---
@@ -189,7 +205,8 @@ export interface Store {
    * Appends a cancel ControlEntry to the log — nothing else. Workers
    * check behind the tail at boundaries; seq order scopes which run the
    * cancel addresses (one landing after a run's terminal message
-   * addresses a run that no longer exists and is ignored).
+   * addresses a run that no longer exists and is ignored). An archived
+   * session rejects the write with ArchivedError.
    */
   requestCancel(ref: SessionRef): Promise<void>;
 
@@ -200,7 +217,8 @@ export interface Store {
    * → the message becomes an entry and an inference item starts a run;
    * open item → the message parks as a pending input. Whether a parked
    * input steers or follows up is decided by which boundary drains it,
-   * never by the message itself.
+   * never by the message itself. An archived session rejects intake with
+   * ArchivedError.
    */
   intake(ref: SessionRef, message: UserMessage): Promise<IntakeResult>;
 
@@ -234,25 +252,66 @@ export class FencedError extends Error {
   }
 }
 
-export type ConfigKind = "agent" | "env";
+export type ArchivedResourceKind = "agent" | "env" | "session";
+
+/** What each kind is called in the message; the wording belongs to the
+ *  kind, not to the factory that names it. */
+const ARCHIVED_LABEL: Record<ArchivedResourceKind, string> = {
+  agent: "agent config",
+  env: "env config",
+  session: "session",
+};
 
 /**
- * Thrown when a mutation or new reference targets an archived config.
- * Terminal, unlike VersionConflictError: no retry can ever succeed.
+ * Thrown when a mutation or new reference targets any archived resource.
+ * One type is deliberate: agent configs, env configs, and sessions share
+ * the same terminal verdict and callers normally need one catch path. The
+ * resourceKind/resourceId pair preserves specific identity when it matters.
+ * Terminal, unlike VersionConflictError or SessionNotIdleError: no retry can
+ * ever succeed.
+ *
+ * The thrower names the kind — the factories, never a shape test on the
+ * ref. A Session row is structurally a SessionRef AND carries both config
+ * ids, so inferring the kind would misread the whole-row-as-ref calls the
+ * api makes (store.intake(session, …)); every throw site already knows
+ * which resource it read.
  */
 export class ArchivedError extends Error {
   readonly namespace: string;
-  readonly configId: ConfigId;
-  readonly configKind: ConfigKind;
+  readonly resourceId: string;
+  readonly resourceKind: ArchivedResourceKind;
 
-  constructor(ref: AgentConfigRef | EnvConfigRef) {
-    const configKind = "agentConfigId" in ref ? "agent" : "env";
-    const configId = "agentConfigId" in ref ? ref.agentConfigId : ref.envConfigId;
-    super(`${configKind} config ${ref.namespace}/${configId} is archived`);
+  private constructor(kind: ArchivedResourceKind, namespace: string, resourceId: string) {
+    super(`${ARCHIVED_LABEL[kind]} ${namespace}/${resourceId} is archived`);
     this.name = "ArchivedError";
+    this.namespace = namespace;
+    this.resourceId = resourceId;
+    this.resourceKind = kind;
+  }
+
+  static forAgentConfig(ref: AgentConfigRef): ArchivedError {
+    return new ArchivedError("agent", ref.namespace, ref.agentConfigId);
+  }
+
+  static forEnvConfig(ref: EnvConfigRef): ArchivedError {
+    return new ArchivedError("env", ref.namespace, ref.envConfigId);
+  }
+
+  static forSession(ref: SessionRef): ArchivedError {
+    return new ArchivedError("session", ref.namespace, ref.sessionId);
+  }
+}
+
+/** Thrown when archive is requested while the session has an open item. */
+export class SessionNotIdleError extends Error {
+  readonly namespace: string;
+  readonly sessionId: string;
+
+  constructor(ref: SessionRef) {
+    super(`session ${ref.namespace}/${ref.sessionId} is not idle`);
+    this.name = "SessionNotIdleError";
     this.namespace = ref.namespace;
-    this.configId = configId;
-    this.configKind = configKind;
+    this.sessionId = ref.sessionId;
   }
 }
 

--- a/packages/agent/test/store-port.test.ts
+++ b/packages/agent/test/store-port.test.ts
@@ -1,21 +1,41 @@
 import { describe, expect, it } from "vitest";
-import { ArchivedError } from "../src";
+import { ArchivedError, SessionNotIdleError } from "../src";
 
 describe("Store port errors", () => {
   it("identifies the namespace and kind of config that is archived", () => {
-    expect(new ArchivedError({ namespace: "tenant-a", agentConfigId: "ac1" })).toMatchObject({
+    expect(
+      ArchivedError.forAgentConfig({ namespace: "tenant-a", agentConfigId: "ac1" }),
+    ).toMatchObject({
       name: "ArchivedError",
       namespace: "tenant-a",
-      configId: "ac1",
-      configKind: "agent",
+      resourceId: "ac1",
+      resourceKind: "agent",
       message: "agent config tenant-a/ac1 is archived",
     });
-    expect(new ArchivedError({ namespace: "tenant-b", envConfigId: "ec1" })).toMatchObject({
+    expect(ArchivedError.forEnvConfig({ namespace: "tenant-b", envConfigId: "ec1" })).toMatchObject(
+      {
+        name: "ArchivedError",
+        namespace: "tenant-b",
+        resourceId: "ec1",
+        resourceKind: "env",
+        message: "env config tenant-b/ec1 is archived",
+      },
+    );
+  });
+
+  it("identifies terminal and running session conflicts", () => {
+    expect(ArchivedError.forSession({ namespace: "tenant-a", sessionId: "s1" })).toMatchObject({
       name: "ArchivedError",
+      namespace: "tenant-a",
+      resourceId: "s1",
+      resourceKind: "session",
+      message: "session tenant-a/s1 is archived",
+    });
+    expect(new SessionNotIdleError({ namespace: "tenant-b", sessionId: "s2" })).toMatchObject({
+      name: "SessionNotIdleError",
       namespace: "tenant-b",
-      configId: "ec1",
-      configKind: "env",
-      message: "env config tenant-b/ec1 is archived",
+      sessionId: "s2",
+      message: "session tenant-b/s2 is not idle",
     });
   });
 });

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -206,6 +206,10 @@ export const ListSessionsRequest = z.object({
   namespace: z.string().min(1),
   limit: z.number().int().min(1),
   after: z.string().min(1).optional(),
+  // The default list is active rows only: archived history grows without
+  // bound, and a caller asking for its sessions means the live ones. The
+  // terminal rows are an explicit opt-in; retrieval by id is unaffected.
+  includeArchived: z.boolean().optional(),
 });
 export type ListSessionsRequest = z.infer<typeof ListSessionsRequest>;
 
@@ -234,6 +238,9 @@ export const Session = SessionRef.extend({
   // execute_tools claim (Store.bindSandbox); absent until then.
   sandboxId: z.string().optional(),
   createdAt: z.iso.datetime(),
+  // Archive is terminal: the session remains readable but accepts no new
+  // client writes. Absence, rather than null, is the active state.
+  archivedAt: z.iso.datetime().optional(),
 });
 export type Session = z.infer<typeof Session>;
 

--- a/packages/core/test/store.test.ts
+++ b/packages/core/test/store.test.ts
@@ -12,6 +12,7 @@ import {
   IntakeResult,
   ListAgentConfigsRequest,
   ListEnvConfigsRequest,
+  ListSessionsRequest,
   PendingInput,
   Session,
   SessionRef,
@@ -287,6 +288,34 @@ describe("sessions", () => {
     expect(roundTrip(Session, session)).toEqual(session);
   });
 
+  it("round-trips an archived session — the mark is a timestamp, not a flag", () => {
+    const session = {
+      namespace: "default",
+      sessionId: "s1",
+      agentConfigId: "ac1",
+      agentConfigVersion: 2,
+      envConfigId: "ec1",
+      envConfigSnapshot: { network: { type: "unrestricted" }, packages: {} },
+      createdAt: "2026-08-11T12:00:00Z",
+      archivedAt: "2026-08-13T12:00:00Z",
+    };
+    expect(roundTrip(Session, session)).toEqual(session);
+  });
+
+  it("rejects null or boolean session archivedAt — active is spelled by absence", () => {
+    const session = {
+      namespace: "default",
+      sessionId: "s1",
+      agentConfigId: "ac1",
+      agentConfigVersion: 1,
+      envConfigId: "ec1",
+      envConfigSnapshot: { network: { type: "unrestricted" }, packages: {} },
+      createdAt: "2026-08-11T12:00:00Z",
+    };
+    expect(Session.safeParse({ ...session, archivedAt: null }).success).toBe(false);
+    expect(Session.safeParse({ ...session, archivedAt: true }).success).toBe(false);
+  });
+
   // The recipe is copied, not referenced: env configs update in place, so
   // a session that resolved one at read time could change under a running
   // run. The snapshot is a resolved decision, so it is never absent.
@@ -351,6 +380,24 @@ describe("sessions", () => {
     expect(SessionRef.safeParse({ namespace: "tenant-a", sessionId: "s1" }).success).toBe(true);
     expect(SessionRef.safeParse({ namespace: "tenant-a", sessionId: "" }).success).toBe(false);
     expect(SessionRef.safeParse({ namespace: "", sessionId: "s1" }).success).toBe(false);
+  });
+
+  it("validates session pagination's archived opt-in", () => {
+    expect(
+      ListSessionsRequest.safeParse({
+        namespace: "tenant-a",
+        limit: 10,
+        after: "s1",
+        includeArchived: true,
+      }).success,
+    ).toBe(true);
+    expect(
+      ListSessionsRequest.safeParse({
+        namespace: "tenant-a",
+        limit: 10,
+        includeArchived: "true",
+      }).success,
+    ).toBe(false);
   });
 
   it("requires an explicit namespace when creating a session", () => {


### PR DESCRIPTION
Sessions get the terminal state the configs already had: `POST /v1/sessions/:id/archive` stamps `archivedAt`, keeps the row and its history readable, and turns intake, cancellation, and sandbox rebinding into 409 conflicts. The transition is refused with `SessionNotIdleError` while a non-done work item says the session is running, and it takes the same session row lock intake and `commitStep` do, so a run can never start behind it. Because a cancelled run parks its pending inputs for the next intake and archive guarantees there is no next one, the same transaction drains them into the log rather than stranding a message the api already answered 202. `GET /v1/sessions` now omits archived rows by default with an `include_archived` opt-in — an enum rather than `z.coerce.boolean`, which would read `"false"` as true — backed by a partial index, while the full index still serves the archived-inclusive page. `ArchivedError` covers sessions too and takes its kind from the thrower (`forAgentConfig` / `forEnvConfig` / `forSession`) instead of inferring it from the ref's shape, which a whole `Session` row defeats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)