### PR TITLE
Add the agent config list to the console

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,8 @@ E2B_API_KEY=
 # Inside compose the services reach the postgres service directly; set this
 # only when running an app against your own postgres (e.g. `pnpm dev`).
 # DATABASE_URL=postgres://funky:funky@localhost:5432/funky
+
+# The api the web console's dev server proxies to, with FUNKY_AUTH_TOKEN
+# above attached to each request (`pnpm -F web dev`). Defaults to the api's
+# compose port.
+# FUNKY_API_URL=http://localhost:3000

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -20,8 +20,21 @@ pnpm -F web lint     # oxlint
 | `src/pages/`      | One module per section                                               |
 
 Routing is the URL hash (`#/agent`), so sections are linkable and the browser owns history —
-`src/lib/useHashRoute.ts` is the whole router. Sections are placeholders for now; each gets
-wired to its endpoints in turn.
+`src/lib/useHashRoute.ts` is the whole router. A section renders the page named in its
+`nav.ts` entry, or the placeholder if it has none yet; each gets wired to its endpoints in
+turn.
+
+## Talking to the api
+
+The api has no CORS and is bearer-authed, so the browser never calls it directly. The dev
+server proxies same-origin `/v1` to the api and adds the `Authorization` header itself
+(`vite.config.ts`), reading `FUNKY_AUTH_TOKEN` from the **monorepo root `.env`** — the same
+file `docker compose up` reads, so there is no second copy to keep in sync, and the token
+never enters the client bundle. Point it elsewhere with `FUNKY_API_URL` (default
+`http://localhost:3000`).
+
+So: start the stack (`docker compose up`), then `pnpm -F web dev`. With the api down, the
+proxy answers 502 and the console says it can't reach it.
 
 ## Brand
 

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -72,6 +72,10 @@
   display: grid;
   place-items: center;
   padding: 56px 24px 76px;
+  /* A page's usable width is the pane's, not the window's — the sidebar
+     takes 252px of it. Pages that reflow (a table becoming cards) query
+     this container, so they switch on the space they actually have. */
+  container: pane / inline-size;
 }
 
 /* Dot grid, faded out downward, so the pane has texture without noise. */

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/App.tsx
 // The console shell: a persistent sidebar beside one routed pane. Sections
-// live in nav.ts; the route is the URL hash, so every section is linkable.
+// live in nav.ts — including which page each renders — and the route is the
+// URL hash, so every section is linkable.
 import { useEffect } from "react";
 import { Sidebar } from "./components/Sidebar";
 import { ExternalLinkIcon } from "./components/Icons";
@@ -37,7 +38,11 @@ function App() {
         </header>
 
         <div className="content">
-          <Placeholder key={active.id} item={active} />
+          {active.Page ? (
+            <active.Page key={active.id} />
+          ) : (
+            <Placeholder key={active.id} item={active} />
+          )}
         </div>
       </main>
     </div>

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -64,6 +64,16 @@ export function SessionIcon(props: SVGProps<SVGSVGElement>) {
   );
 }
 
+/** Reload a list. */
+export function RefreshIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <Stroke width={15} height={15} {...props}>
+      <path d="M20.5 12A8.5 8.5 0 1 1 18 6" />
+      <path d="M21.5 2.5V6H18" />
+    </Stroke>
+  );
+}
+
 /** Topbar docs link. */
 export function ExternalLinkIcon(props: SVGProps<SVGSVGElement>) {
   return (

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -30,6 +30,11 @@
   --accent-glow: rgba(27, 69, 232, 0.13);
   --brand-shadow: rgba(27, 69, 232, 0.34);
 
+  /* Status green — the one hue outside the logo palette. "Active" is a
+     health signal, not a brand accent, so it does not borrow saffron. */
+  --ok: #15a34a;
+  --ok-glow: rgba(21, 163, 74, 0.2);
+
   --dot: rgba(16, 20, 38, 0.07);
 
   --shadow-sm: 0 1px 2px rgba(16, 24, 48, 0.05);
@@ -80,6 +85,9 @@
     --accent-line: rgba(130, 158, 255, 0.3);
     --accent-glow: rgba(45, 85, 230, 0.26);
     --brand-shadow: rgba(27, 69, 232, 0.55);
+
+    --ok: #4ade80;
+    --ok-glow: rgba(74, 222, 128, 0.2);
 
     --dot: rgba(255, 255, 255, 0.055);
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,6 +1,114 @@
 // apps/web/src/lib/api.ts
-// What the console knows about the api it fronts. The namespace is part of
-// every request the api takes (create bodies carry it, id-addressed routes
-// take ?namespace=); absence resolves to this default, and the console has
-// no namespace switcher yet, so it addresses exactly this one.
+// The api as the browser sees it: same-origin paths and no credential.
+// Auth is the dev server's job — vite.config.ts proxies /v1 to the api and
+// injects the bearer token — so nothing here, and nothing in the bundle,
+// ever holds it.
+//
+// The wire types are hand-mirrored from @funky/core rather than imported:
+// core's shapes are zod schemas, and a console that only reads JSON has no
+// reason to pull a validator into the browser. What follows is exactly
+// what apps/api returns, nothing more.
+
+// The namespace is part of every request the api takes (create bodies
+// carry it, id-addressed and list routes take ?namespace=); absence
+// resolves to this default, and the console has no namespace switcher yet,
+// so it addresses exactly this one.
 export const DEFAULT_NAMESPACE = "default";
+
+export type InferenceConfig = {
+  provider: string;
+  model: string;
+  maxTokens?: number;
+  temperature?: number;
+};
+
+/** One agent config, at one version. */
+export type AgentConfig = {
+  id: string;
+  namespace: string;
+  inference: InferenceConfig;
+  systemPrompt: string;
+  /** Monotonic; an update lands as the next version rather than a rewrite. */
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+  /** Set once retired. Archive is terminal, so absence is the active state. */
+  archivedAt?: string;
+  metadata?: unknown;
+};
+
+/** The envelope every collection route returns (api routes/common.ts). */
+export type Page<T> = {
+  data: T[];
+  hasMore: boolean;
+  /** Cursor for the next page — what to send as `after`; absent when empty. */
+  lastId?: string;
+};
+
+/** A failed call, carrying the api's own message when it sent one. */
+export class ApiError extends Error {
+  status: number | undefined;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
+// The console's likeliest failure by far, and neither "Failed to fetch" nor
+// "502 Bad Gateway" names it: the api isn't up, or the proxy can't reach it.
+const UNREACHABLE = "Can't reach the api — is it running, and is FUNKY_API_URL right?";
+
+/** The message out of the api's error envelope, or what the status means. */
+async function failure(res: Response): Promise<ApiError> {
+  const body: unknown = await res.json().catch(() => undefined);
+  const message = (body as { error?: { message?: string } } | undefined)?.error?.message;
+  // A gateway status carries no envelope because the api never answered:
+  // it is the dev server's proxy speaking, so say what that means.
+  const gateway = res.status === 502 || res.status === 503 || res.status === 504;
+  return new ApiError(
+    message ?? (gateway ? UNREACHABLE : `${res.status} ${res.statusText}`),
+    res.status,
+  );
+}
+
+async function get<T>(
+  path: string,
+  params: Record<string, string | undefined>,
+  signal?: AbortSignal,
+): Promise<T> {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) query.set(key, value);
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(`${path}?${query}`, { headers: { accept: "application/json" }, signal });
+  } catch (cause) {
+    if (cause instanceof DOMException && cause.name === "AbortError") throw cause;
+    throw new ApiError(UNREACHABLE);
+  }
+  if (!res.ok) throw await failure(res);
+  return (await res.json()) as T;
+}
+
+/**
+ * One page of the namespace's agent configs, newest first. The api resolves
+ * each config to its CURRENT version, so a config appears once here however
+ * many times it has been updated.
+ */
+export function listAgentConfigs(
+  opts: { after?: string; limit?: number; signal?: AbortSignal } = {},
+): Promise<Page<AgentConfig>> {
+  return get<Page<AgentConfig>>(
+    "/v1/agent-configs",
+    {
+      namespace: DEFAULT_NAMESPACE,
+      limit: opts.limit === undefined ? undefined : String(opts.limit),
+      after: opts.after,
+    },
+    opts.signal,
+  );
+}

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -1,0 +1,37 @@
+// apps/web/src/lib/format.ts
+// Timestamps the way a console wants them: the age at a glance, the exact
+// instant on hover. Both from Intl, so the browser owns locale and wording.
+
+const RELATIVE = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+const ABSOLUTE = new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "medium" });
+
+// Each unit with how many of it the next one takes. Walked in order, so the
+// result is the coarsest unit the value still reads as a small number in;
+// past the last entry the value is already in years.
+const UNITS: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+  ["second", 60],
+  ["minute", 60],
+  ["hour", 24],
+  ["day", 7],
+  ["week", 4.348],
+  ["month", 12],
+];
+
+/** e.g. "3 hours ago". Returns the input unchanged if it isn't a date. */
+export function relativeTime(iso: string, now: number = Date.now()): string {
+  const at = new Date(iso).getTime();
+  if (Number.isNaN(at)) return iso;
+
+  let value = (at - now) / 1000; // negative = in the past
+  for (const [unit, per] of UNITS) {
+    if (Math.abs(value) < per) return RELATIVE.format(Math.round(value), unit);
+    value /= per;
+  }
+  return RELATIVE.format(Math.round(value), "year");
+}
+
+/** The full local timestamp — the hover text behind a relative one. */
+export function absoluteTime(iso: string): string {
+  const at = new Date(iso);
+  return Number.isNaN(at.getTime()) ? iso : ABSOLUTE.format(at);
+}

--- a/apps/web/src/lib/useNow.ts
+++ b/apps/web/src/lib/useNow.ts
@@ -1,0 +1,17 @@
+// apps/web/src/lib/useNow.ts
+// A clock that advances, for anything rendered relative to "now". Without
+// it a relative timestamp is only true at the moment it rendered: a console
+// left open would still read "12 seconds ago" an hour later.
+import { useEffect, useState } from "react";
+
+/** The current time, re-read every `everyMs` for as long as it is rendered. */
+export function useNow(everyMs: number): number {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), everyMs);
+    return () => clearInterval(timer);
+  }, [everyMs]);
+
+  return now;
+}

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -4,6 +4,7 @@
 // Kept free of JSX so it can hold both the data and the route resolver.
 import type { ReactElement, SVGProps } from "react";
 import { AgentIcon, BoltIcon, EnvironmentIcon, SessionIcon } from "./components/Icons";
+import { AgentConfigs } from "./pages/AgentConfigs";
 
 export type NavItem = {
   /** The hash route, `#/<id>`, and the item's identity. */
@@ -16,6 +17,9 @@ export type NavItem = {
   chip: string;
   /** Rendered as a caption above the item, when it opens a group. */
   groupLabel?: string;
+  /** The section's page. Absent while a section is unbuilt — those render
+   *  the placeholder from the blurb and chip above. */
+  Page?: () => ReactElement;
 };
 
 /** Non-empty by type: the first section is what an unknown route falls back to. */
@@ -36,6 +40,7 @@ export const NAV_ITEMS: [NavItem, ...NavItem[]] = [
       "Agent configs are the model, the system prompt, and the tools a session runs with. Versioned, so an update lands as a new version rather than a rewrite.",
     chip: "/v1/agent-configs",
     groupLabel: "Resources",
+    Page: AgentConfigs,
   },
   {
     id: "environment",

--- a/apps/web/src/pages/AgentConfigs.css
+++ b/apps/web/src/pages/AgentConfigs.css
@@ -1,0 +1,392 @@
+/* apps/web/src/pages/AgentConfigs.css
+   The first data page: a header, a table, and the states around it. Sits at
+   the top of the routed pane rather than its centre (the pane centres the
+   hero placeholder), and every colour resolves to a token in index.css. */
+
+.agents {
+  align-self: start;
+  width: 100%;
+  max-width: 900px;
+  /* A grid item's auto min-width is min-content — which the table's own
+     min-width sets. Without this the section grows past the pane and the
+     page overflows sideways, instead of .table-wrap scrolling. */
+  min-width: 0;
+  animation: agents-in 420ms var(--ease);
+}
+
+/* Header ----------------------------------------------------------------- */
+
+.agents-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.agents-title {
+  font-size: 21px;
+  font-weight: 600;
+  letter-spacing: -0.35px;
+  color: var(--text);
+}
+
+.notice-body code {
+  padding: 1px 5px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-elev);
+  font: 500 12px var(--mono);
+  color: var(--text-2);
+}
+
+/* Button ----------------------------------------------------------------- */
+
+.btn {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 14px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-elev);
+  font: 500 13px var(--sans);
+  color: var(--text-2);
+  cursor: pointer;
+  transition:
+    color var(--dur) var(--ease),
+    border-color var(--dur) var(--ease),
+    box-shadow var(--dur) var(--ease),
+    transform var(--dur) var(--ease);
+}
+
+.btn:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-sm);
+  transform: translateY(-1px);
+}
+
+.btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+/* Table ------------------------------------------------------------------ */
+
+/* The id column is a uuid: rather than truncate it, the table keeps its
+   natural width and this scrolls when the pane is narrower. */
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--bg-elev);
+  box-shadow: var(--shadow-sm);
+  scrollbar-width: thin;
+}
+
+.table {
+  width: 100%;
+  min-width: 700px;
+  border-collapse: collapse;
+}
+
+.table th {
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-sunken);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  text-align: left;
+  color: var(--text-3);
+  white-space: nowrap;
+}
+
+.col-model {
+  width: 26%;
+}
+
+.col-status {
+  width: 122px;
+}
+
+.col-when {
+  width: 138px;
+}
+
+.table td {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  font-size: 13.5px;
+  color: var(--text-2);
+  white-space: nowrap;
+  transition: background-color var(--dur) var(--ease);
+}
+
+.table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.table tbody tr:hover td {
+  background: var(--hover);
+}
+
+.id {
+  font: 500 12.5px var(--mono);
+  color: var(--text);
+}
+
+.model {
+  display: block;
+  font: 500 13px var(--mono);
+  color: var(--text);
+}
+
+.provider {
+  font-size: 11px;
+  color: var(--text-3);
+}
+
+/* Status ----------------------------------------------------------------- */
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 3px 11px 3px 9px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.pill-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.pill-active {
+  color: var(--text-2);
+}
+
+.pill-active .pill-dot {
+  background: var(--ok);
+  box-shadow: 0 0 0 3px var(--ok-glow);
+}
+
+.pill-archived {
+  color: var(--text-3);
+  background: var(--bg-sunken);
+}
+
+.pill-archived .pill-dot {
+  background: var(--text-3);
+  opacity: 0.6;
+}
+
+/* Loading ---------------------------------------------------------------- */
+
+.bar {
+  display: block;
+  height: 11px;
+  border-radius: 5.5px;
+  background: linear-gradient(90deg, var(--bg-sunken), var(--hover), var(--bg-sunken));
+  background-size: 220% 100%;
+  animation: bar-shimmer 1.5s linear infinite;
+}
+
+.bar-id {
+  width: 268px;
+}
+
+.bar-model {
+  width: 60%;
+}
+
+.bar-status {
+  width: 72px;
+}
+
+.bar-when {
+  width: 84px;
+}
+
+/* Error / empty ---------------------------------------------------------- */
+
+.notice {
+  display: grid;
+  justify-items: center;
+  gap: 9px;
+  padding: 46px 24px;
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--r-lg);
+  background: var(--bg-elev);
+  text-align: center;
+}
+
+.notice-icon {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  margin-bottom: 2px;
+  border: 1px solid var(--border);
+  border-radius: 13px;
+  background: linear-gradient(180deg, var(--bg-elev), var(--accent-soft));
+  color: var(--accent);
+}
+
+.notice-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.notice-body {
+  max-width: 52ch;
+  font-size: 13.5px;
+  line-height: 1.6;
+  color: var(--text-2);
+}
+
+.notice .btn {
+  margin-top: 8px;
+}
+
+/* Pagination ------------------------------------------------------------- */
+
+.agents-more {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.agents-more-error {
+  font-size: 12.5px;
+  color: var(--text-3);
+}
+
+@keyframes agents-in {
+  from {
+    opacity: 0;
+    transform: translateY(9px);
+  }
+}
+
+@keyframes bar-shimmer {
+  from {
+    background-position: 130% 0;
+  }
+  to {
+    background-position: -30% 0;
+  }
+}
+
+/* Narrow pane: the four columns need about 790px before Created starts
+   getting clipped, and reaching it would mean scrolling the card sideways.
+   Under that, each row becomes a stacked card instead — the id, then the
+   model beside its status, then when it was created. The header row has
+   nothing left to label, so it goes with them.
+
+   Keyed to the pane rather than the window (see .content in App.css): a
+   1000px window still leaves this only ~700px once the sidebar is out. */
+@container pane (max-width: 790px) {
+  .table {
+    min-width: 0;
+  }
+
+  .table thead {
+    display: none;
+  }
+
+  .table,
+  .table tbody,
+  .table td {
+    display: block;
+  }
+
+  .table tr {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      "id id"
+      "model status"
+      "when when";
+    gap: 5px 12px;
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .table tbody tr:last-child {
+    border-bottom: none;
+  }
+
+  .table td {
+    padding: 0;
+    border: none;
+    white-space: normal;
+  }
+
+  /* Hover lands on the whole card now, not one cell of it. */
+  .table tbody tr:hover {
+    background: var(--hover);
+  }
+
+  .table tbody tr:hover td {
+    background: none;
+  }
+
+  .table td:nth-child(1) {
+    grid-area: id;
+  }
+
+  .table td:nth-child(2) {
+    grid-area: model;
+  }
+
+  .table td:nth-child(3) {
+    grid-area: status;
+    align-self: center;
+    justify-self: end;
+  }
+
+  .table td:nth-child(4) {
+    grid-area: when;
+    font-size: 12.5px;
+    color: var(--text-3);
+  }
+
+  /* A uuid is 36 characters: let it break rather than push the card wide. */
+  .id {
+    overflow-wrap: anywhere;
+  }
+
+  .bar-id {
+    width: 100%;
+  }
+
+  .notice {
+    padding: 38px 18px;
+  }
+}
+
+/* A card with room for two columns: the status and the age sit beside the
+   id and the model rather than under them, so the row stays two lines. */
+@container pane (min-width: 520px) and (max-width: 790px) {
+  .table tr {
+    grid-template-areas:
+      "id status"
+      "model when";
+    align-items: center;
+    gap: 7px 16px;
+  }
+
+  .table td:nth-child(4) {
+    justify-self: end;
+  }
+}

--- a/apps/web/src/pages/AgentConfigs.tsx
+++ b/apps/web/src/pages/AgentConfigs.tsx
@@ -1,0 +1,223 @@
+// apps/web/src/pages/AgentConfigs.tsx
+// The Agent section: the namespace's agent configs, newest first.
+//
+// A config is mutable and versioned — an update lands as a new version
+// rather than a rewrite — and this list shows each config ONCE, at its
+// latest version (the version the api's list route resolves, and the one a
+// new session would pin). Older versions stay readable by id + version and
+// stay pinned by the sessions that started on them; listing them all would
+// make this a changelog rather than an inventory.
+import { useEffect, useRef, useState } from "react";
+import { type AgentConfig, listAgentConfigs } from "../lib/api";
+import { absoluteTime, relativeTime } from "../lib/format";
+import { useNow } from "../lib/useNow";
+import { AgentIcon, RefreshIcon } from "../components/Icons";
+import "./AgentConfigs.css";
+
+type State =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; configs: AgentConfig[]; hasMore: boolean; cursor?: string };
+
+/** Placeholder rows while the first page is in flight — same shape, so
+ *  arriving data replaces them without the layout jumping. */
+const SKELETON = [0, 1, 2];
+
+/** How often the Created column re-reads the clock. Fine enough that the
+ *  coarsest thing it prints — "1 minute ago" — is never a minute stale. */
+const TICK_MS = 30_000;
+
+const messageOf = (err: unknown) => (err instanceof Error ? err.message : String(err));
+
+export function AgentConfigs() {
+  const [state, setState] = useState<State>({ status: "loading" });
+  const [more, setMore] = useState<{ busy: boolean; error?: string }>({ busy: false });
+  // Bumped to re-run the effect — refresh and retry both go through
+  // reload(), so a reload is one code path.
+  const [reloads, setReloads] = useState(0);
+  // Relative timestamps are only true at the moment they render, so the
+  // clock they read has to keep moving.
+  const now = useNow(TICK_MS);
+  // The in-flight next-page request, if any. Held so a reload can cancel
+  // it: its rows belong to the walk being replaced, not to the new one.
+  const pagination = useRef<AbortController | null>(null);
+
+  // The reset lives here rather than in the effect: the click is what makes
+  // this loading again, and the effect's job is only to fetch.
+  function reload() {
+    setState({ status: "loading" });
+    setMore({ busy: false });
+    setReloads((n) => n + 1);
+  }
+
+  useEffect(() => {
+    const abort = new AbortController();
+    listAgentConfigs({ signal: abort.signal }).then(
+      (page) =>
+        setState({
+          status: "ready",
+          configs: page.data,
+          hasMore: page.hasMore,
+          cursor: page.lastId,
+        }),
+      (err: unknown) => {
+        if (abort.signal.aborted) return;
+        setState({ status: "error", message: messageOf(err) });
+      },
+    );
+    return () => {
+      abort.abort();
+      // Same generation, same fate: a page still arriving would otherwise
+      // append itself to — and move the cursor of — a list it is no longer
+      // part of, dropping or duplicating rows on the next Load more.
+      pagination.current?.abort();
+    };
+  }, [reloads]);
+
+  // The next page, appended. `cursor` is the previous page's last id — the
+  // keyset the api hands back, not an offset, so rows created meanwhile
+  // never shift the walk.
+  async function loadMore() {
+    if (state.status !== "ready" || state.cursor === undefined || more.busy) return;
+    const abort = new AbortController();
+    pagination.current = abort;
+    setMore({ busy: true });
+    try {
+      const page = await listAgentConfigs({ after: state.cursor, signal: abort.signal });
+      setState((prev) =>
+        prev.status === "ready"
+          ? {
+              ...prev,
+              configs: [...prev.configs, ...page.data],
+              hasMore: page.hasMore,
+              cursor: page.lastId,
+            }
+          : prev,
+      );
+      setMore({ busy: false });
+    } catch (err) {
+      // Superseded by a reload, which has already reset this — nothing to
+      // report, and nothing of this walk left to report it against.
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      // The rows already on screen are still good: only the page that
+      // failed is news, so it reports beside the button, not over the list.
+      setMore({ busy: false, error: messageOf(err) });
+    }
+  }
+
+  return (
+    <section className="agents">
+      <header className="agents-head">
+        <h1 className="agents-title">Agent configs</h1>
+        <button
+          className="btn"
+          type="button"
+          onClick={reload}
+          disabled={state.status === "loading"}
+        >
+          <RefreshIcon />
+          Refresh
+        </button>
+      </header>
+
+      {state.status === "error" ? (
+        <div className="notice">
+          <p className="notice-title">Couldn&rsquo;t load agent configs</p>
+          <p className="notice-body">{state.message}</p>
+          <button className="btn" type="button" onClick={reload}>
+            <RefreshIcon />
+            Try again
+          </button>
+        </div>
+      ) : state.status === "ready" && state.configs.length === 0 ? (
+        <div className="notice">
+          <span className="notice-icon" aria-hidden="true">
+            <AgentIcon width={22} height={22} strokeWidth={1.6} />
+          </span>
+          <p className="notice-title">No agent configs yet</p>
+          <p className="notice-body">
+            A config is the model and system prompt a session runs with. Create one with{" "}
+            <code>POST /v1/agent-configs</code>.
+          </p>
+        </div>
+      ) : (
+        <div className="table-wrap">
+          <table className="table">
+            <thead>
+              <tr>
+                <th className="col-id">Id</th>
+                <th className="col-model">Model</th>
+                <th className="col-status">Status</th>
+                <th className="col-when">Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              {state.status === "loading"
+                ? SKELETON.map((row) => (
+                    <tr key={row}>
+                      <td>
+                        <span className="bar bar-id" />
+                      </td>
+                      <td>
+                        <span className="bar bar-model" />
+                      </td>
+                      <td>
+                        <span className="bar bar-status" />
+                      </td>
+                      <td>
+                        <span className="bar bar-when" />
+                      </td>
+                    </tr>
+                  ))
+                : state.configs.map((config) => (
+                    <tr key={config.id}>
+                      <td>
+                        <span className="id">{config.id}</span>
+                      </td>
+                      <td>
+                        <span className="model">{config.inference.model}</span>
+                        <span className="provider">{config.inference.provider}</span>
+                      </td>
+                      <td>
+                        <Status archivedAt={config.archivedAt} />
+                      </td>
+                      <td>
+                        <time dateTime={config.createdAt} title={absoluteTime(config.createdAt)}>
+                          {relativeTime(config.createdAt, now)}
+                        </time>
+                      </td>
+                    </tr>
+                  ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {state.status === "ready" && state.hasMore ? (
+        <div className="agents-more">
+          <button className="btn" type="button" onClick={loadMore} disabled={more.busy}>
+            {more.busy ? "Loading…" : "Load more"}
+          </button>
+          {more.error ? <span className="agents-more-error">{more.error}</span> : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+/** Archive is the one terminal transition, so this is a state, not a toggle. */
+function Status({ archivedAt }: { archivedAt?: string }) {
+  return (
+    <span
+      className={archivedAt ? "pill pill-archived" : "pill pill-active"}
+      title={
+        archivedAt
+          ? `Archived ${absoluteTime(archivedAt)} — read-only, and no new session can use it`
+          : "Accepts updates and new sessions"
+      }
+    >
+      <span className="pill-dot" aria-hidden="true" />
+      {archivedAt ? "Archived" : "Active"}
+    </span>
+  );
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,8 +1,37 @@
+import { fileURLToPath } from "node:url";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import babel from "@rolldown/plugin-babel";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 
-// https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), babel({ presets: [reactCompilerPreset()] })],
+// The api has no CORS and is bearer-authed, so the browser never calls it
+// directly: the dev server proxies same-origin /v1 to it and adds the
+// Authorization header itself. The token is read from the MONOREPO ROOT
+// .env — the same file `docker compose up` reads, so there is no second
+// copy to keep in sync — and stays in this node process; it is never part
+// of the client bundle.
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+export default defineConfig(({ mode }) => {
+  // "" as the prefix: these are the stack's own variables, not VITE_ ones.
+  const env = loadEnv(mode, repoRoot, "");
+  const token = env.FUNKY_AUTH_TOKEN;
+
+  return {
+    plugins: [react(), babel({ presets: [reactCompilerPreset()] })],
+    server: {
+      proxy: {
+        "/v1": {
+          target: env.FUNKY_API_URL || "http://localhost:3000",
+          changeOrigin: true,
+          configure: (proxy) => {
+            proxy.on("proxyReq", (proxyReq) => {
+              // No token configured is a real state (FUNKY_AUTH=disabled):
+              // forward unauthenticated and let the api answer 401 if not.
+              if (token) proxyReq.setHeader("authorization", `Bearer ${token}`);
+            });
+          },
+        },
+      },
+    },
+  };
 });


### PR DESCRIPTION
The Agent section becomes a real page: the namespace's agent configs — id, model, status, created — newest first, each config shown once at the version the api's list route resolves, with loading, empty, and error states plus keyset paging through `lastId`. Being the first page that calls the api, it also lands the piece that makes any of them possible — the dev server proxies same-origin `/v1` to `FUNKY_API_URL` and injects the bearer token from the monorepo root `.env`, so the credential never enters the browser and the api needs no CORS (documented in `.env.example` and the web README); there is no api change of any kind. Rows reflow from a table into cards on a narrow pane, keyed to a container query on the *pane* rather than the window, since the sidebar takes 252px of it. Created ticks on a 30s clock (`src/lib/useNow.ts`) so a console left open doesn't freeze at "12 seconds ago", and an in-flight next page is cancelled on refresh so a superseded page can't append its rows or move the cursor. Verified against the running api at 390/560/768/1000/1280px in light and dark, with the pagination race reproduced in a browser and re-run against the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)