### PR TITLE
Route inference on the config's provider through a driver registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,7 @@ scheduler; nothing else changes.
 ### Other model providers
 
 Inference goes through the [Vercel AI SDK](https://ai-sdk.dev) behind a vendor-neutral
-port — one adapter, any AI SDK provider. The shipped stack wires Anthropic; to run on
-another vendor, swap the provider factory in the worker's composition root
-([`apps/worker/src/main.ts`](apps/worker/src/main.ts)) — `createOpenAI` fits exactly where
-`createAnthropic` sits — and supply that vendor's key instead.
+port — one adapter, any AI SDK provider.
 
 ## Why Funky?
 

--- a/apps/web/src/lib/providers.ts
+++ b/apps/web/src/lib/providers.ts
@@ -8,12 +8,12 @@
 //    it starts and injects the ids it found a non-empty key for. Only the
 //    IDS cross into the bundle — no key value ever does, same rule as
 //    FUNKY_AUTH_TOKEN.
-//  - The worker can route to it. apps/worker/src/main.ts constructs ONE
-//    inference adapter at composition (`createAnthropic`), and the driver
-//    never reads config.inference.provider — "picked the adapter at
-//    composition and is not part of the request"
-//    (packages/agent/src/driver/loop.ts). A config naming a provider the
-//    worker didn't wire would still run on the one it did.
+//  - The worker can route to it. apps/worker/src/main.ts wires one
+//    inference adapter per vendor into a registry keyed by provider id,
+//    and the driver resolves config.inference.provider against it on
+//    every claim (packages/agent/src/driver/loop.ts). A config naming a
+//    provider the worker didn't wire ends its run in error — it never
+//    runs on some other vendor.
 //
 // The second fact is why this is a registry and not a scan of whatever keys
 // happen to be in .env: an entry here is a claim that the worker serves it.

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -33,9 +33,15 @@ const sandboxes = createE2bProvider({ apiKey: cfg.e2bApiKey });
 
 const deps: DriverDeps = {
   store,
-  provider: createAiSdkProvider({
-    languageModel: createAnthropic({ apiKey: cfg.anthropicApiKey }),
-  }),
+  // The registry the driver routes each claim's `inference.provider`
+  // on: its keys are the providers this worker serves. Anthropic only,
+  // today — a second vendor is a second entry and its key.
+  providers: new Map([
+    [
+      "anthropic",
+      createAiSdkProvider({ languageModel: createAnthropic({ apiKey: cfg.anthropicApiKey }) }),
+    ],
+  ]),
   toolSpecs: sandboxToolSpecs,
   // Ensure-on-claim: the loop calls this only for an execute_tools item
   // that will actually execute. The sandbox recipe is the snapshot the
@@ -53,5 +59,8 @@ const deps: DriverDeps = {
   },
 };
 
-console.log(`worker: claiming (lease=${cfg.leaseMs}ms idlePoll=${cfg.idlePollMs}ms)`);
+console.log(
+  `worker: claiming (providers=${[...deps.providers.keys()].join(",")} ` +
+    `lease=${cfg.leaseMs}ms idlePoll=${cfg.idlePollMs}ms)`,
+);
 await runDriver(deps, { leaseMs: cfg.leaseMs, idlePollMs: cfg.idlePollMs });

--- a/packages/adapters/test/crash-resume.test.ts
+++ b/packages/adapters/test/crash-resume.test.ts
@@ -85,7 +85,7 @@ async function driveToIdle(store: Store): Promise<void> {
   const tools = createTools();
   const deps: StepDeps = {
     store,
-    provider: createProvider(),
+    providers: new Map([[inferenceConfig.provider, createProvider()]]),
     toolSpecs: [...tools.values()].map(toToolSpec),
   };
   for (;;) {

--- a/packages/adapters/test/driver.test.ts
+++ b/packages/adapters/test/driver.test.ts
@@ -132,10 +132,15 @@ const inferenceConfig = {
   temperature: 0.2,
 };
 
-async function newSession(): Promise<SessionRef> {
+/** The registry as a worker wires it: this adapter under the id the
+ *  config names, and nothing else. */
+const serving = (provider: InferenceProvider): ReadonlyMap<string, InferenceProvider> =>
+  new Map([[inferenceConfig.provider, provider]]);
+
+async function newSession(inference = inferenceConfig): Promise<SessionRef> {
   const agentConfigRef = await store.createAgentConfig({
     namespace: DEFAULT_NAMESPACE,
-    inference: inferenceConfig,
+    inference,
     systemPrompt: "be brief",
   });
   const envConfigRef = await store.createEnvConfig({ namespace: DEFAULT_NAMESPACE });
@@ -181,7 +186,7 @@ describe("driver steps over the pg store", () => {
     const provider = scriptedProvider([callEcho("hi"), sayText("done!")]);
     const deps: StepDeps = {
       store,
-      provider,
+      providers: serving(provider),
       toolSpecs: [...echoOnly.values()].map(toToolSpec),
     };
 
@@ -223,7 +228,11 @@ describe("driver steps over the pg store", () => {
     expect(queued.kind).toBe("queued");
 
     const provider = scriptedProvider([sayText("ok")]);
-    await runStep({ store, provider, toolSpecs: [] }, await claim(sessionRef), 60_000);
+    await runStep(
+      { store, providers: serving(provider), toolSpecs: [] },
+      await claim(sessionRef),
+      60_000,
+    );
 
     // Steering shaped the context (appended at the tail)…
     expect(provider.requests[0]?.context.map((m) => m.role)).toEqual(["user", "user"]);
@@ -244,7 +253,7 @@ describe("driver steps over the pg store", () => {
       [...sayText("first").slice(0, 3), { wait: gate.promise }, sayText("first")[3] as Step],
       sayText("second"),
     ]);
-    const deps: StepDeps = { store, provider, toolSpecs: [] };
+    const deps: StepDeps = { store, providers: serving(provider), toolSpecs: [] };
 
     const inFlight = runStep(deps, await claim(sessionRef), 60_000);
     // Arrive after run 1's inference prep: too late to steer this step.
@@ -272,7 +281,7 @@ describe("driver steps over the pg store", () => {
     expect(queued.kind).toBe("queued");
 
     const provider = scriptedProvider([sayText("fresh")]);
-    const deps: StepDeps = { store, provider, toolSpecs: [] };
+    const deps: StepDeps = { store, providers: serving(provider), toolSpecs: [] };
     await runStep(deps, await claim(sessionRef), 60_000);
 
     // The run ended without inference, appending nothing; the queued
@@ -296,12 +305,43 @@ describe("driver steps over the pg store", () => {
     const sessionRef = await newSession();
     await store.intake(sessionRef, user("go"));
     const provider = scriptedProvider([[{ throw: new Error("provider exploded") }]]);
-    await runStep({ store, provider, toolSpecs: [] }, await claim(sessionRef), 60_000);
+    await runStep(
+      { store, providers: serving(provider), toolSpecs: [] },
+      await claim(sessionRef),
+      60_000,
+    );
 
     const log = messages(await store.readEntries(sessionRef));
     expect(log).toHaveLength(2);
     expect(log[1]).toMatchObject({ role: "assistant", stopReason: "error" });
     expect(provider.requests).toHaveLength(1);
+    expect(await store.claimItem({ leaseMs: 60_000, session: sessionRef })).toBeUndefined();
+  });
+
+  it("commits an error and ends the run when the config names a provider this worker does not serve", async () => {
+    const sessionRef = await newSession({ ...inferenceConfig, provider: "elsewhere" });
+    await store.intake(sessionRef, user("go"));
+    const provider = scriptedProvider([sayText("never asked")]);
+    await runStep(
+      { store, providers: serving(provider), toolSpecs: [] },
+      await claim(sessionRef),
+      60_000,
+    );
+
+    // The step's own outcome, committed — not routed to whatever IS wired,
+    // and not left uncommitted for the next claimer to refuse again.
+    const log = messages(await store.readEntries(sessionRef));
+    expect(log).toHaveLength(2);
+    expect(log[1]).toMatchObject({
+      role: "assistant",
+      content: [],
+      model: inferenceConfig.model,
+      stopReason: "error",
+      errorMessage: expect.stringContaining('"elsewhere"'),
+    });
+    // …and the message names what this worker would have served.
+    expect(log[1]).toMatchObject({ errorMessage: expect.stringContaining("scripted") });
+    expect(provider.requests).toHaveLength(0);
     expect(await store.claimItem({ leaseMs: 60_000, session: sessionRef })).toBeUndefined();
   });
 
@@ -316,7 +356,11 @@ describe("driver steps over the pg store", () => {
         return echo.execute(args, ctx);
       },
     };
-    const deps: StepDeps = { store, provider, toolSpecs: [...echoOnly.values()].map(toToolSpec) };
+    const deps: StepDeps = {
+      store,
+      providers: serving(provider),
+      toolSpecs: [...echoOnly.values()].map(toToolSpec),
+    };
 
     await store.intake(sessionRef, user("go"));
     await runStep(deps, await claim(sessionRef), 60_000); // inference → tool call
@@ -350,7 +394,7 @@ describe("driver steps over the pg store", () => {
     const sessionRef = await newSession();
     await store.intake(sessionRef, user("go"));
     const provider = scriptedProvider([sayText("later")]);
-    const deps: StepDeps = { store, provider, toolSpecs: [] };
+    const deps: StepDeps = { store, providers: serving(provider), toolSpecs: [] };
 
     // The lease dies between claim and runStep — the window the loop's
     // sandbox bind occupies. The awaited first beat must catch it.
@@ -372,7 +416,7 @@ describe("driver steps over the pg store", () => {
     const sessionRef = await newSession();
     await store.intake(sessionRef, user("go"));
     const provider = scriptedProvider([["untilAborted"], sayText("recovered")]);
-    const deps: StepDeps = { store, provider, toolSpecs: [] };
+    const deps: StepDeps = { store, providers: serving(provider), toolSpecs: [] };
 
     const inFlight = runStep(deps, await claim(sessionRef, 500), 500);
     await until(() => provider.requests.length === 1);
@@ -406,7 +450,7 @@ describe("driver steps over the pg store", () => {
     };
 
     const provider = scriptedProvider([sayText("a"), sayText("b")]);
-    const deps: StepDeps = { store: fencingStore, provider, toolSpecs: [] };
+    const deps: StepDeps = { store: fencingStore, providers: serving(provider), toolSpecs: [] };
 
     // First step's commit is fenced: runStep swallows it and drops the work.
     await runStep(deps, await claim(sessionRef, 300), 300);

--- a/packages/adapters/test/fixtures/crash-driver.ts
+++ b/packages/adapters/test/fixtures/crash-driver.ts
@@ -11,7 +11,13 @@ import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
 import { type DriverDeps, runDriver, type Store, toToolSpec } from "@funky/agent";
 import { createPgStore, type StoreDb } from "../../src";
-import { createProvider, createTools, type KillSpec, stallForever } from "./crash-script";
+import {
+  createProvider,
+  createTools,
+  inferenceConfig,
+  type KillSpec,
+  stallForever,
+} from "./crash-script";
 
 const dataDir = process.env["CRASH_DATA_DIR"];
 if (!dataDir) throw new Error("crash-driver: CRASH_DATA_DIR is required");
@@ -56,7 +62,7 @@ const wrapped: Store = {
 const tools = createTools({ spec, onStall });
 const deps: DriverDeps = {
   store: wrapped,
-  provider: createProvider({ spec, onStall }),
+  providers: new Map([[inferenceConfig.provider, createProvider({ spec, onStall })]]),
   toolSpecs: [...tools.values()].map(toToolSpec),
   bindTools: async () => tools,
 };

--- a/packages/agent/src/driver/loop.ts
+++ b/packages/agent/src/driver/loop.ts
@@ -30,6 +30,8 @@
 
 import type {
   AgentMessage,
+  AssistantMessage,
+  InferenceConfig,
   ProviderEvent,
   SessionEntry,
   SessionRef,
@@ -55,7 +57,11 @@ import {
  *  bound map as an argument, because binding is the loop's job. */
 export interface StepDeps {
   store: Store;
-  provider: InferenceProvider;
+  /** The inference adapters this worker wired, keyed by the id a
+   *  config's `inference.provider` names. Resolved per claim, so
+   *  sessions on one worker run on different vendors; the keys are the
+   *  whole of what this worker serves (see unservedProvider). */
+  providers: ReadonlyMap<string, InferenceProvider>;
   /** Static tool declarations for the inference branch. Declaring tools
    *  never needs a sandbox, so an inference-only turn never pays for
    *  one — the ensure-on-claim half of the ratified lifecycle. */
@@ -187,21 +193,25 @@ export async function runStep(
       // and are consumed by it.
       const pending = await store.pendingInputs(item);
       const steering = pending.map((input) => input.message);
-      // config.inference.provider picked the adapter at composition and
-      // is not part of the request.
-      // StepDeps is structurally an InferenceDeps; no re-wrapping.
-      const message = await inference(
-        deps,
-        {
-          model: config.inference.model,
-          maxTokens: config.inference.maxTokens,
-          temperature: config.inference.temperature,
-          system: config.systemPrompt,
-          context: buildContext(entries, steering),
-          tools: deps.toolSpecs,
-        },
-        step.signal,
-      );
+      // `provider` is read here and nowhere else: it picks the adapter
+      // and stops — it never joins the request (see the port). A
+      // provider this worker did not wire fails the step in the commit,
+      // not in a throw (see unservedProvider).
+      const provider = deps.providers.get(config.inference.provider);
+      const message = provider
+        ? await inference(
+            { provider, onDelta: deps.onDelta },
+            {
+              model: config.inference.model,
+              maxTokens: config.inference.maxTokens,
+              temperature: config.inference.temperature,
+              system: config.systemPrompt,
+              context: buildContext(entries, steering),
+              tools: deps.toolSpecs,
+            },
+            step.signal,
+          )
+        : unservedProvider(config.inference, deps.providers);
       append = [...steering, message];
       consumeInputs = pending.map((input) => input.id);
       tail = message;
@@ -249,6 +259,26 @@ export async function runStep(
   } finally {
     heartbeat.stop();
   }
+}
+
+/**
+ * The step's outcome for a provider this worker didn't wire: an
+ * error-stopped message, committed, so the run ends "error" with the
+ * reason in the log. Not a throw — an uncommitted item is re-claimed on
+ * lease expiry by workers with the same env, and would cycle forever.
+ */
+function unservedProvider(
+  inference: InferenceConfig,
+  providers: ReadonlyMap<string, InferenceProvider>,
+): AssistantMessage {
+  const served = [...providers.keys()].sort().join(", ") || "none";
+  return {
+    role: "assistant",
+    content: [],
+    model: inference.model,
+    stopReason: "error",
+    errorMessage: `no inference provider "${inference.provider}" on this worker (it serves: ${served})`,
+  };
 }
 
 /**

--- a/packages/agent/src/ports/inference-provider.ts
+++ b/packages/agent/src/ports/inference-provider.ts
@@ -7,10 +7,7 @@ import type { AgentMessage, ProviderEvent, ToolSpec } from "@funky/core";
  * Contract for implementations:
  * - Map the request's sampling fields (`maxTokens`, `temperature`, …) to
  *   vendor parameters; an absent field means the vendor's own default,
- *   never a harness default. The config's `provider` field is consumed
- *   before this port — it picks the adapter (the composition root today;
- *   a registry or mux when a second vendor exists) and stops there, so a
- *   stream() implementation never sees it.
+ *   never a harness default.
  * - Translate `req` to the vendor wire format and the vendor's stream events
  *   to `ProviderEvent`s, one by one, as they arrive. Nothing else: no fold
  *   (the engine assembles the message), no retries (driver policy), no

--- a/packages/core/src/inference.ts
+++ b/packages/core/src/inference.ts
@@ -3,12 +3,7 @@ import { z } from "zod";
 /**
  * The inference vocabulary — the declarative description of how a
  * session's inference runs: which provider serves it, which model, and
- * how to sample. `provider` ("anthropic", "openai", …) names the
- * interpreting adapter and is consumed picking it (2026-08-15) — the
- * composition root today, a registry when a second vendor exists; it is
- * not part of the StreamRequest. model/maxTokens/temperature ride the
- * request for the chosen adapter to map. Core does not enumerate
- * vendors.
+ * how to sample.
  */
 export const InferenceConfig = z.object({
   provider: z.string(),


### PR DESCRIPTION
`StepDeps.provider` becomes `StepDeps.providers`, a `ReadonlyMap` keyed by the exact string a config's `inference.provider` carries, and `runStep` resolves it per claim where the config is already loaded. A provider the worker didn't wire commits an error-stopped assistant message naming the served ids, never a throw, since an uncommitted item would be re-claimed by workers with the same env and cycle forever. The worker wires one entry, `anthropic`, and logs the served ids at boot, so the shipped stack is unchanged in practice and a second vendor is one more entry plus its key. The driver suite and crash fixtures pass a map under their existing `scripted` id, with a new driver test for the unserved case; the port, core, console, and README comments now describe the registry instead of the single adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
