### PR TITLE
Round-trip each vendor's continuity metadata on stored parts

### DIFF
--- a/packages/adapters/src/inference/aisdk.ts
+++ b/packages/adapters/src/inference/aisdk.ts
@@ -13,13 +13,21 @@
 // in order of first appearance, which is also the block order the
 // engine's fold reconstructs.
 //
-// The one vendor-specific patch: Anthropic's extended-thinking protocol
-// requires signatures (and redacted payloads) to round-trip verbatim,
-// and the AI SDK carries them in the `anthropic` provider-metadata
-// namespace — signatures arrive as empty reasoning deltas, redacted
-// blocks as reasoning-start metadata, and replay wants the same values
-// back as reasoning-part providerOptions. Capturing and re-attaching
-// that namespace is inert for every other vendor.
+// Vendor continuity data — Anthropic's thinking signatures, OpenAI's
+// reasoning items, Gemini's thought signatures — arrives as
+// `providerMetadata` on a block's chunks, on whichever chunks the vendor
+// chose (Anthropic: an empty reasoning delta; Gemini: every chunk). The
+// adapter merges it per block, later chunks winning, hands the merge to
+// the engine on the block's end event, and on replay attaches each
+// stored part's metadata back as `providerOptions`, verbatim. No vendor
+// is named in the process: whatever an SDK attaches is what it gets
+// back.
+//
+// A tool call closes on the SDK's assembled `tool-call` part, not on
+// `tool-input-end`: the assembled part is where the metadata lands, and
+// some providers (openai-compatible, so Together) stream no input parts
+// at all — for those the start and a single delta are synthesized from
+// it.
 
 import {
   type AssistantModelMessage,
@@ -28,7 +36,7 @@ import {
   type LanguageModel,
   type LanguageModelUsage,
   type ModelMessage,
-  type ProviderMetadata,
+  type ProviderMetadata as SdkProviderMetadata,
   streamText,
   tool,
   type ToolResultPart,
@@ -36,6 +44,8 @@ import {
 } from "ai";
 import type {
   AgentMessage,
+  JsonValue,
+  ProviderMetadata,
   ProviderStopReason,
   ThinkingContent,
   ToolResultMessage,
@@ -68,21 +78,30 @@ export function createAiSdkProvider(opts: AiSdkProviderOptions): InferenceProvid
 
       interface Block {
         index: number;
-        signature?: string;
-        redactedData?: string;
+        /** The vendor's continuity data, merged across the block's chunks. */
+        metadata?: ProviderMetadata;
       }
       const blocks = new Map<string, Block>();
       let nextIndex = 0;
-      const open = (kind: string, id: string): Block => {
+      const open = (kind: string, id: string, metadata?: SdkProviderMetadata): Block => {
         const block: Block = { index: nextIndex++ };
         blocks.set(`${kind}:${id}`, block);
+        absorb(block, metadata);
         return block;
       };
-      const at = (kind: string, id: string): Block => {
+      const at = (kind: string, id: string, metadata?: SdkProviderMetadata): Block => {
         const block = blocks.get(`${kind}:${id}`);
         if (!block) throw new Error(`aisdk: ${kind} part for unopened block ${id}`);
+        absorb(block, metadata);
         return block;
       };
+      const ended = (block: Block): { providerMetadata?: ProviderMetadata } =>
+        block.metadata === undefined ? {} : { providerMetadata: block.metadata };
+      // Provider-executed tools (server-side search, code execution) are
+      // never declared by this adapter, so no vendor should run one. If
+      // one does, the call and its result are the vendor's affair, not a
+      // local tool for the driver to schedule: skipped, never surfaced.
+      const foreign = new Set<string>();
 
       let finish:
         | { finishReason: FinishReason; raw: string | undefined; usage: LanguageModelUsage }
@@ -91,28 +110,32 @@ export function createAiSdkProvider(opts: AiSdkProviderOptions): InferenceProvid
       for await (const part of result.stream) {
         switch (part.type) {
           case "text-start":
-            yield { type: "text_start" as const, contentIndex: open("text", part.id).index };
+            yield {
+              type: "text_start" as const,
+              contentIndex: open("text", part.id, part.providerMetadata).index,
+            };
             break;
           case "text-delta":
             yield {
               type: "text_delta" as const,
-              contentIndex: at("text", part.id).index,
+              contentIndex: at("text", part.id, part.providerMetadata).index,
               delta: part.text,
             };
             break;
-          case "text-end":
-            yield { type: "text_end" as const, contentIndex: at("text", part.id).index };
-            break;
-          case "reasoning-start": {
-            const block = open("reasoning", part.id);
-            block.redactedData = anthropicString(part.providerMetadata, "redactedData");
-            yield { type: "thinking_start" as const, contentIndex: block.index };
+          case "text-end": {
+            const block = at("text", part.id, part.providerMetadata);
+            yield { type: "text_end" as const, contentIndex: block.index, ...ended(block) };
             break;
           }
+          case "reasoning-start":
+            yield {
+              type: "thinking_start" as const,
+              contentIndex: open("reasoning", part.id, part.providerMetadata).index,
+            };
+            break;
           case "reasoning-delta": {
-            const block = at("reasoning", part.id);
-            const signature = anthropicString(part.providerMetadata, "signature");
-            if (signature !== undefined) block.signature = signature;
+            // An empty delta is metadata only (Anthropic's signature).
+            const block = at("reasoning", part.id, part.providerMetadata);
             if (part.text !== "") {
               yield {
                 type: "thinking_delta" as const,
@@ -123,38 +146,59 @@ export function createAiSdkProvider(opts: AiSdkProviderOptions): InferenceProvid
             break;
           }
           case "reasoning-end": {
-            const block = at("reasoning", part.id);
-            const signature =
-              anthropicString(part.providerMetadata, "signature") ?? block.signature;
-            yield block.redactedData !== undefined
-              ? {
-                  type: "thinking_end" as const,
-                  contentIndex: block.index,
-                  signature: block.redactedData,
-                  redacted: true,
-                }
-              : { type: "thinking_end" as const, contentIndex: block.index, signature };
+            const block = at("reasoning", part.id, part.providerMetadata);
+            yield { type: "thinking_end" as const, contentIndex: block.index, ...ended(block) };
             break;
           }
           case "tool-input-start":
+            if (part.providerExecuted) {
+              foreign.add(part.id);
+              break;
+            }
             // The part's id IS the vendor's tool call id.
             yield {
               type: "toolcall_start" as const,
-              contentIndex: open("tool", part.id).index,
+              contentIndex: open("tool", part.id, part.providerMetadata).index,
               toolCallId: part.id,
               toolName: part.toolName,
             };
             break;
           case "tool-input-delta":
+            if (foreign.has(part.id)) break;
             yield {
               type: "toolcall_delta" as const,
-              contentIndex: at("tool", part.id).index,
+              contentIndex: at("tool", part.id, part.providerMetadata).index,
               argsDelta: part.delta,
             };
             break;
           case "tool-input-end":
-            yield { type: "toolcall_end" as const, contentIndex: at("tool", part.id).index };
+            if (foreign.has(part.id)) break;
+            // Metadata only; the assembled tool-call below closes the block.
+            at("tool", part.id, part.providerMetadata);
             break;
+          case "tool-call": {
+            if (part.providerExecuted || foreign.has(part.toolCallId)) break;
+            let block = blocks.get(`tool:${part.toolCallId}`);
+            if (block === undefined) {
+              // No input parts were streamed: the assembled call is all
+              // there is, so it becomes the start and a single delta.
+              block = open("tool", part.toolCallId);
+              yield {
+                type: "toolcall_start" as const,
+                contentIndex: block.index,
+                toolCallId: part.toolCallId,
+                toolName: part.toolName,
+              };
+              yield {
+                type: "toolcall_delta" as const,
+                contentIndex: block.index,
+                argsDelta: typeof part.input === "string" ? part.input : JSON.stringify(part.input),
+              };
+            }
+            absorb(block, part.providerMetadata);
+            yield { type: "toolcall_end" as const, contentIndex: block.index, ...ended(block) };
+            break;
+          }
           case "finish":
             finish = {
               finishReason: part.finishReason,
@@ -167,8 +211,8 @@ export function createAiSdkProvider(opts: AiSdkProviderOptions): InferenceProvid
           case "abort":
             throw new DOMException("The operation was aborted.", "AbortError");
           default:
-            // start / step markers, assembled tool-call parts (already
-            // streamed as input parts), sources, files, raw chunks.
+            // start / step markers, tool results and errors of
+            // provider-executed tools, sources, files, raw chunks.
             break;
         }
       }
@@ -186,6 +230,49 @@ export function createAiSdkProvider(opts: AiSdkProviderOptions): InferenceProvid
   };
 }
 
+/** Merge one chunk's metadata into its block: per vendor namespace,
+ *  later keys win. An absent value or an empty namespace says nothing
+ *  and leaves nothing behind. */
+function absorb(
+  block: { metadata?: ProviderMetadata },
+  metadata: SdkProviderMetadata | undefined,
+): void {
+  if (metadata === undefined) return;
+  for (const [vendor, values] of Object.entries(metadata)) {
+    const json = toJsonObject(values);
+    if (Object.keys(json).length === 0) continue;
+    const merged = (block.metadata ??= {});
+    merged[vendor] = { ...merged[vendor], ...json };
+  }
+}
+
+/** The SDK's JSON allows `undefined` at any depth (the Anthropic package
+ *  emits `caller: { toolId: undefined }` on tool calls); the log's
+ *  JsonValue does not, and the store validates before it writes. Drop
+ *  such keys and null such array slots — what JSON.stringify would do. */
+function toJsonObject(values: object): Record<string, JsonValue> {
+  const out: Record<string, JsonValue> = {};
+  for (const [key, value] of Object.entries(values)) {
+    const json = toJson(value);
+    if (json !== undefined) out[key] = json;
+  }
+  return out;
+}
+
+function toJson(value: unknown): JsonValue | undefined {
+  if (value === null) return null;
+  switch (typeof value) {
+    case "string":
+    case "number":
+    case "boolean":
+      return value;
+    case "object":
+      return Array.isArray(value) ? value.map((item) => toJson(item) ?? null) : toJsonObject(value);
+    default:
+      return undefined;
+  }
+}
+
 function toToolSet(specs: ToolSpec[]): ToolSet {
   return Object.fromEntries(
     specs.map((spec) => [
@@ -201,6 +288,12 @@ function toToolSet(specs: ToolSpec[]): ToolSet {
 }
 
 type AssistantPart = Exclude<AssistantModelMessage["content"], string>[number];
+
+/** A stored part's metadata, back on the SDK part as `providerOptions`. */
+const replayed = (
+  metadata: ProviderMetadata | undefined,
+): { providerOptions?: ProviderMetadata } =>
+  metadata === undefined ? {} : { providerOptions: metadata };
 
 function toModelMessages(context: AgentMessage[]): ModelMessage[] {
   const out: ModelMessage[] = [];
@@ -221,15 +314,22 @@ function toModelMessages(context: AgentMessage[]): ModelMessage[] {
         for (const part of message.content) {
           if (part.type === "text") {
             // Vendors reject empty text blocks; an empty part carries nothing.
-            if (part.text !== "") parts.push({ type: "text", text: part.text });
+            if (part.text !== "") {
+              parts.push({ type: "text", text: part.text, ...replayed(part.providerMetadata) });
+            }
           } else if (part.type === "thinking") {
-            parts.push(toReasoningPart(part));
+            parts.push({
+              type: "reasoning",
+              text: part.thinking,
+              ...replayed(part.providerMetadata ?? legacyAnthropicMetadata(part)),
+            });
           } else {
             parts.push({
               type: "tool-call",
               toolCallId: part.id,
               toolName: part.name,
               input: part.arguments,
+              ...replayed(part.providerMetadata),
             });
           }
         }
@@ -254,26 +354,14 @@ function toModelMessages(context: AgentMessage[]): ModelMessage[] {
   return out;
 }
 
-/** Replay of a thinking part: signed → an Anthropic thinking block,
- *  redacted → redacted_thinking (the opaque payload rides in
- *  `thinkingSignature`, see core). @ai-sdk/anthropic reads exactly these
- *  providerOptions keys; unsigned parts ride as plain reasoning text. */
-function toReasoningPart(part: ThinkingContent): AssistantPart {
-  if (part.redacted && part.thinkingSignature !== undefined) {
-    return {
-      type: "reasoning",
-      text: "",
-      providerOptions: { anthropic: { redactedData: part.thinkingSignature } },
-    };
-  }
-  if (part.thinkingSignature !== undefined) {
-    return {
-      type: "reasoning",
-      text: part.thinking,
-      providerOptions: { anthropic: { signature: part.thinkingSignature } },
-    };
-  }
-  return { type: "reasoning", text: part.thinking };
+/** Rows stored before `providerMetadata` existed (Anthropic only): the
+ *  signature, or a redacted block's opaque payload, in the shape
+ *  @ai-sdk/anthropic reads. New rows never take this path. */
+function legacyAnthropicMetadata(part: ThinkingContent): ProviderMetadata | undefined {
+  if (part.thinkingSignature === undefined) return undefined;
+  return part.redacted
+    ? { anthropic: { redactedData: part.thinkingSignature } }
+    : { anthropic: { signature: part.thinkingSignature } };
 }
 
 function toToolOutput(message: ToolResultMessage): ToolResultPart["output"] {
@@ -318,9 +406,4 @@ function toUsage(usage: LanguageModelUsage): Usage {
     cacheWrite: usage.inputTokenDetails.cacheWriteTokens ?? 0,
     ...(reasoning !== undefined ? { reasoning } : {}),
   };
-}
-
-function anthropicString(metadata: ProviderMetadata | undefined, key: string): string | undefined {
-  const value = metadata?.["anthropic"]?.[key];
-  return typeof value === "string" ? value : undefined;
 }

--- a/packages/adapters/test/aisdk.test.ts
+++ b/packages/adapters/test/aisdk.test.ts
@@ -2,14 +2,16 @@
 // streamText pipeline runs between the mock and the adapter, so these
 // tests cover the adapter's actual seam: spec stream parts in,
 // ProviderEvents out, and the request mapping the mock records
-// (doStreamCalls) on the way in. The Anthropic thinking-signature
-// shapes mirror what @ai-sdk/anthropic actually emits and reads
-// (signature as an empty reasoning-delta's metadata, redactedData on
-// reasoning-start, providerOptions on replayed reasoning parts).
+// (doStreamCalls) on the way in. The metadata shapes mirror what the
+// vendor SDKs actually emit and read: Anthropic's signature as an empty
+// reasoning-delta's metadata and redactedData on reasoning-start,
+// OpenAI's reasoning item filled in at reasoning-end, Gemini's thought
+// signature on every chunk of a block, and providerOptions on replayed
+// parts.
 
 import { describe, expect, it } from "vitest";
 import { MockLanguageModelV3, convertArrayToReadableStream, simulateReadableStream } from "ai/test";
-import type { AgentMessage, ProviderEvent } from "@funky/core";
+import { type AgentMessage, type ProviderEvent, ProviderMetadata } from "@funky/core";
 import type { InferenceProvider, StreamRequest } from "@funky/agent";
 import { createAiSdkProvider } from "../src";
 
@@ -61,6 +63,12 @@ const request = (overrides: Partial<StreamRequest> = {}): StreamRequest => ({
 
 const live = (): AbortSignal => new AbortController().signal;
 
+const echoSpec = {
+  name: "echo",
+  description: "echoes",
+  inputSchema: { type: "object", properties: { text: { type: "string" } }, required: ["text"] },
+};
+
 async function collect(provider: InferenceProvider, req: StreamRequest): Promise<ProviderEvent[]> {
   const events: ProviderEvent[] = [];
   for await (const event of provider.stream(req, live())) events.push(event);
@@ -96,10 +104,11 @@ describe("aisdk adapter: stream mapping", () => {
       { type: "tool-input-delta", id: "call_9", delta: '{"text":' },
       { type: "tool-input-delta", id: "call_9", delta: '"hi"}' },
       { type: "tool-input-end", id: "call_9" },
+      { type: "tool-call", toolCallId: "call_9", toolName: "echo", input: '{"text":"hi"}' },
       finish("tool-calls"),
     ]);
 
-    const events = await collect(provider, request());
+    const events = await collect(provider, request({ tools: [echoSpec] }));
     expect(events).toEqual([
       { type: "toolcall_start", contentIndex: 0, toolCallId: "call_9", toolName: "echo" },
       { type: "toolcall_delta", contentIndex: 0, argsDelta: '{"text":' },
@@ -130,7 +139,11 @@ describe("aisdk adapter: stream mapping", () => {
     expect(events.slice(0, 3)).toEqual([
       { type: "thinking_start", contentIndex: 0 },
       { type: "thinking_delta", contentIndex: 0, delta: "because" },
-      { type: "thinking_end", contentIndex: 0, signature: "sig-1" },
+      {
+        type: "thinking_end",
+        contentIndex: 0,
+        providerMetadata: { anthropic: { signature: "sig-1" } },
+      },
     ]);
     // The following text block gets the next contentIndex.
     expect(events[3]).toEqual({ type: "text_start", contentIndex: 1 });
@@ -150,7 +163,157 @@ describe("aisdk adapter: stream mapping", () => {
     const events = await collect(provider, request());
     expect(events.slice(0, 2)).toEqual([
       { type: "thinking_start", contentIndex: 0 },
-      { type: "thinking_end", contentIndex: 0, signature: "opaque-payload", redacted: true },
+      {
+        type: "thinking_end",
+        contentIndex: 0,
+        providerMetadata: { anthropic: { redactedData: "opaque-payload" } },
+      },
+    ]);
+  });
+
+  it("merges metadata across a block's chunks — Gemini attaches its signature to every one", async () => {
+    const google = { google: { thoughtSignature: "ts-1" } };
+    const { provider } = providerWith([
+      { type: "text-start", id: "0", providerMetadata: google },
+      { type: "text-delta", id: "0", delta: "Hi", providerMetadata: google },
+      { type: "text-end", id: "0" },
+      { type: "tool-input-start", id: "call_1", toolName: "echo", providerMetadata: google },
+      { type: "tool-input-delta", id: "call_1", delta: '{"text":"hi"}', providerMetadata: google },
+      { type: "tool-input-end", id: "call_1", providerMetadata: google },
+      {
+        type: "tool-call",
+        toolCallId: "call_1",
+        toolName: "echo",
+        input: '{"text":"hi"}',
+        providerMetadata: google,
+      },
+      finish("tool-calls"),
+    ]);
+
+    const events = await collect(provider, request({ tools: [echoSpec] }));
+    expect(events).toEqual([
+      { type: "text_start", contentIndex: 0 },
+      { type: "text_delta", contentIndex: 0, delta: "Hi" },
+      { type: "text_end", contentIndex: 0, providerMetadata: google },
+      { type: "toolcall_start", contentIndex: 1, toolCallId: "call_1", toolName: "echo" },
+      { type: "toolcall_delta", contentIndex: 1, argsDelta: '{"text":"hi"}' },
+      { type: "toolcall_end", contentIndex: 1, providerMetadata: google },
+      expect.objectContaining({ type: "done", stopReason: "tool_use" }),
+    ]);
+  });
+
+  it("lets later chunks win — OpenAI fills the encrypted reasoning in at reasoning-end", async () => {
+    const { provider } = providerWith([
+      {
+        type: "reasoning-start",
+        id: "0",
+        providerMetadata: { openai: { itemId: "rs_1", reasoningEncryptedContent: null } },
+      },
+      { type: "reasoning-delta", id: "0", delta: "hmm" },
+      {
+        type: "reasoning-end",
+        id: "0",
+        providerMetadata: { openai: { itemId: "rs_1", reasoningEncryptedContent: "enc" } },
+      },
+      finish("stop"),
+    ]);
+
+    const events = await collect(provider, request());
+    expect(events[2]).toEqual({
+      type: "thinking_end",
+      contentIndex: 0,
+      providerMetadata: { openai: { itemId: "rs_1", reasoningEncryptedContent: "enc" } },
+    });
+  });
+
+  it("drops undefined at any depth before metadata reaches the log — the Anthropic package emits some", async () => {
+    const { provider } = providerWith([
+      { type: "tool-input-start", id: "call_1", toolName: "echo" },
+      { type: "tool-input-delta", id: "call_1", delta: '{"text":"hi"}' },
+      { type: "tool-input-end", id: "call_1" },
+      {
+        type: "tool-call",
+        toolCallId: "call_1",
+        toolName: "echo",
+        input: '{"text":"hi"}',
+        providerMetadata: {
+          anthropic: {
+            caller: { type: "direct", toolId: undefined },
+            tags: [{ id: "a", note: undefined }],
+          },
+          empty: { nothing: undefined },
+        },
+      },
+      finish("tool-calls"),
+    ]);
+
+    const events = await collect(provider, request({ tools: [echoSpec] }));
+    const end = events.find((event) => event.type === "toolcall_end");
+    // toStrictEqual: an `undefined`-valued key is a difference here.
+    expect(end).toStrictEqual({
+      type: "toolcall_end",
+      contentIndex: 0,
+      providerMetadata: { anthropic: { caller: { type: "direct" }, tags: [{ id: "a" }] } },
+    });
+    expect(ProviderMetadata.safeParse(end?.providerMetadata).success).toBe(true);
+  });
+
+  it("leaves provider-executed calls to the vendor — streamed or assembled, nothing is surfaced", async () => {
+    const { provider } = providerWith([
+      { type: "tool-input-start", id: "srv_1", toolName: "web_search", providerExecuted: true },
+      { type: "tool-input-delta", id: "srv_1", delta: '{"q":"x"}' },
+      { type: "tool-input-end", id: "srv_1" },
+      {
+        type: "tool-call",
+        toolCallId: "srv_1",
+        toolName: "web_search",
+        input: '{"q":"x"}',
+        providerExecuted: true,
+      },
+      {
+        type: "tool-call",
+        toolCallId: "srv_2",
+        toolName: "code_execution",
+        input: "{}",
+        providerExecuted: true,
+      },
+      { type: "text-start", id: "0" },
+      { type: "text-delta", id: "0", delta: "done" },
+      { type: "text-end", id: "0" },
+      finish("stop"),
+    ]);
+
+    const events = await collect(provider, request());
+    expect(events.map((event) => event.type)).toEqual([
+      "text_start",
+      "text_delta",
+      "text_end",
+      "done",
+    ]);
+  });
+
+  it("closes a call from the assembled tool-call alone — openai-compatible providers stream no input parts", async () => {
+    const { provider } = providerWith([
+      {
+        type: "tool-call",
+        toolCallId: "call_t",
+        toolName: "echo",
+        input: '{"text":"hi"}',
+        providerMetadata: { openaiCompatible: { thoughtSignature: "ts-2" } },
+      },
+      finish("tool-calls"),
+    ]);
+
+    const events = await collect(provider, request({ tools: [echoSpec] }));
+    expect(events).toEqual([
+      { type: "toolcall_start", contentIndex: 0, toolCallId: "call_t", toolName: "echo" },
+      { type: "toolcall_delta", contentIndex: 0, argsDelta: '{"text":"hi"}' },
+      {
+        type: "toolcall_end",
+        contentIndex: 0,
+        providerMetadata: { openaiCompatible: { thoughtSignature: "ts-2" } },
+      },
+      expect.objectContaining({ type: "done", stopReason: "tool_use" }),
     ]);
   });
 
@@ -251,15 +414,23 @@ describe("aisdk adapter: request mapping", () => {
     expect(call.temperature).toBeUndefined();
   });
 
-  it("round-trips the context: thinking signatures, tool pairs, redacted blocks", async () => {
+  it("round-trips each part's metadata verbatim, and legacy thinking fields as Anthropic's", async () => {
+    const openai = { openai: { itemId: "rs_1", reasoningEncryptedContent: "enc" } };
+    const google = { google: { thoughtSignature: "ts-1" } };
     const context: AgentMessage[] = [
       { role: "user", content: [{ type: "text", text: "go" }] },
       {
         role: "assistant",
         content: [
-          { type: "thinking", thinking: "because", thinkingSignature: "sig-1" },
-          { type: "text", text: "running echo" },
-          { type: "toolCall", id: "call_1", name: "echo", arguments: { text: "hi" } },
+          { type: "thinking", thinking: "because", providerMetadata: openai },
+          { type: "text", text: "running echo", providerMetadata: google },
+          {
+            type: "toolCall",
+            id: "call_1",
+            name: "echo",
+            arguments: { text: "hi" },
+            providerMetadata: google,
+          },
         ],
         model: "model-1",
         stopReason: "tool_use",
@@ -275,6 +446,7 @@ describe("aisdk adapter: request mapping", () => {
         role: "assistant",
         content: [
           { type: "thinking", thinking: "", thinkingSignature: "opaque", redacted: true },
+          { type: "thinking", thinking: "legacy", thinkingSignature: "sig-1" },
           { type: "text", text: "done" },
         ],
         model: "model-1",
@@ -292,13 +464,15 @@ describe("aisdk adapter: request mapping", () => {
       {
         role: "assistant",
         content: [
+          { type: "reasoning", text: "because", providerOptions: openai },
+          { type: "text", text: "running echo", providerOptions: google },
           {
-            type: "reasoning",
-            text: "because",
-            providerOptions: { anthropic: { signature: "sig-1" } },
+            type: "tool-call",
+            toolCallId: "call_1",
+            toolName: "echo",
+            input: { text: "hi" },
+            providerOptions: google,
           },
-          { type: "text", text: "running echo" },
-          { type: "tool-call", toolCallId: "call_1", toolName: "echo", input: { text: "hi" } },
         ],
       },
       {
@@ -319,6 +493,11 @@ describe("aisdk adapter: request mapping", () => {
             type: "reasoning",
             text: "",
             providerOptions: { anthropic: { redactedData: "opaque" } },
+          },
+          {
+            type: "reasoning",
+            text: "legacy",
+            providerOptions: { anthropic: { signature: "sig-1" } },
           },
           { type: "text", text: "done" },
         ],

--- a/packages/agent/src/engine/inference.ts
+++ b/packages/agent/src/engine/inference.ts
@@ -3,6 +3,7 @@ import type {
   AssistantMessage,
   JsonValue,
   ProviderEvent,
+  ProviderMetadata,
   TextContent,
   ThinkingContent,
   ToolCall,
@@ -87,6 +88,7 @@ export async function inference(
           partAt(event.contentIndex, "text").text += event.delta;
           break;
         case "text_end":
+          attach(partAt(event.contentIndex, "text"), event.providerMetadata);
           break;
         case "thinking_start":
           parts[event.contentIndex] = { type: "thinking", thinking: "" };
@@ -94,17 +96,9 @@ export async function inference(
         case "thinking_delta":
           partAt(event.contentIndex, "thinking").thinking += event.delta;
           break;
-        case "thinking_end": {
-          const part = partAt(event.contentIndex, "thinking");
-          if (event.signature !== undefined) part.thinkingSignature = event.signature;
-          if (event.redacted) {
-            // Redacted blocks carry no visible thinking; the opaque payload
-            // rides in the signature so replay reconstructs redacted_thinking.
-            part.redacted = true;
-            part.thinking = "";
-          }
+        case "thinking_end":
+          attach(partAt(event.contentIndex, "thinking"), event.providerMetadata);
           break;
-        }
         case "toolcall_start":
           parts[event.contentIndex] = {
             type: "toolCall",
@@ -123,6 +117,7 @@ export async function inference(
         case "toolcall_end": {
           const part = partAt(event.contentIndex, "toolCall");
           part.arguments = parseArguments(argBuffers.get(event.contentIndex) ?? "");
+          attach(part, event.providerMetadata);
           break;
         }
         case "done":
@@ -145,6 +140,11 @@ export async function inference(
   // (SDK throw, clean stream end) — the partial draft is the message.
   if (signal.aborted) return { ...base, stopReason: "aborted" };
   return { ...base, stopReason: "error", errorMessage: failure ?? "unknown provider failure" };
+}
+
+/** The vendor's continuity data rides on the finished part, verbatim; absent stays absent. */
+function attach(part: DraftPart, metadata: ProviderMetadata | undefined): void {
+  if (metadata !== undefined) part.providerMetadata = metadata;
 }
 
 /** Providers stream tool arguments as JSON text; an empty buffer means no arguments. */

--- a/packages/agent/test/inference.test.ts
+++ b/packages/agent/test/inference.test.ts
@@ -97,17 +97,45 @@ describe("inference", () => {
   });
 
   it("folds a redacted thinking block into an empty part carrying the opaque payload", async () => {
+    const redacted = { anthropic: { redactedData: "opaque-payload" } };
     const message = await run([
       { type: "thinking_start", contentIndex: 0 },
-      { type: "thinking_end", contentIndex: 0, signature: "opaque-payload", redacted: true },
+      { type: "thinking_end", contentIndex: 0, providerMetadata: redacted },
       { type: "text_start", contentIndex: 1 },
       { type: "text_delta", contentIndex: 1, delta: "ok" },
       { type: "text_end", contentIndex: 1 },
       { type: "done", stopReason: "end_turn", usage },
     ]);
     expect(message.content).toEqual([
-      { type: "thinking", thinking: "", thinkingSignature: "opaque-payload", redacted: true },
+      { type: "thinking", thinking: "", providerMetadata: redacted },
       { type: "text", text: "ok" },
+    ]);
+  });
+
+  it("attaches each end event's provider metadata to its part, verbatim, and nothing when absent", async () => {
+    const google = { google: { thoughtSignature: "ts-1" } };
+    const message = await run([
+      { type: "text_start", contentIndex: 0 },
+      { type: "text_delta", contentIndex: 0, delta: "Hi" },
+      { type: "text_end", contentIndex: 0, providerMetadata: google },
+      { type: "toolcall_start", contentIndex: 1, toolCallId: "call_1", toolName: "bash" },
+      { type: "toolcall_delta", contentIndex: 1, argsDelta: '{"command":"ls"}' },
+      { type: "toolcall_end", contentIndex: 1, providerMetadata: google },
+      { type: "text_start", contentIndex: 2 },
+      { type: "text_delta", contentIndex: 2, delta: "bye" },
+      { type: "text_end", contentIndex: 2 },
+      { type: "done", stopReason: "tool_use", usage },
+    ]);
+    expect(message.content).toEqual([
+      { type: "text", text: "Hi", providerMetadata: google },
+      {
+        type: "toolCall",
+        id: "call_1",
+        name: "bash",
+        arguments: { command: "ls" },
+        providerMetadata: google,
+      },
+      { type: "text", text: "bye" },
     ]);
   });
 

--- a/packages/core/src/messages.ts
+++ b/packages/core/src/messages.ts
@@ -25,11 +25,24 @@ export const JsonValue: z.ZodType<JsonValue> = z.lazy(() =>
   ]),
 );
 
+/**
+ * A vendor's own continuity data for one content part — thinking
+ * signatures, reasoning item ids, encrypted reasoning, thought
+ * signatures — keyed by vendor namespace, exactly as the vendor SDK
+ * attached it. Opaque here: core never reads it. The inference adapter
+ * captures it verbatim on the way in and hands it back verbatim on
+ * replay, so every vendor's multi-turn requirements are met without
+ * core knowing what any of them are.
+ */
+export const ProviderMetadata = z.record(z.string(), z.record(z.string(), JsonValue));
+export type ProviderMetadata = z.infer<typeof ProviderMetadata>;
+
 // --- content parts ---
 
 export const TextContent = z.object({
   type: z.literal("text"),
   text: z.string(),
+  providerMetadata: ProviderMetadata.optional(),
 });
 export type TextContent = z.infer<typeof TextContent>;
 
@@ -42,10 +55,13 @@ export type ImageContent = z.infer<typeof ImageContent>;
 
 export const ThinkingContent = z.object({
   type: z.literal("thinking"),
+  // Empty for a redacted block: the vendor keeps the text and hands back
+  // only the opaque payload, which rides in `providerMetadata`.
   thinking: z.string(),
-  // Anthropic extended thinking: the signature must round-trip to the API
-  // for multi-turn continuity. When `redacted` is true, `thinking` is empty
-  // and the opaque encrypted payload rides in `thinkingSignature`.
+  providerMetadata: ProviderMetadata.optional(),
+  // Legacy, Anthropic-only, no longer written: rows stored before
+  // `providerMetadata` carry the signature here — or, when `redacted`,
+  // the opaque encrypted payload. Replay still reads them.
   thinkingSignature: z.string().optional(),
   redacted: z.boolean().optional(),
 });
@@ -56,6 +72,7 @@ export const ToolCall = z.object({
   id: z.string(),
   name: z.string(),
   arguments: z.record(z.string(), JsonValue),
+  providerMetadata: ProviderMetadata.optional(),
 });
 export type ToolCall = z.infer<typeof ToolCall>;
 

--- a/packages/core/src/provider-events.ts
+++ b/packages/core/src/provider-events.ts
@@ -1,4 +1,4 @@
-import type { StopReason, Usage } from "./messages";
+import type { ProviderMetadata, StopReason, Usage } from "./messages";
 
 /**
  * Streaming increments from a model provider.
@@ -20,21 +20,25 @@ import type { StopReason, Usage } from "./messages";
 /** Outcomes a provider can report. `aborted`/`error` are assigned by the engine, never by a provider. */
 export type ProviderStopReason = Extract<StopReason, "end_turn" | "tool_use" | "max_tokens">;
 
+/**
+ * The `*_end` events may carry the vendor's continuity data for the
+ * finished part (`ProviderMetadata` in messages): the adapter merges
+ * whatever the vendor attached across the part's chunks, the fold
+ * attaches it to the part, replay hands it back verbatim. A redacted
+ * thinking block never streams deltas — an empty start/end pair whose
+ * metadata carries the opaque payload.
+ */
 export type ProviderEvent =
   | { type: "text_start"; contentIndex: number }
   | { type: "text_delta"; contentIndex: number; delta: string }
-  | { type: "text_end"; contentIndex: number }
+  | { type: "text_end"; contentIndex: number; providerMetadata?: ProviderMetadata }
   | { type: "thinking_start"; contentIndex: number }
   | { type: "thinking_delta"; contentIndex: number; delta: string }
-  /** Anthropic delivers the signature at block end; the fold attaches it to the part.
-   *  Redacted blocks never stream deltas: adapters emit an empty start/end pair with
-   *  `redacted: true` and the opaque encrypted payload in `signature`; the fold sets
-   *  the part's `redacted` flag so replay reconstructs a `redacted_thinking` block. */
-  | { type: "thinking_end"; contentIndex: number; signature?: string; redacted?: boolean }
+  | { type: "thinking_end"; contentIndex: number; providerMetadata?: ProviderMetadata }
   /** Tool identity is known before arguments stream — required here, so UIs can show the call early. */
   | { type: "toolcall_start"; contentIndex: number; toolCallId: string; toolName: string }
   /** Arguments stream as partial JSON text; the fold buffers and parses at `toolcall_end`. */
   | { type: "toolcall_delta"; contentIndex: number; argsDelta: string }
-  | { type: "toolcall_end"; contentIndex: number }
+  | { type: "toolcall_end"; contentIndex: number; providerMetadata?: ProviderMetadata }
   /** Terminal marker. Carries the provider outcome and usage — never a message. */
   | { type: "done"; stopReason: ProviderStopReason; usage: Usage };

--- a/packages/core/test/entries.test.ts
+++ b/packages/core/test/entries.test.ts
@@ -26,6 +26,36 @@ describe("SessionEntry", () => {
     expect(SessionEntry.parse(JSON.parse(JSON.stringify(entry)))).toEqual(entry);
   });
 
+  it("round-trips a part's provider metadata verbatim, beside the legacy thinking fields", () => {
+    const google = { google: { thoughtSignature: "ts-1" } };
+    const entry = {
+      ...envelope,
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "because",
+            providerMetadata: { openai: { itemId: "rs_1", reasoningEncryptedContent: null } },
+          },
+          { type: "thinking", thinking: "", thinkingSignature: "opaque", redacted: true },
+          { type: "text", text: "checking", providerMetadata: google },
+          {
+            type: "toolCall",
+            id: "c1",
+            name: "read",
+            arguments: { path: "a.ts" },
+            providerMetadata: google,
+          },
+        ],
+        model: "gemini-3.7-flash",
+        stopReason: "tool_use",
+      },
+    };
+    expect(SessionEntry.parse(JSON.parse(JSON.stringify(entry)))).toEqual(entry);
+  });
+
   it("round-trips a custom entry with a nested payload", () => {
     const entry = {
       ...envelope,


### PR DESCRIPTION
Text, thinking, and tool-call parts in core gain an optional opaque `providerMetadata`, keyed by vendor namespace exactly as the AI SDK attached it; the end events carry it, the engine fold attaches it, and the adapter merges it per block with later chunks winning and replays it verbatim as `providerOptions`, which restores reasoning continuity across tool steps for OpenAI and Gemini and retires the adapter's Anthropic special case, with `thinkingSignature` and `redacted` kept as legacy read-only fields for rows written before this change. Tool calls now close on the SDK's assembled `tool-call` part, since openai-compatible providers such as Together stream no input parts at all and the old adapter dropped their calls entirely. Metadata is sanitized to the log's JSON shape at any depth, because `@ai-sdk/anthropic` emits `undefined`-valued keys on every tool call and the store validates entries on write, and provider-executed tool parts are skipped rather than surfaced as local calls. Tests cover the Anthropic, OpenAI, Gemini, and Together metadata shapes, the sanitizing, the provider-executed skip, the verbatim replay with the legacy mapping, and the core schema round-trip; entries are jsonb, so no migration is needed. Replay is verified against the SDKs' documented shapes with a mock model, not against live APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
