### PR TITLE
Make agent configs archivable from the console

### DIFF
--- a/apps/web/src/components/Modal.css
+++ b/apps/web/src/components/Modal.css
@@ -158,3 +158,36 @@ body:has(dialog.modal[open]) {
     padding-right: 16px;
   }
 }
+
+/* Its own threshold, not the padding one above: a row of buttons has no
+   give — .btn is flex: none and this row does not wrap — so the widest
+   footer in the console (Archive + Cancel + "Save as version 12", ~316px
+   of buttons and gaps) needs about 380px of viewport before it stops
+   fitting. Below that the row overflows, and since it is justified to
+   flex-end the overflow leaves by the LEFT edge, taking whichever button
+   leads the footer off the panel with it. 440px keeps a margin over the
+   380 without stacking footers that still had room.
+
+   column-reverse rather than column: source order leads with the least-used
+   action (the one the row wants on the left), which is the last place it
+   belongs in a thumb-ordered column. */
+@media (max-width: 440px) {
+  .modal-foot {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  /* Stretched, so the label needs telling where to sit — a content-width
+     pill never had to say. */
+  .modal-foot .btn {
+    justify-content: center;
+  }
+
+  /* The api's refusal reads above the buttons, not between them: highest
+     order is topmost under column-reverse. Its auto margin has no free
+     space to take in a stretched column, so it goes too. */
+  .modal-foot .form-failure {
+    order: 1;
+    margin-right: 0;
+  }
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -38,8 +38,10 @@
   --ok: #15a34a;
   --ok-glow: rgba(21, 163, 74, 0.2);
 
-  /* Red is likewise a signal, not a brand colour: it says the api refused,
-     and nothing else in the console is allowed to borrow it. */
+  /* Red is likewise a signal, not a brand colour, and it carries exactly
+     two meanings: the api refused, and this action destroys something.
+     Nothing decorative may borrow it. Text-only by design — it is never a
+     fill, so it always reads against a surface, never under a label. */
   --bad: #cf2a1e;
 
   --dot: rgba(16, 20, 38, 0.07);
@@ -98,6 +100,7 @@
     --ok: #4ade80;
     --ok-glow: rgba(74, 222, 128, 0.2);
 
+    /* Lightened for the dark background, the same way --accent is. */
     --bad: #ff8f84;
 
     --dot: rgba(255, 255, 255, 0.055);
@@ -142,8 +145,10 @@ a {
 
 /* Button ------------------------------------------------------------------
    One pill, two weights: the default reads as secondary, .btn-primary as
-   the action a surface exists to perform. Shared by the pages and the
-   modal, so it sits here rather than in either. */
+   the action a surface exists to perform. A destructive action stays on the
+   default weight and says so in var(--bad) instead (see .btn-archive) — the
+   filled red was tried and cut, because it out-shouted the Save beside it.
+   Shared by the pages and the modal, so it sits here rather than in either. */
 
 .btn {
   display: inline-flex;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -208,3 +208,25 @@ export function updateAgentConfig(
     opts.signal,
   );
 }
+
+/**
+ * Archives a config and returns it carrying the mark. Terminal, and the
+ * api has no route back: the row stays readable at every version and the
+ * sessions that already pinned one keep running, but it takes no further
+ * update and no new session can name it. Idempotent by consequence — a
+ * second call answers with the first one's archivedAt rather than failing.
+ */
+export function archiveAgentConfig(
+  id: string,
+  opts: { signal?: AbortSignal } = {},
+): Promise<AgentConfig> {
+  return post<AgentConfig>(
+    `/v1/agent-configs/${encodeURIComponent(id)}/archive`,
+    // No body, because the route takes none — there is nothing to say
+    // beyond "retire this". JSON.stringify(undefined) is undefined, which
+    // fetch sends as no body at all.
+    undefined,
+    { namespace: DEFAULT_NAMESPACE },
+    opts.signal,
+  );
+}

--- a/apps/web/src/pages/AgentConfigs.tsx
+++ b/apps/web/src/pages/AgentConfigs.tsx
@@ -121,10 +121,10 @@ export function AgentConfigs({ route }: PageProps) {
     window.dispatchEvent(new HashChangeEvent("hashchange"));
   }
 
-  // An update lands as a new version of the same config, so the row is
-  // replaced where it is: this list is ordered by creation, which an edit
-  // does not change.
-  function saved(config: AgentConfig) {
+  // An update lands as a new version of the same config and an archive
+  // marks that same config terminal, so either way the row is replaced
+  // where it is: this list is ordered by creation, which neither changes.
+  function changed(config: AgentConfig) {
     setState((prev) =>
       prev.status === "ready"
         ? { ...prev, configs: prev.configs.map((c) => (c.id === config.id ? config : c)) }
@@ -302,7 +302,7 @@ export function AgentConfigs({ route }: PageProps) {
           key={route}
           id={route}
           config={editing}
-          onSaved={saved}
+          onChanged={changed}
           onClose={closeEditor}
           returnFocus={createButton}
         />

--- a/apps/web/src/pages/EditAgentConfig.css
+++ b/apps/web/src/pages/EditAgentConfig.css
@@ -27,3 +27,42 @@
   background: var(--bg-sunken);
   font-size: 12.5px;
 }
+
+/* Archive is the footer's left-hand action, so the two buttons that answer
+   the form — Cancel and Save — stay together on the right, and the one that
+   ends the config isn't sitting among them.
+
+   Red in the label, not in a fill: this button archives on the click, but a
+   filled red beside the filled cobalt Save would fight it, and the
+   destructive one is the wrong one to win. The hue is the warning. */
+.btn-archive {
+  margin-right: auto;
+  color: var(--bad);
+}
+
+/* .btn's hover resolves the label to var(--text), which would drop the one
+   thing this button says about itself. The surface is left alone, so the
+   label holds 5.25:1 (light) / 8.02:1 (dark) in every state. */
+.btn-archive:hover:not(:disabled) {
+  color: var(--bad);
+  border-color: var(--bad);
+}
+
+/* Modal.css gives .form-failure the auto margin that pushes it left. With
+   an Archive button already taking the footer's spare width there is none
+   left to share, and the refusal belongs beside the action that caused it
+   rather than spread away from it. */
+.btn-archive ~ .form-failure {
+  margin-right: 0;
+}
+
+/* Modal.css stacks the footer below 440px and stretches every button. An
+   auto margin in the cross axis takes precedence over align-items, so
+   leaving this one would strand Archive at content width beside two
+   full-width buttons — the placement it buys is a row concept only. Keep
+   this threshold in step with that one. */
+@media (max-width: 440px) {
+  .btn-archive {
+    margin-right: 0;
+  }
+}

--- a/apps/web/src/pages/EditAgentConfig.tsx
+++ b/apps/web/src/pages/EditAgentConfig.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/pages/EditAgentConfig.tsx
 // The Edit Agent dialog, at `#/agent/<id>`: the same three fields the create
-// dialog writes, over POST /v1/agent-configs/:id.
+// dialog writes, over POST /v1/agent-configs/:id — plus Archive, the one
+// action on a config that isn't an edit.
 //
 // Two things the api's update semantics dictate, both load-bearing:
 //
@@ -15,10 +16,13 @@
 //
 // An archived config is read-only — the store matches no mutation against
 // it — so the dialog shows it and says so rather than offering a Save the
-// api would refuse.
+// api would refuse. Archiving is what puts a config there, and it archives
+// on the click: no confirmation step, so the red label on its button is the
+// whole of the warning.
 import { type FormEvent, type RefObject, useEffect, useState } from "react";
 import {
   type AgentConfig,
+  archiveAgentConfig,
   getAgentConfig,
   type UpdateAgentConfigInput,
   updateAgentConfig,
@@ -55,7 +59,7 @@ function withCurrent(options: FieldOption[], current: string): FieldOption[] {
 export function EditAgentConfig({
   id,
   config,
-  onSaved,
+  onChanged,
   onClose,
   returnFocus,
 }: {
@@ -63,7 +67,10 @@ export function EditAgentConfig({
   /** The row, when the list already has it. Absent on a deep link into a
    *  page the walk hasn't reached, which is what the fetch below is for. */
   config?: AgentConfig;
-  onSaved: (config: AgentConfig) => void;
+  /** The config as the api now holds it — a new version after a save, the
+   *  same one carrying its mark after an archive. Either way the caller's
+   *  row is stale and this is what replaces it. */
+  onChanged: (config: AgentConfig) => void;
   onClose: () => void;
   returnFocus?: RefObject<HTMLElement | null>;
 }) {
@@ -108,7 +115,7 @@ export function EditAgentConfig({
   return (
     <EditForm
       config={loaded}
-      onSaved={onSaved}
+      onChanged={onChanged}
       onClose={onClose}
       returnFocus={returnFocus}
       // A save replaces the config the form was built from, so the form
@@ -120,18 +127,22 @@ export function EditAgentConfig({
 
 function EditForm({
   config,
-  onSaved,
+  onChanged,
   onClose,
   returnFocus,
 }: {
   config: AgentConfig;
-  onSaved: (config: AgentConfig) => void;
+  onChanged: (config: AgentConfig) => void;
   onClose: () => void;
   returnFocus?: RefObject<HTMLElement | null>;
 }) {
   const [fields, setFields] = useState<Fields>(() => fieldsOf(config));
-  const [busy, setBusy] = useState(false);
   const [failure, setFailure] = useState<string>();
+  // WHICH write is in flight, not merely whether one is. The two paths out
+  // of this dialog are mutually exclusive and every control is disabled by
+  // either, so one value says it — and each button can still name its own.
+  const [pending, setPending] = useState<"saving" | "archiving">();
+  const busy = pending !== undefined;
 
   const archived = config.archivedAt !== undefined;
   const saved = fieldsOf(config);
@@ -182,12 +193,27 @@ function EditForm({
     };
 
     setFailure(undefined);
-    setBusy(true);
+    setPending("saving");
     try {
-      onSaved(await updateAgentConfig(config.id, input));
+      onChanged(await updateAgentConfig(config.id, input));
     } catch (err) {
       setFailure(messageOf(err));
-      setBusy(false);
+      setPending(undefined);
+    }
+  }
+
+  // The terminal transition, taken on the click. It reaches the api the
+  // same way a save does — and reports a refusal in the same place — but
+  // it costs no version and, unlike a save, it cannot be revisited.
+  async function archive() {
+    if (busy || archived) return;
+    setFailure(undefined);
+    setPending("archiving");
+    try {
+      onChanged(await archiveAgentConfig(config.id));
+    } catch (err) {
+      setFailure(messageOf(err));
+      setPending(undefined);
     }
   }
 
@@ -252,7 +278,15 @@ function EditForm({
           />
         </div>
 
+        {/* Archive sits away from the two buttons that answer the form:
+            it is the one action here that doesn't write a version, and
+            the one with nothing on the other side of it. */}
         <footer className="modal-foot">
+          {archived ? null : (
+            <button className="btn btn-archive" type="button" onClick={archive} disabled={busy}>
+              {pending === "archiving" ? "Archiving…" : "Archive"}
+            </button>
+          )}
           {failure ? (
             <p className="form-failure" role="alert">
               {failure}
@@ -263,7 +297,7 @@ function EditForm({
           </button>
           {archived ? null : (
             <button className="btn btn-primary" type="submit" disabled={busy || !changed}>
-              {busy ? "Saving…" : `Save as version ${config.version + 1}`}
+              {pending === "saving" ? "Saving…" : `Save as version ${config.version + 1}`}
             </button>
           )}
         </footer>


### PR DESCRIPTION
The Agent edit dialog gets an Archive button over `POST /v1/agent-configs/:id/archive` — that endpoint was already implemented and tested on the api, and the list already rendered an Active/Archived pill, so the console simply had no way to reach it (no api, core or adapter changes here). Archive is terminal and the api has no route back, so the button says so in `var(--bad)` rather than behind a confirmation step, which widens a rule `index.css` stated explicitly: red now carries both "the api refused" and "this action destroys something" — a filled-red weight was tried and cut for out-shouting the Save beside it. `busy` becomes `pending: "saving" | "archiving"` so each button names its own in-flight state instead of archiving making Save read "Saving…", and the dialog's callback is `onChanged` rather than `onSaved`, since an archive replaces the caller's row without writing a version. `Modal.css` also gains a stacked footer below 440px: a footer row has no give — `.btn` is `flex: none` and `.modal-foot` does not wrap — so three buttons plus "Save as version 12" outran the 256px a 320px screen leaves, and because the row is justified to `flex-end` the overflow left by the *left* edge, carrying Archive off the panel.

Verified: build, lint, typecheck and prettier pass, and the create → archive round trip was exercised against a live api (200 with `archivedAt`, idempotent on repeat, 409 on a subsequent update). Not verified visually — there was no browser available in this session, so the narrow-viewport footer is reasoned from the box model and confirmed in the compiled CSS rather than observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)