### PR TITLE
Add updatedAt to environment configs

### DIFF
--- a/apps/api/test/env-configs.test.ts
+++ b/apps/api/test/env-configs.test.ts
@@ -42,6 +42,7 @@ describe("POST /v1/env-configs", () => {
     expect(body.namespace).toBe("default");
     expect(typeof body.id).toBe("string");
     expect(typeof body.createdAt).toBe("string");
+    expect(body.updatedAt).toBe(body.createdAt);
   });
 
   it("stores an explicit recipe verbatim and GET returns the same row", async () => {
@@ -160,6 +161,7 @@ describe("POST /v1/env-configs/:id", () => {
     expect(updated).toEqual({
       ...created,
       packages: { npm: ["zod@4"] },
+      updatedAt: expect.any(String),
     });
     expect(await (await get(app, `/v1/env-configs/${created.id}`)).json()).toEqual(updated);
   });

--- a/packages/adapters/migrations/20260820000000_init/migration.sql
+++ b/packages/adapters/migrations/20260820000000_init/migration.sql
@@ -56,6 +56,9 @@ CREATE TABLE env_configs (
   packages jsonb NOT NULL,
   metadata jsonb,
   created_at timestamptz NOT NULL,
+  -- Latest recipe edit; equal to created_at until the first update.
+  -- Archive is a lifecycle mark rather than an edit, so it does not move.
+  updated_at timestamptz NOT NULL,
   -- Retires the recipe without deleting it. Existing sessions have their
   -- own copy; NULL means no archive event, and the mark is never cleared.
   archived_at timestamptz,

--- a/packages/adapters/src/store/pg.ts
+++ b/packages/adapters/src/store/pg.ts
@@ -143,6 +143,7 @@ const toEnvConfig = (row: typeof envConfigs.$inferSelect): EnvConfig =>
     namespace: row.namespace,
     ...unwrapped(row.metadata),
     createdAt: iso(row.createdAt),
+    updatedAt: iso(row.updatedAt),
     ...(row.archivedAt === null ? {} : { archivedAt: iso(row.archivedAt) }),
   });
 
@@ -421,6 +422,7 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
     async createEnvConfig(req) {
       const parsed = CreateEnvConfigRequest.parse(req);
       const id = randomUUID();
+      const timestamp = now();
       await db.insert(envConfigs).values({
         id,
         // Materialized at create — resolved decisions, not restatable defaults.
@@ -428,7 +430,8 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         network: parsed.network ?? { type: "unrestricted" },
         packages: parsed.packages ?? {},
         metadata: wrap(parsed.metadata),
-        createdAt: now(),
+        createdAt: timestamp,
+        updatedAt: timestamp,
       });
       return EnvConfigRef.parse({ namespace: parsed.namespace, envConfigId: id });
     },
@@ -458,7 +461,11 @@ export function createPgStore(db: StoreDb, opts: PgStoreOptions = {}): Store {
         return row === undefined ? undefined : toEnvConfig(row);
       }
 
-      const [row] = await db.update(envConfigs).set(updates).where(mutable).returning();
+      const [row] = await db
+        .update(envConfigs)
+        .set({ ...updates, updatedAt: now() })
+        .where(mutable)
+        .returning();
       if (row !== undefined) return toEnvConfig(row);
 
       // An unmatched mutation is either unknown/foreign or archived. Rows

--- a/packages/adapters/src/store/schema.ts
+++ b/packages/adapters/src/store/schema.ts
@@ -91,6 +91,8 @@ export const envConfigs = pgTable(
     packages: jsonb("packages").$type<Packages>().notNull(),
     metadata: jsonb("metadata").$type<WrappedJson>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+    // Latest recipe edit; archive is a lifecycle mark, not a recipe edit.
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
     // The terminal state, set once: null = active. Existing sessions use
     // their snapshot, while this mark closes the recipe to new sessions.
     archivedAt: timestamp("archived_at", { withTimezone: true }),

--- a/packages/adapters/test/store-conformance.ts
+++ b/packages/adapters/test/store-conformance.ts
@@ -303,6 +303,7 @@ export function describeStoreConformance(
         const config = await store.getEnvConfig(ref);
         expect(config?.network).toEqual({ type: "unrestricted" });
         expect(config?.packages).toEqual({});
+        expect(config?.updatedAt).toBe(config?.createdAt);
       });
 
       it("preserves a provided recipe verbatim", async () => {
@@ -322,6 +323,7 @@ export function describeStoreConformance(
           metadata: { stage: "initial" },
         });
         const before = await store.getEnvConfig(ref);
+        clock.advance(1_000);
 
         const withPackages = await store.updateEnvConfig(ref, {
           packages: { npm: ["zod@4"] },
@@ -329,7 +331,10 @@ export function describeStoreConformance(
         expect(withPackages).toEqual({
           ...before,
           packages: { npm: ["zod@4"] },
+          updatedAt: withPackages?.updatedAt,
         });
+        expect(Date.parse(withPackages!.updatedAt)).toBeGreaterThan(Date.parse(before!.updatedAt));
+        clock.advance(1_000);
 
         const updated = await store.updateEnvConfig(ref, {
           network: { type: "none" },
@@ -339,7 +344,9 @@ export function describeStoreConformance(
           ...withPackages,
           network: { type: "none" },
           metadata: null,
+          updatedAt: updated?.updatedAt,
         });
+        expect(Date.parse(updated!.updatedAt)).toBeGreaterThan(Date.parse(withPackages!.updatedAt));
         expect(await store.getEnvConfig(ref)).toEqual(updated);
       });
 
@@ -623,6 +630,7 @@ export function describeStoreConformance(
         const archived = await store.archiveEnvConfig(ref);
 
         expect(archived).toMatchObject({ ...before, archivedAt: expect.any(String) });
+        expect(archived?.updatedAt).toBe(before?.updatedAt);
         expect(await store.getEnvConfig(ref)).toEqual(archived);
       });
 

--- a/packages/agent/src/ports/store.ts
+++ b/packages/agent/src/ports/store.ts
@@ -102,9 +102,10 @@ export interface Store {
   getEnvConfig(ref: EnvConfigRef): Promise<EnvConfig | undefined>;
   /**
    * Partially update one namespace's environment config in place. Omitted
-   * fields are preserved; an empty request is a read-like no-op. Namespace
-   * is immutable and carried by the ref. An unknown or foreign ref is
-   * indistinguishable from absence and returns undefined.
+   * fields are preserved; a real edit advances updatedAt, while an empty
+   * request is a read-like no-op that preserves it. Namespace is immutable
+   * and carried by the ref. An unknown or foreign ref is indistinguishable
+   * from absence and returns undefined.
    *
    * An archived config is read-only: a mutation throws ArchivedError. An
    * empty request remains a read and returns the archived row unchanged.
@@ -118,8 +119,9 @@ export interface Store {
   /**
    * Archive one namespace's environment config. The row stays readable and
    * sessions that already copied its recipe keep running; future writes and
-   * references from new sessions are refused. There is no unarchive, making
-   * repeat calls idempotent: they return the original archivedAt.
+   * references from new sessions are refused. Archiving does not edit the
+   * recipe, so updatedAt is preserved. There is no unarchive, making repeat
+   * calls idempotent: they return the original archivedAt.
    */
   archiveEnvConfig(ref: EnvConfigRef): Promise<EnvConfig | undefined>;
   /** One namespace's env configs, newest first — see ListEnvConfigsRequest. */

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -15,7 +15,8 @@ import { InferenceConfig } from "./inference";
  *
  * Request shapes (Create*Request, after InferenceRequest and
  * StreamRequest) become stored rows verbatim, plus store-minted envelope
- * fields (id/createdAt, and version/updatedAt on mutable agent configs).
+ * fields (id/createdAt, updatedAt on mutable configs, and version on agent
+ * configs).
  * Two rules keep every row one-shaped:
  * - Rows store decisions, not rules: a default that is RESOLVED at
  *   creation time is materialized into the stored row (network →
@@ -186,6 +187,9 @@ export const EnvConfig = EnvConfigRef.extend({
   ...EnvConfigSnapshot.shape,
   metadata: JsonValue.optional(),
   createdAt: z.iso.datetime(),
+  // The latest recipe edit. Equal to createdAt until the first update;
+  // archiving retires the recipe without editing it, so it does not move.
+  updatedAt: z.iso.datetime(),
   // Set once when the recipe is retired. Absence is the active state;
   // archive is terminal, so there is no boolean state to toggle back.
   archivedAt: z.iso.datetime().optional(),

--- a/packages/core/test/store.test.ts
+++ b/packages/core/test/store.test.ts
@@ -172,6 +172,7 @@ describe("env configs", () => {
       namespace: "tenant-a",
       metadata: { envId: "env_014588" },
       createdAt: "2026-08-11T12:00:00Z",
+      updatedAt: "2026-08-12T12:00:00Z",
     };
     expect(roundTrip(EnvConfig, config)).toEqual(config);
   });
@@ -183,6 +184,7 @@ describe("env configs", () => {
       packages: {},
       namespace: "tenant-a",
       createdAt: "2026-08-11T12:00:00Z",
+      updatedAt: "2026-08-12T12:00:00Z",
       archivedAt: "2026-08-13T12:00:00Z",
     };
     expect(roundTrip(EnvConfig, config)).toEqual(config);
@@ -195,6 +197,7 @@ describe("env configs", () => {
       packages: {},
       namespace: "tenant-a",
       createdAt: "2026-08-11T12:00:00Z",
+      updatedAt: "2026-08-11T12:00:00Z",
     };
     expect(EnvConfig.safeParse({ ...config, archivedAt: null }).success).toBe(false);
     expect(EnvConfig.safeParse({ ...config, archivedAt: true }).success).toBe(false);
@@ -266,6 +269,7 @@ describe("env configs", () => {
       namespace: "tenant-a",
       packages: {},
       createdAt: "2026-08-11T12:00:00Z",
+      updatedAt: "2026-08-11T12:00:00Z",
     });
     expect(result.success).toBe(false);
   });
@@ -348,7 +352,15 @@ describe("sessions", () => {
     }
     // The row is the recipe plus its envelope, nothing else.
     expect(Object.keys(EnvConfig.shape).sort()).toEqual(
-      [...recipe, "namespace", "envConfigId", "metadata", "createdAt", "archivedAt"].sort(),
+      [
+        ...recipe,
+        "namespace",
+        "envConfigId",
+        "metadata",
+        "createdAt",
+        "updatedAt",
+        "archivedAt",
+      ].sort(),
     );
   });
 


### PR DESCRIPTION
Adds a required updatedAt field to environment config domain and persistence schemas and exposes it through API resources. Creation initializes it to createdAt, while actual recipe or metadata edits advance it. Empty updates and archive operations preserve the previous timestamp, matching agent-config semantics. Expands core, store conformance, and API tests; pnpm test, pnpm typecheck, and pnpm format:check pass.