### PR TITLE
Add agent config creation to the console

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -16,7 +16,7 @@ pnpm -F web lint     # oxlint
 | `src/App.tsx`     | The shell: the sidebar beside one routed pane                        |
 | `src/nav.ts`      | Every section, in one list — the sidebar and the router both read it |
 | `src/lib/`        | What the console knows about the api it fronts                       |
-| `src/components/` | The shell's pieces (sidebar, icons)                                  |
+| `src/components/` | The shell's pieces (sidebar, icons, modal)                           |
 | `src/pages/`      | One module per section                                               |
 
 Routing is the URL hash (`#/agent`), so sections are linkable and the browser owns history —

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -74,6 +74,25 @@ export function RefreshIcon(props: SVGProps<SVGSVGElement>) {
   );
 }
 
+/** Create — the one action that adds a row to a list. */
+export function PlusIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <Stroke width={15} height={15} {...props}>
+      <path d="M12 5v14M5 12h14" />
+    </Stroke>
+  );
+}
+
+/** The affordance on a <select>, which draws no arrow of its own once its
+ *  native appearance is dropped for the shared control styling. */
+export function ChevronDownIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <Stroke width={14} height={14} {...props}>
+      <path d="M5.5 9 12 15.5 18.5 9" />
+    </Stroke>
+  );
+}
+
 /** Topbar docs link. */
 export function ExternalLinkIcon(props: SVGProps<SVGSVGElement>) {
   return (

--- a/apps/web/src/components/Modal.css
+++ b/apps/web/src/components/Modal.css
@@ -1,0 +1,133 @@
+/* apps/web/src/components/Modal.css
+   The dialog shell: the backdrop, the panel, and the three classes the
+   caller's body uses (.modal-form, .modal-body, .modal-foot). Every colour
+   resolves to a token in index.css. */
+
+/* The <dialog> element is the centring frame, not a surface: it is
+   transparent so .modal-panel is the only thing drawn, which also makes a
+   click on the dialog itself unambiguously a click on the backdrop. */
+.modal {
+  width: min(560px, 100% - 32px);
+  max-height: none;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--text);
+  overflow: visible;
+}
+
+.modal::backdrop {
+  background: rgba(8, 10, 20, 0.42);
+  backdrop-filter: blur(3px) saturate(0.9);
+}
+
+@media (prefers-color-scheme: dark) {
+  .modal::backdrop {
+    background: rgba(3, 4, 9, 0.62);
+  }
+}
+
+.modal[open] {
+  animation: modal-in 240ms var(--ease);
+}
+
+.modal[open]::backdrop {
+  animation: backdrop-in 240ms var(--ease);
+}
+
+/* The page behind a modal shouldn't scroll under it. */
+body:has(dialog.modal[open]) {
+  overflow: hidden;
+}
+
+.modal-panel {
+  display: flex;
+  flex-direction: column;
+  /* The panel — not the viewport — is what a long body scrolls inside. */
+  max-height: min(84svh, 760px);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--bg-elev);
+  box-shadow: var(--shadow-lg);
+}
+
+/* Head ------------------------------------------------------------------- */
+
+.modal-head {
+  flex: none;
+  padding: 20px 22px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.modal-title {
+  font-size: 16.5px;
+  font-weight: 600;
+  letter-spacing: -0.2px;
+  color: var(--text);
+}
+
+.modal-desc {
+  margin-top: 5px;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--text-3);
+}
+
+.modal-desc code {
+  font: 500 12px var(--mono);
+  color: var(--text-2);
+}
+
+/* Body ------------------------------------------------------------------- */
+
+/* min-height: 0 on both, or the scrolling body would refuse to shrink below
+   its content and push the footer off the panel instead. */
+.modal-form {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.modal-body {
+  min-height: 0;
+  overflow-y: auto;
+  padding: 18px 22px;
+  scrollbar-width: thin;
+}
+
+.modal-foot {
+  display: flex;
+  flex: none;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 14px 22px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-sunken);
+  border-radius: 0 0 calc(var(--r-lg) - 1px) calc(var(--r-lg) - 1px);
+}
+
+@keyframes modal-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px) scale(0.985);
+  }
+}
+
+@keyframes backdrop-in {
+  from {
+    opacity: 0;
+  }
+}
+
+/* Media, not @container as the pages use: a modal dialog lives in the top
+   layer, so its containing block is the viewport and the pane's width has
+   nothing to do with how much room it has. */
+@media (max-width: 560px) {
+  .modal-head,
+  .modal-body,
+  .modal-foot {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+}

--- a/apps/web/src/components/Modal.tsx
+++ b/apps/web/src/components/Modal.tsx
@@ -1,0 +1,110 @@
+// apps/web/src/components/Modal.tsx
+// A modal built on <dialog>, so the browser owns what a modal is: the focus
+// trap, the inert page behind it, Escape, and the top layer. Nothing here
+// re-implements any of that.
+//
+// The dialog's lifetime is the caller's state — it is mounted while open —
+// so this never lets the browser close it on its own. Escape is intercepted
+// and reported as onClose instead.
+//
+// Focus is handed back by hand. The browser restores it when a dialog in the
+// document closes, but by the time an unmount cleanup runs React has already
+// detached the node, so close() there restores nothing and focus falls to
+// <body>. The opener is captured on open and re-focused on unmount instead —
+// or, when what the dialog did removed the opener, `returnFocus`.
+//
+// The caller fills the body. Modal.css styles three classes for it to use:
+// .modal-form (the column), .modal-body (the scrolling part), .modal-foot
+// (the actions), plus [data-autofocus] to name where focus should land.
+import { type ReactNode, type RefObject, useEffect, useId, useRef } from "react";
+import "./Modal.css";
+
+export function Modal({
+  title,
+  description,
+  dismissible = true,
+  returnFocus,
+  onClose,
+  children,
+}: {
+  title: string;
+  /** One line under the title: what creating this actually does. */
+  description?: ReactNode;
+  /** False while the dialog owns something in flight — Escape and the
+   *  backdrop stop dismissing it, so a request can't lose its own result. */
+  dismissible?: boolean;
+  /** Where focus goes when the opener didn't survive what the dialog did —
+   *  a list's empty state, say, is replaced by the first row it creates. A
+   *  ref because the caller has no node to give at render time. */
+  returnFocus?: RefObject<HTMLElement | null>;
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  const ref = useRef<HTMLDialogElement>(null);
+  // Tracks whether the press that a click completes STARTED on the backdrop.
+  // A selection dragged out of a field ends there too, and that isn't a
+  // click on the backdrop.
+  const fromBackdrop = useRef(false);
+  const titleId = useId();
+
+  useEffect(() => {
+    const dialog = ref.current;
+    if (!dialog) return;
+    // Read before showModal() moves it: this is the button that was clicked.
+    const opener = document.activeElement;
+    // Read here rather than in the cleanup, where a ref's current value is
+    // no longer the one this effect was set up against. Nothing a dialog
+    // does re-mounts the node a caller nominated to outlive it, so the two
+    // are the same one — and isConnected below covers it if they aren't.
+    const fallback = returnFocus?.current;
+    // StrictMode runs this twice, and showModal() throws on an open dialog.
+    if (!dialog.open) dialog.showModal();
+    // showModal() otherwise focuses the first focusable descendant, which is
+    // whatever the layout happens to put first.
+    dialog.querySelector<HTMLElement>("[data-autofocus]")?.focus();
+    return () => {
+      dialog.close();
+      // isConnected, because the opener may be what the dialog replaced: an
+      // empty state's Create button is gone once the row it created is on
+      // the list. Focus a node no longer in the document and it lands on
+      // <body> anyway, so fall back to whatever the caller kept standing.
+      const back = opener instanceof HTMLElement && opener.isConnected ? opener : fallback;
+      if (back?.isConnected) back.focus();
+    };
+    // A ref's identity is stable, so this never re-runs; it is in the deps
+    // because the effect reads the prop, not because the prop can change.
+  }, [returnFocus]);
+
+  return (
+    <dialog
+      ref={ref}
+      className="modal"
+      aria-labelledby={titleId}
+      onCancel={(event) => {
+        // Escape. Closing is the caller's to do, so this only reports it.
+        event.preventDefault();
+        if (dismissible) onClose();
+      }}
+      onPointerDown={(event) => {
+        fromBackdrop.current = event.target === event.currentTarget;
+      }}
+      onClick={(event) => {
+        // The panel covers the dialog's whole content box, so the dialog
+        // itself is only ever the target of a click on its ::backdrop.
+        if (dismissible && fromBackdrop.current && event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div className="modal-panel">
+        <header className="modal-head">
+          <h2 className="modal-title" id={titleId}>
+            {title}
+          </h2>
+          {description ? <p className="modal-desc">{description}</p> : null}
+        </header>
+        {children}
+      </div>
+    </dialog>
+  );
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,7 +1,8 @@
 /* apps/web/src/index.css
-   Design tokens + reset for the Funky Console. Every surface, line, and
-   motion value in the app resolves to a token here so light and dark stay
-   in step and nothing hard-codes a colour. */
+   Design tokens, reset, and the one control shared app-wide (.btn) for the
+   Funky Console. Every surface, line, and motion value in the app resolves
+   to a token here so light and dark stay in step and nothing hard-codes a
+   colour. */
 
 :root {
   /* Surfaces */
@@ -25,6 +26,8 @@
   --accent: #1b45e8;
   --accent-2: #4d76ff;
   --saffron: #ffc531;
+  --accent-fill: #1b45e8;
+  --accent-fill-hover: #1739c4;
   --accent-soft: rgba(27, 69, 232, 0.08);
   --accent-line: rgba(27, 69, 232, 0.24);
   --accent-glow: rgba(27, 69, 232, 0.13);
@@ -34,6 +37,10 @@
      health signal, not a brand accent, so it does not borrow saffron. */
   --ok: #15a34a;
   --ok-glow: rgba(21, 163, 74, 0.2);
+
+  /* Red is likewise a signal, not a brand colour: it says the api refused,
+     and nothing else in the console is allowed to borrow it. */
+  --bad: #cf2a1e;
 
   --dot: rgba(16, 20, 38, 0.07);
 
@@ -81,6 +88,8 @@
     --accent: #829eff;
     --accent-2: #b6c6ff;
     --saffron: #ffc531;
+    --accent-fill: #2d55e6;
+    --accent-fill-hover: #3d67f5;
     --accent-soft: rgba(130, 158, 255, 0.13);
     --accent-line: rgba(130, 158, 255, 0.3);
     --accent-glow: rgba(45, 85, 230, 0.26);
@@ -88,6 +97,8 @@
 
     --ok: #4ade80;
     --ok-glow: rgba(74, 222, 128, 0.2);
+
+    --bad: #ff8f84;
 
     --dot: rgba(255, 255, 255, 0.055);
 
@@ -127,6 +138,59 @@ a {
 
 ::selection {
   background: var(--accent-soft);
+}
+
+/* Button ------------------------------------------------------------------
+   One pill, two weights: the default reads as secondary, .btn-primary as
+   the action a surface exists to perform. Shared by the pages and the
+   modal, so it sits here rather than in either. */
+
+.btn {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 14px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-elev);
+  font: 500 13px var(--sans);
+  color: var(--text-2);
+  cursor: pointer;
+  transition:
+    color var(--dur) var(--ease),
+    border-color var(--dur) var(--ease),
+    background-color var(--dur) var(--ease),
+    box-shadow var(--dur) var(--ease),
+    transform var(--dur) var(--ease);
+}
+
+.btn:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-sm);
+  transform: translateY(-1px);
+}
+
+.btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+/* Filled with the brand cobalt, which is dark in both schemes — so the
+   label is white in both, not var(--text). */
+.btn-primary {
+  border-color: transparent;
+  background: var(--accent-fill);
+  color: #ffffff;
+  box-shadow: 0 1px 2px var(--brand-shadow);
+}
+
+.btn-primary:hover:not(:disabled) {
+  border-color: transparent;
+  background: var(--accent-fill-hover);
+  color: #ffffff;
+  box-shadow: 0 6px 16px -6px var(--brand-shadow);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -73,7 +73,22 @@ async function failure(res: Response): Promise<ApiError> {
   );
 }
 
-async function get<T>(
+/** One call, with every failure already shaped: an abort stays an abort,
+ *  an unreachable api says so, and anything else carries the api's own
+ *  message (see failure()). */
+async function request<T>(path: string, init: RequestInit): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(path, { ...init, headers: { accept: "application/json", ...init.headers } });
+  } catch (cause) {
+    if (cause instanceof DOMException && cause.name === "AbortError") throw cause;
+    throw new ApiError(UNREACHABLE);
+  }
+  if (!res.ok) throw await failure(res);
+  return (await res.json()) as T;
+}
+
+function get<T>(
   path: string,
   params: Record<string, string | undefined>,
   signal?: AbortSignal,
@@ -82,16 +97,19 @@ async function get<T>(
   for (const [key, value] of Object.entries(params)) {
     if (value !== undefined) query.set(key, value);
   }
+  return request<T>(`${path}?${query}`, { signal });
+}
 
-  let res: Response;
-  try {
-    res = await fetch(`${path}?${query}`, { headers: { accept: "application/json" }, signal });
-  } catch (cause) {
-    if (cause instanceof DOMException && cause.name === "AbortError") throw cause;
-    throw new ApiError(UNREACHABLE);
-  }
-  if (!res.ok) throw await failure(res);
-  return (await res.json()) as T;
+function post<T>(path: string, body: unknown, signal?: AbortSignal): Promise<T> {
+  return request<T>(path, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    // JSON.stringify drops undefined properties, so an optional field left
+    // unset is absent from the body rather than sent as null — which is
+    // what the api's schemas mean by optional.
+    body: JSON.stringify(body),
+    signal,
+  });
 }
 
 /**
@@ -109,6 +127,29 @@ export function listAgentConfigs(
       limit: opts.limit === undefined ? undefined : String(opts.limit),
       after: opts.after,
     },
+    opts.signal,
+  );
+}
+
+/** The create body, minus the namespace this console pins for every call. */
+export type CreateAgentConfigInput = {
+  inference: InferenceConfig;
+  systemPrompt: string;
+  metadata?: unknown;
+};
+
+/**
+ * Creates an agent config and returns it at version 1. The namespace rides
+ * in the BODY here — the create route takes the core request as its wire
+ * shape — where the other routes take it as ?namespace=.
+ */
+export function createAgentConfig(
+  input: CreateAgentConfigInput,
+  opts: { signal?: AbortSignal } = {},
+): Promise<AgentConfig> {
+  return post<AgentConfig>(
+    "/v1/agent-configs",
+    { namespace: DEFAULT_NAMESPACE, ...input },
     opts.signal,
   );
 }

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -22,7 +22,11 @@ export function relativeTime(iso: string, now: number = Date.now()): string {
   const at = new Date(iso).getTime();
   if (Number.isNaN(at)) return iso;
 
-  let value = (at - now) / 1000; // negative = in the past
+  // Every timestamp here describes something that has already happened, so a
+  // positive delta is our clock being behind — a reader on a coarse tick, or
+  // skew against the api's — and never the future. Clamped to 0, which
+  // formats as "now"; the hover text still carries the exact instant.
+  let value = Math.min(at - now, 0) / 1000; // negative = in the past
   for (const [unit, per] of UNITS) {
     if (Math.abs(value) < per) return RELATIVE.format(Math.round(value), unit);
     value /= per;

--- a/apps/web/src/lib/providers.ts
+++ b/apps/web/src/lib/providers.ts
@@ -1,0 +1,57 @@
+// apps/web/src/lib/providers.ts
+// Which providers this console offers, and the models each one serves.
+//
+// A provider is offered only when TWO different things are true, and they
+// are worth keeping apart:
+//
+//  - There is a key for it. vite.config.ts reads the monorepo root .env when
+//    it starts and injects the ids it found a non-empty key for. Only the
+//    IDS cross into the bundle — no key value ever does, same rule as
+//    FUNKY_AUTH_TOKEN.
+//  - The worker can route to it. apps/worker/src/main.ts constructs ONE
+//    inference adapter at composition (`createAnthropic`), and the driver
+//    never reads config.inference.provider — "picked the adapter at
+//    composition and is not part of the request"
+//    (packages/agent/src/driver/loop.ts). A config naming a provider the
+//    worker didn't wire would still run on the one it did.
+//
+// The second fact is why this is a registry and not a scan of whatever keys
+// happen to be in .env: an entry here is a claim that the worker serves it.
+// Adding one is two changes, not one — wire the adapter in the worker's
+// composition root first, then add the entry.
+
+export type ProviderModel = { id: string; label: string };
+
+export type Provider = {
+  /** What lands in `inference.provider`. */
+  id: string;
+  label: string;
+  /** The env var the stack reads its key from; mirrored in vite.config.ts. */
+  envKey: string;
+  /** Newest of each tier. Ids are complete as written — no date suffix. */
+  models: ProviderModel[];
+};
+
+/** Every provider the worker can serve, key or no key. */
+export const KNOWN_PROVIDERS: Provider[] = [
+  {
+    id: "anthropic",
+    label: "Anthropic",
+    envKey: "ANTHROPIC_API_KEY",
+    models: [
+      { id: "claude-opus-5", label: "Claude Opus 5" },
+      { id: "claude-sonnet-5", label: "Claude Sonnet 5" },
+      { id: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
+    ],
+  },
+];
+
+// Replaced at build time by vite.config.ts (`define`), so this is a literal
+// array in the bundle rather than a lookup. Read once, at module load: the
+// dev server read .env once too, when it started.
+declare const __FUNKY_PROVIDERS__: string[];
+
+/** Those with a key configured — the ones a config can actually name. */
+export const PROVIDERS: Provider[] = KNOWN_PROVIDERS.filter((provider) =>
+  __FUNKY_PROVIDERS__.includes(provider.id),
+);

--- a/apps/web/src/pages/AgentConfigs.css
+++ b/apps/web/src/pages/AgentConfigs.css
@@ -40,37 +40,15 @@
   color: var(--text-2);
 }
 
-/* Button ----------------------------------------------------------------- */
+/* Actions ---------------------------------------------------------------- */
 
-.btn {
-  display: inline-flex;
+/* .btn itself lives in index.css — the modal uses it too, and a shared
+   control shouldn't be defined by one page's stylesheet. */
+.agents-actions {
+  display: flex;
   flex: none;
   align-items: center;
-  gap: 7px;
-  padding: 7px 14px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: var(--bg-elev);
-  font: 500 13px var(--sans);
-  color: var(--text-2);
-  cursor: pointer;
-  transition:
-    color var(--dur) var(--ease),
-    border-color var(--dur) var(--ease),
-    box-shadow var(--dur) var(--ease),
-    transform var(--dur) var(--ease);
-}
-
-.btn:hover:not(:disabled) {
-  color: var(--text);
-  border-color: var(--border-strong);
-  box-shadow: var(--shadow-sm);
-  transform: translateY(-1px);
-}
-
-.btn:disabled {
-  opacity: 0.55;
-  cursor: default;
+  gap: 10px;
 }
 
 /* Table ------------------------------------------------------------------ */

--- a/apps/web/src/pages/AgentConfigs.tsx
+++ b/apps/web/src/pages/AgentConfigs.tsx
@@ -11,7 +11,8 @@ import { useEffect, useRef, useState } from "react";
 import { type AgentConfig, listAgentConfigs } from "../lib/api";
 import { absoluteTime, relativeTime } from "../lib/format";
 import { useNow } from "../lib/useNow";
-import { AgentIcon, RefreshIcon } from "../components/Icons";
+import { AgentIcon, PlusIcon, RefreshIcon } from "../components/Icons";
+import { CreateAgentConfig } from "./CreateAgentConfig";
 import "./AgentConfigs.css";
 
 type State =
@@ -41,6 +42,11 @@ export function AgentConfigs() {
   // The in-flight next-page request, if any. Held so a reload can cancel
   // it: its rows belong to the walk being replaced, not to the new one.
   const pagination = useRef<AbortController | null>(null);
+  const [creating, setCreating] = useState(false);
+  // The header's Create button, which every state of this page renders. It
+  // is where the dialog puts focus back when what opened it was the empty
+  // state's button — the row it creates is what replaces that button.
+  const createButton = useRef<HTMLButtonElement>(null);
 
   // The reset lives here rather than in the effect: the click is what makes
   // this loading again, and the effect's job is only to fetch.
@@ -73,6 +79,23 @@ export function AgentConfigs() {
       pagination.current?.abort();
     };
   }, [reloads]);
+
+  // A new config is the newest, and this list is newest-first, so it goes on
+  // the front. The cursor is a keyset rather than an offset, so a row
+  // arriving at the head leaves the rest of the walk exactly where it was —
+  // there is nothing to re-fetch.
+  function added(config: AgentConfig) {
+    setCreating(false);
+    // Off the ready path there is no list to add it to; the load that was
+    // already needed is what will show it.
+    if (state.status !== "ready") {
+      reload();
+      return;
+    }
+    setState((prev) =>
+      prev.status === "ready" ? { ...prev, configs: [config, ...prev.configs] } : prev,
+    );
+  }
 
   // The next page, appended. `cursor` is the previous page's last id — the
   // keyset the api hands back, not an offset, so rows created meanwhile
@@ -109,15 +132,26 @@ export function AgentConfigs() {
     <section className="agents">
       <header className="agents-head">
         <h1 className="agents-title">Agent configs</h1>
-        <button
-          className="btn"
-          type="button"
-          onClick={reload}
-          disabled={state.status === "loading"}
-        >
-          <RefreshIcon />
-          Refresh
-        </button>
+        <div className="agents-actions">
+          <button
+            className="btn"
+            type="button"
+            onClick={reload}
+            disabled={state.status === "loading"}
+          >
+            <RefreshIcon />
+            Refresh
+          </button>
+          <button
+            className="btn btn-primary"
+            type="button"
+            ref={createButton}
+            onClick={() => setCreating(true)}
+          >
+            <PlusIcon />
+            Create
+          </button>
+        </div>
       </header>
 
       {state.status === "error" ? (
@@ -136,9 +170,13 @@ export function AgentConfigs() {
           </span>
           <p className="notice-title">No agent configs yet</p>
           <p className="notice-body">
-            A config is the model and system prompt a session runs with. Create one with{" "}
-            <code>POST /v1/agent-configs</code>.
+            A config is the model and system prompt a session runs with. Create the first one, or
+            post it yourself to <code>/v1/agent-configs</code>.
           </p>
+          <button className="btn btn-primary" type="button" onClick={() => setCreating(true)}>
+            <PlusIcon />
+            Create agent config
+          </button>
         </div>
       ) : (
         <div className="table-wrap">
@@ -192,6 +230,14 @@ export function AgentConfigs() {
           </table>
         </div>
       )}
+
+      {creating ? (
+        <CreateAgentConfig
+          onCreated={added}
+          onClose={() => setCreating(false)}
+          returnFocus={createButton}
+        />
+      ) : null}
 
       {state.status === "ready" && state.hasMore ? (
         <div className="agents-more">

--- a/apps/web/src/pages/CreateAgentConfig.css
+++ b/apps/web/src/pages/CreateAgentConfig.css
@@ -1,0 +1,161 @@
+/* apps/web/src/pages/CreateAgentConfig.css
+   The create form inside the modal shell (components/Modal.css owns the
+   panel, the scrolling body, and the footer). Every colour resolves to a
+   token in index.css. */
+
+/* The body as a column of fields. gap rather than margins, so spacing never
+   depends on which field happens to follow which. */
+.form-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+/* Two fields abreast where both are short, stacking when the panel is
+   narrow enough that a pair would squeeze each other. */
+.field-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 15px 14px;
+}
+
+@media (max-width: 480px) {
+  .field-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.field-label {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.field-optional {
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+
+/* Control ---------------------------------------------------------------- */
+
+.control {
+  width: 100%;
+  padding: 8px 11px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-sm);
+  background: var(--bg);
+  font: 400 13.5px var(--sans);
+  color: var(--text);
+  transition:
+    border-color var(--dur) var(--ease),
+    box-shadow var(--dur) var(--ease);
+}
+
+textarea.control {
+  /* Only vertically: a wider textarea would break the two-column grid. */
+  resize: vertical;
+  min-height: 62px;
+  line-height: 1.55;
+}
+
+/* Select ----------------------------------------------------------------- */
+
+/* The wrapper exists to position the arrow over the control; the select
+   fills it so the two share one box. */
+.select-wrap {
+  position: relative;
+  display: flex;
+}
+
+select.control {
+  appearance: none;
+  /* Room for the arrow, so a long label never runs under it. */
+  padding-right: 32px;
+  cursor: pointer;
+}
+
+.select-arrow {
+  position: absolute;
+  top: 50%;
+  right: 11px;
+  transform: translateY(-50%);
+  color: var(--text-3);
+  /* The arrow is the select's affordance, not a target of its own: a click
+     on it has to reach the control underneath. */
+  pointer-events: none;
+}
+
+.control::placeholder {
+  color: var(--text-3);
+}
+
+.control:hover:not(:focus) {
+  border-color: var(--text-3);
+}
+
+.control:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+
+/* No provider ------------------------------------------------------------ */
+
+.prose {
+  font-size: 13.5px;
+  line-height: 1.6;
+  color: var(--text-2);
+}
+
+.prose code,
+.key-list code {
+  padding: 1px 5px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-sunken);
+  font: 500 12px var(--mono);
+  color: var(--text);
+}
+
+.key-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 14px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.key-list li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.key-list span {
+  font-size: 12.5px;
+  color: var(--text-3);
+}
+
+/* Failure ---------------------------------------------------------------- */
+
+/* The api's own refusal, beside the actions that caused it. margin-right
+   takes the footer's spare width so the buttons stay right-aligned. */
+.form-failure {
+  margin-right: auto;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--bad);
+}

--- a/apps/web/src/pages/CreateAgentConfig.tsx
+++ b/apps/web/src/pages/CreateAgentConfig.tsx
@@ -1,0 +1,286 @@
+// apps/web/src/pages/CreateAgentConfig.tsx
+// The Create Agent dialog: the POST /v1/agent-configs body as a form.
+//
+// The form is the request's REQUIRED shape and nothing else: provider,
+// model, system prompt. The body's optional parts — maxTokens, temperature,
+// metadata — are left out and therefore left absent, which is what the api
+// reads as "the provider's own default" and "no metadata". They belong to a
+// config being tuned, not to one being made; POST the body directly, or
+// update the config afterwards, when that is what you want.
+//
+// Provider and model are both closed choices, and the model list is the
+// SELECTED provider's (see lib/providers.ts): a config's provider names what
+// will actually serve it, so the two cannot be set to disagree here. With no
+// provider key configured there is nothing truthful to offer, and the dialog
+// says that instead of taking a request the stack can't honour.
+//
+// Namespace is omitted for a different reason: the console addresses exactly
+// one (see DEFAULT_NAMESPACE in lib/api.ts) and has no switcher, so offering
+// the field would let a config land somewhere the list can't show it.
+import { type ChangeEvent, type FormEvent, type RefObject, useState } from "react";
+import {
+  type AgentConfig,
+  createAgentConfig,
+  type CreateAgentConfigInput,
+  DEFAULT_NAMESPACE,
+} from "../lib/api";
+import { KNOWN_PROVIDERS, type Provider, PROVIDERS } from "../lib/providers";
+import { ChevronDownIcon } from "../components/Icons";
+import { Modal } from "../components/Modal";
+import "./CreateAgentConfig.css";
+
+type Fields = {
+  provider: string;
+  model: string;
+  systemPrompt: string;
+};
+
+const messageOf = (err: unknown) => (err instanceof Error ? err.message : String(err));
+
+export function CreateAgentConfig({
+  onCreated,
+  onClose,
+  returnFocus,
+}: {
+  /** The new config, at version 1 — the caller puts it on the list. */
+  onCreated: (config: AgentConfig) => void;
+  onClose: () => void;
+  /** Focus lands here if creating the config removed whatever opened this
+   *  (Modal's `returnFocus`) — the first row replaces the empty state. */
+  returnFocus?: RefObject<HTMLElement | null>;
+}) {
+  // Both branches are dialogs, so which one opens is decided before either
+  // mounts — and the hooks live in the branch that needs them.
+  return PROVIDERS.length === 0 ? (
+    <NoProvider onClose={onClose} returnFocus={returnFocus} />
+  ) : (
+    <Form onCreated={onCreated} onClose={onClose} returnFocus={returnFocus} />
+  );
+}
+
+/** What there is to say when the stack has no key for any provider it can
+ *  serve: the form would only be able to offer a lie. */
+function NoProvider({
+  onClose,
+  returnFocus,
+}: {
+  onClose: () => void;
+  returnFocus?: RefObject<HTMLElement | null>;
+}) {
+  return (
+    <Modal
+      title="No provider configured"
+      description="A config names the provider that will run it, and the console offers only providers this stack has a key for."
+      returnFocus={returnFocus}
+      onClose={onClose}
+    >
+      <div className="modal-body">
+        <p className="prose">
+          Add a key to the monorepo root <code>.env</code> — the same file{" "}
+          <code>docker compose up</code> reads — then restart the dev server:
+        </p>
+        <ul className="key-list">
+          {KNOWN_PROVIDERS.map((provider) => (
+            <li key={provider.id}>
+              <code>{provider.envKey}</code>
+              <span>{provider.label}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <footer className="modal-foot">
+        <button className="btn" type="button" onClick={onClose} data-autofocus="">
+          Close
+        </button>
+      </footer>
+    </Modal>
+  );
+}
+
+function Form({
+  onCreated,
+  onClose,
+  returnFocus,
+}: {
+  onCreated: (config: AgentConfig) => void;
+  onClose: () => void;
+  returnFocus?: RefObject<HTMLElement | null>;
+}) {
+  // Non-empty by construction: CreateAgentConfig renders this branch only
+  // when there is a provider to start on.
+  const [fields, setFields] = useState<Fields>(() => onProvider(PROVIDERS[0], ""));
+  const [busy, setBusy] = useState(false);
+  // The api's refusal — a 400, or an api that isn't there. There is nothing
+  // for the fields themselves to refuse: every one of them is either a
+  // closed choice or free text the api takes as-is.
+  const [failure, setFailure] = useState<string>();
+
+  const provider = PROVIDERS.find((entry) => entry.id === fields.provider) ?? PROVIDERS[0];
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    if (busy) return;
+
+    const input: CreateAgentConfigInput = {
+      inference: { provider: fields.provider, model: fields.model },
+      systemPrompt: fields.systemPrompt,
+    };
+
+    setFailure(undefined);
+    setBusy(true);
+    try {
+      // No abort signal: a create in flight is a row that may well exist, so
+      // the dialog refuses to close (dismissible below) rather than walk
+      // away from an answer it would then have to guess at.
+      onCreated(await createAgentConfig(input));
+      // Created — the caller unmounts this, so there is no state to reset.
+    } catch (err) {
+      setFailure(messageOf(err));
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Modal
+      title="Create agent config"
+      description={
+        <>
+          The model and system prompt a session runs with. Lands as version 1 in the{" "}
+          <code>{DEFAULT_NAMESPACE}</code> namespace.
+        </>
+      }
+      dismissible={!busy}
+      returnFocus={returnFocus}
+      onClose={onClose}
+    >
+      <form className="modal-form" onSubmit={submit} noValidate>
+        <div className="modal-body form-fields">
+          <div className="field-row">
+            <Field
+              label="Provider"
+              name="provider"
+              value={fields.provider}
+              // Changing the provider changes the model with it: a Claude id
+              // under some other provider is the mismatch these two closed
+              // lists exist to make unrepresentable.
+              onChange={(id) => setFields(onProvider(byId(id), fields.systemPrompt))}
+              options={PROVIDERS.map((entry) => ({ id: entry.id, label: entry.label }))}
+              autoFocus
+              required
+            />
+            <Field
+              label="Model"
+              name="model"
+              value={fields.model}
+              onChange={(model) => setFields((prev) => ({ ...prev, model }))}
+              options={provider.models}
+              required
+            />
+          </div>
+
+          <Field
+            label="System prompt"
+            name="systemPrompt"
+            value={fields.systemPrompt}
+            onChange={(systemPrompt) => setFields((prev) => ({ ...prev, systemPrompt }))}
+            placeholder="You are a data analyst."
+            rows={6}
+            multiline
+          />
+        </div>
+
+        <footer className="modal-foot">
+          {failure ? (
+            <p className="form-failure" role="alert">
+              {failure}
+            </p>
+          ) : null}
+          <button className="btn" type="button" onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+          <button className="btn btn-primary" type="submit" disabled={busy}>
+            {busy ? "Creating…" : "Create"}
+          </button>
+        </footer>
+      </form>
+    </Modal>
+  );
+}
+
+/** A provider by id, falling back to the first — an id the select didn't
+ *  render can't be chosen, so the fallback is for types, not for users. */
+const byId = (id: string): Provider => PROVIDERS.find((entry) => entry.id === id) ?? PROVIDERS[0];
+
+/** The fields as they are on a provider: its first model, since the one that
+ *  was selected belonged to whichever provider is being left. */
+const onProvider = (provider: Provider, systemPrompt: string): Fields => ({
+  provider: provider.id,
+  model: provider.models[0].id,
+  systemPrompt,
+});
+
+/** One labelled control — a select when `options`, a textarea when
+ *  `multiline`, an input otherwise. Nothing sits under it: the label says
+ *  what the field is, and a form of three says the rest by being three. */
+function Field({
+  label,
+  name,
+  value,
+  onChange,
+  options,
+  multiline,
+  autoFocus,
+  ...control
+}: {
+  label: string;
+  name: string;
+  value: string;
+  onChange: (value: string) => void;
+  /** Turns the field into a closed choice; the id is the stored value. */
+  options?: Array<{ id: string; label: string }>;
+  multiline?: boolean;
+  autoFocus?: boolean;
+  rows?: number;
+  placeholder?: string;
+  required?: boolean;
+}) {
+  const props = {
+    id: name,
+    name,
+    value,
+    className: "control",
+    // Modal focuses this on open rather than React on mount: the dialog
+    // moves focus itself when it opens, and would move it right back off.
+    "data-autofocus": autoFocus ? "" : undefined,
+    onChange: (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
+      onChange(event.target.value),
+    ...control,
+  };
+
+  return (
+    <div className="field">
+      <label className="field-label" htmlFor={name}>
+        {label}
+        {control.required ? null : <span className="field-optional">optional</span>}
+      </label>
+      {options ? (
+        // The arrow is ours: dropping the native appearance for the shared
+        // control styling takes the platform's with it.
+        <span className="select-wrap">
+          <select {...props}>
+            {options.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <ChevronDownIcon className="select-arrow" />
+        </span>
+      ) : multiline ? (
+        <textarea {...props} />
+      ) : (
+        <input {...props} />
+      )}
+    </div>
+  );
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -11,13 +11,30 @@ import { defineConfig, loadEnv } from "vite";
 // of the client bundle.
 const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 
+// Which providers the stack has a key for. Mirrors the `envKey` of each
+// entry in src/lib/providers.ts, keyed by the same id — that file owns the
+// labels and models, this owns where the key is read from, and neither can
+// offer a provider the other doesn't know. Kept as its own table rather than
+// imported because tsconfig.node.json's program is just this file.
+const PROVIDER_ENV_KEYS: Record<string, string> = {
+  anthropic: "ANTHROPIC_API_KEY",
+};
+
 export default defineConfig(({ mode }) => {
   // "" as the prefix: these are the stack's own variables, not VITE_ ones.
   const env = loadEnv(mode, repoRoot, "");
   const token = env.FUNKY_AUTH_TOKEN;
 
+  // The ids only — a key's VALUE never leaves this process, and a key that
+  // is present but empty (as .env.example ships it) is not a key. Read once,
+  // here: adding a key to .env takes a dev-server restart to show up.
+  const providers = Object.entries(PROVIDER_ENV_KEYS)
+    .filter(([, key]) => (env[key] ?? "").trim() !== "")
+    .map(([id]) => id);
+
   return {
     plugins: [react(), babel({ presets: [reactCompilerPreset()] })],
+    define: { __FUNKY_PROVIDERS__: JSON.stringify(providers) },
     server: {
       proxy: {
         "/v1": {


### PR DESCRIPTION
Adds a **Create** button to the console's Agent page, opening a modal over `POST /v1/agent-configs` with provider, model, and system prompt — the body's optional parts (`maxTokens`, `temperature`, `metadata`) are left absent, so the api reads them as the provider's own defaults.

Provider and model are both closed choices and the model list belongs to the selected provider, because `inference.provider` is a label rather than a route — the worker constructs one adapter at composition and the driver never reads it — so offering a provider the worker cannot serve would make configs that lie about what runs them; `vite.config.ts` reads the monorepo root `.env` and injects the ids of providers with a non-empty key (ids only, no value reaches the bundle), and `src/lib/providers.ts` is the registry where an entry is a claim that the worker serves it, so with no key configured the dialog says so instead of taking the request.

`components/Modal.tsx` wraps the native `<dialog>` so the browser owns the focus trap, the top layer, and Escape, with focus handed back to the opener by hand — React detaches the node before the unmount cleanup runs, so `close()` there restores nothing — falling back to the header's Create button when creating the first config removes the empty-state opener.

Also moves the shared `.btn` into `index.css` now that the modal uses it too, and clamps `relativeTime`: an api timestamp is never in the future, so a positive delta is a stale clock rather than "in 27 seconds".

Verified with `pnpm typecheck`, `pnpm -F web lint`, `prettier --check .`, and `pnpm -F web build`; creates were exercised against a live api through the dev proxy, and provider injection was checked in the built bundle both with and without the key. The focus-return path is reasoned rather than observed — there was no browser tooling in this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)