### PR TITLE
Add the env config list to the console

### DIFF
--- a/apps/web/src/components/Status.css
+++ b/apps/web/src/components/Status.css
@@ -1,0 +1,39 @@
+/* apps/web/src/components/Status.css
+   The lifecycle pill. Two states, because archive is terminal: live, or
+   retired. Every colour resolves to a token in index.css. */
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 3px 11px 3px 9px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.pill-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.pill-active {
+  color: var(--text-2);
+}
+
+.pill-active .pill-dot {
+  background: var(--ok);
+  box-shadow: 0 0 0 3px var(--ok-glow);
+}
+
+.pill-archived {
+  color: var(--text-3);
+  background: var(--bg-sunken);
+}
+
+.pill-archived .pill-dot {
+  background: var(--text-3);
+  opacity: 0.6;
+}

--- a/apps/web/src/components/Status.tsx
+++ b/apps/web/src/components/Status.tsx
@@ -1,0 +1,23 @@
+// apps/web/src/components/Status.tsx
+// The one status a config has. Shared by the resource lists, which all
+// front the same lifecycle: a config is live until it is archived, and the
+// api has no route back.
+import { absoluteTime } from "../lib/format";
+import "./Status.css";
+
+/** Archive is the one terminal transition, so this is a state, not a toggle. */
+export function Status({ archivedAt }: { archivedAt?: string }) {
+  return (
+    <span
+      className={archivedAt ? "pill pill-archived" : "pill pill-active"}
+      title={
+        archivedAt
+          ? `Archived ${absoluteTime(archivedAt)} — read-only, and no new session can use it`
+          : "Accepts updates and new sessions"
+      }
+    >
+      <span className="pill-dot" aria-hidden="true" />
+      {archivedAt ? "Archived" : "Active"}
+    </span>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -37,6 +37,34 @@ export type AgentConfig = {
   metadata?: unknown;
 };
 
+/** Reachability as intent, not mechanism: an adapter that cannot enforce
+ *  what this asks for must refuse to provision rather than run more open. */
+export type NetworkPolicy =
+  { type: "unrestricted" } | { type: "none" } | { type: "allowlist"; domains: string[] };
+
+/** Specs keyed by package manager ("pip", "npm", "apt", …), each spec left
+ *  in its own ecosystem's syntax — the key names the interpreter. */
+export type Packages = Record<string, string[]>;
+
+/**
+ * One env config: the sandbox recipe a session's commands run inside.
+ * Unlike an agent config it is updated IN PLACE — there is no version to
+ * pin, which is why a session copies the recipe instead of referencing it.
+ */
+export type EnvConfig = {
+  id: string;
+  namespace: string;
+  network: NetworkPolicy;
+  packages: Packages;
+  createdAt: string;
+  /** The latest edit to the recipe. Equal to createdAt until the first
+   *  update; archiving retires it without editing it, so it does not move. */
+  updatedAt: string;
+  /** Set once retired. Archive is terminal, so absence is the active state. */
+  archivedAt?: string;
+  metadata?: unknown;
+};
+
 /** The envelope every collection route returns (api routes/common.ts). */
 export type Page<T> = {
   data: T[];
@@ -227,6 +255,25 @@ export function archiveAgentConfig(
     // fetch sends as no body at all.
     undefined,
     { namespace: DEFAULT_NAMESPACE },
+    opts.signal,
+  );
+}
+
+/**
+ * One page of the namespace's env configs, newest first. Archived recipes
+ * are listed beside live ones — they stay readable, and the sessions that
+ * copied them keep running — so a row's status is worth a column.
+ */
+export function listEnvConfigs(
+  opts: { after?: string; limit?: number; signal?: AbortSignal } = {},
+): Promise<Page<EnvConfig>> {
+  return get<Page<EnvConfig>>(
+    "/v1/env-configs",
+    {
+      namespace: DEFAULT_NAMESPACE,
+      limit: opts.limit === undefined ? undefined : String(opts.limit),
+      after: opts.after,
+    },
     opts.signal,
   );
 }

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -17,6 +17,11 @@ const UNITS: Array<[Intl.RelativeTimeFormatUnit, number]> = [
   ["month", 12],
 ];
 
+/** How often a view showing relative times must re-read the clock. Fine
+ *  enough that the coarsest thing relativeTime prints — "1 minute ago" — is
+ *  never a minute stale. */
+export const RELATIVE_TICK_MS = 30_000;
+
 /** e.g. "3 hours ago". Returns the input unchanged if it isn't a date. */
 export function relativeTime(iso: string, now: number = Date.now()): string {
   const at = new Date(iso).getTime();

--- a/apps/web/src/lib/useList.ts
+++ b/apps/web/src/lib/useList.ts
@@ -1,0 +1,136 @@
+// apps/web/src/lib/useList.ts
+// The machine every resource list in this console runs: the first page in
+// flight, a keyset walk for the rest, and a reload that cancels whatever
+// that walk was doing. Generic over the row, because none of it is about
+// what the rows are — the sections differ in their columns and their
+// actions, not in how they load.
+import { useEffect, useRef, useState } from "react";
+import type { Page } from "./api";
+
+/** What a list is showing right now. `ready` is the only state with rows;
+ *  the others are what the page draws instead of a table. */
+export type ListState<T> =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; items: T[]; hasMore: boolean; cursor?: string };
+
+/**
+ * One page of rows. The api's list functions already have this shape, so a
+ * section passes its own straight in — and because they are module-level
+ * functions they are stable, which is what lets this be an effect
+ * dependency rather than something held in a ref.
+ */
+export type FetchPage<T> = (opts: { after?: string; signal: AbortSignal }) => Promise<Page<T>>;
+
+/** Placeholder rows while the first page is in flight — one per row a table
+ *  draws, so arriving data replaces them without the layout jumping. */
+export const SKELETON = [0, 1, 2];
+
+const messageOf = (err: unknown) => (err instanceof Error ? err.message : String(err));
+
+/**
+ * Rows keyed by `id`, newest first, with `prepend`/`replace` for the ones a
+ * page changes itself: this console's lists are ordered by creation, and no
+ * edit it can make moves a row, so a changed row is replaced where it is
+ * rather than re-fetched.
+ */
+export function useList<T extends { id: string }>(fetchPage: FetchPage<T>) {
+  const [state, setState] = useState<ListState<T>>({ status: "loading" });
+  const [more, setMore] = useState<{ busy: boolean; error?: string }>({ busy: false });
+  // Bumped to re-run the effect — refresh and retry both go through
+  // reload(), so a reload is one code path.
+  const [reloads, setReloads] = useState(0);
+  // The in-flight next-page request, if any. Held so a reload can cancel
+  // it: its rows belong to the walk being replaced, not to the new one.
+  const pagination = useRef<AbortController | null>(null);
+
+  // The reset lives here rather than in the effect: the click is what makes
+  // this loading again, and the effect's job is only to fetch.
+  function reload() {
+    setState({ status: "loading" });
+    setMore({ busy: false });
+    setReloads((n) => n + 1);
+  }
+
+  useEffect(() => {
+    const abort = new AbortController();
+    fetchPage({ signal: abort.signal }).then(
+      (page) =>
+        setState({
+          status: "ready",
+          items: page.data,
+          hasMore: page.hasMore,
+          cursor: page.lastId,
+        }),
+      (err: unknown) => {
+        if (abort.signal.aborted) return;
+        setState({ status: "error", message: messageOf(err) });
+      },
+    );
+    return () => {
+      abort.abort();
+      // Same generation, same fate: a page still arriving would otherwise
+      // append itself to — and move the cursor of — a list it is no longer
+      // part of, dropping or duplicating rows on the next Load more.
+      pagination.current?.abort();
+    };
+  }, [fetchPage, reloads]);
+
+  // The next page, appended. `cursor` is the previous page's last id — the
+  // keyset the api hands back, not an offset, so rows created meanwhile
+  // never shift the walk.
+  async function loadMore() {
+    if (state.status !== "ready" || state.cursor === undefined || more.busy) return;
+    const abort = new AbortController();
+    pagination.current = abort;
+    setMore({ busy: true });
+    try {
+      const page = await fetchPage({ after: state.cursor, signal: abort.signal });
+      setState((prev) =>
+        prev.status === "ready"
+          ? {
+              ...prev,
+              items: [...prev.items, ...page.data],
+              hasMore: page.hasMore,
+              cursor: page.lastId,
+            }
+          : prev,
+      );
+      setMore({ busy: false });
+    } catch (err) {
+      // Superseded by a reload, which has already reset this — nothing to
+      // report, and nothing of this walk left to report it against.
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      // The rows already on screen are still good: only the page that
+      // failed is news, so it reports beside the button, not over the list.
+      setMore({ busy: false, error: messageOf(err) });
+    }
+  }
+
+  /** A row just created. It is the newest, and this list is newest-first, so
+   *  it goes on the front; the cursor is a keyset rather than an offset, so
+   *  a row arriving at the head leaves the rest of the walk exactly where it
+   *  was and there is nothing to re-fetch. */
+  function prepend(item: T) {
+    // Off the ready path there is no list to add it to — the load that was
+    // already needed is what will show it.
+    if (state.status !== "ready") {
+      reload();
+      return;
+    }
+    setState((prev) =>
+      prev.status === "ready" ? { ...prev, items: [item, ...prev.items] } : prev,
+    );
+  }
+
+  /** A row that changed, put back where it was — see the header. */
+  function replace(item: T) {
+    setState((prev) =>
+      prev.status === "ready"
+        ? { ...prev, items: prev.items.map((row) => (row.id === item.id ? item : row)) }
+        : prev,
+    );
+  }
+
+  return { state, more, reload, loadMore, prepend, replace };
+}

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -5,6 +5,7 @@
 import type { ReactElement, SVGProps } from "react";
 import { AgentIcon, BoltIcon, EnvironmentIcon, SessionIcon } from "./components/Icons";
 import { AgentConfigs } from "./pages/AgentConfigs";
+import { EnvConfigs } from "./pages/EnvConfigs";
 
 /** What a page is handed: the part of the route below its own section, so
  *  a section can address something inside itself (`#/agent/<id>`) without
@@ -54,6 +55,7 @@ export const NAV_ITEMS: [NavItem, ...NavItem[]] = [
     blurb:
       "Env configs are the sandbox recipe: the base image a session's commands execute inside. One sandbox per session, bound in the store so it outlives any worker.",
     chip: "/v1/env-configs",
+    Page: EnvConfigs,
   },
   {
     id: "session",

--- a/apps/web/src/pages/AgentConfigs.css
+++ b/apps/web/src/pages/AgentConfigs.css
@@ -1,156 +1,11 @@
 /* apps/web/src/pages/AgentConfigs.css
-   The first data page: a header, a table, and the states around it. Sits at
-   the top of the routed pane rather than its centre (the pane centres the
-   hero placeholder), and every colour resolves to a token in index.css. */
-
-.agents {
-  align-self: start;
-  width: 100%;
-  max-width: 900px;
-  /* A grid item's auto min-width is min-content — which the table's own
-     min-width sets. Without this the section grows past the pane and the
-     page overflows sideways, instead of .table-wrap scrolling. */
-  min-width: 0;
-  animation: agents-in 420ms var(--ease);
-}
-
-/* Header ----------------------------------------------------------------- */
-
-.agents-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 18px;
-}
-
-.agents-title {
-  font-size: 21px;
-  font-weight: 600;
-  letter-spacing: -0.35px;
-  color: var(--text);
-}
-
-.notice-body code {
-  padding: 1px 5px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--bg-elev);
-  font: 500 12px var(--mono);
-  color: var(--text-2);
-}
-
-/* Actions ---------------------------------------------------------------- */
-
-/* .btn itself lives in index.css — the modal uses it too, and a shared
-   control shouldn't be defined by one page's stylesheet. */
-.agents-actions {
-  display: flex;
-  flex: none;
-  align-items: center;
-  gap: 10px;
-}
-
-/* Table ------------------------------------------------------------------ */
-
-/* The id column is a uuid: rather than truncate it, the table keeps its
-   natural width and this scrolls when the pane is narrower. */
-.table-wrap {
-  overflow-x: auto;
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  background: var(--bg-elev);
-  box-shadow: var(--shadow-sm);
-  scrollbar-width: thin;
-}
-
-.table {
-  width: 100%;
-  min-width: 700px;
-  border-collapse: collapse;
-}
-
-.table th {
-  padding: 10px 16px;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg-sunken);
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.13em;
-  text-transform: uppercase;
-  text-align: left;
-  color: var(--text-3);
-  white-space: nowrap;
-}
+   What only the agent list draws: the model column, and where the four
+   columns land once the pane is too narrow for a table. The header, the
+   table, the pill, the skeleton and the empty/error notices are
+   pages/list.css — every section's list is that one. */
 
 .col-model {
   width: 26%;
-}
-
-.col-status {
-  width: 122px;
-}
-
-.col-when {
-  width: 138px;
-}
-
-.table td {
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--border);
-  font-size: 13.5px;
-  color: var(--text-2);
-  white-space: nowrap;
-  transition: background-color var(--dur) var(--ease);
-}
-
-.table tbody tr:last-child td {
-  border-bottom: none;
-}
-
-.table tbody tr:hover td {
-  background: var(--hover);
-}
-
-.id {
-  font: 500 12.5px var(--mono);
-  color: var(--text);
-}
-
-/* A row is one link, stretched. The anchor lives in the id cell — so the
-   link's text is the id, which is what it addresses — and its ::after
-   covers the row, making the whole row the hit area without nesting
-   anything clickable inside anything else clickable. */
-.table tbody tr {
-  position: relative;
-}
-
-.row-link {
-  text-decoration: none;
-}
-
-.row-link::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  /* Above the cells, below nothing: no other control lives in a row. */
-  z-index: 1;
-}
-
-.table tbody tr:hover .row-link {
-  text-decoration: underline;
-  text-underline-offset: 2.5px;
-}
-
-/* The row is the target, so it is the row that shows the focus ring. */
-.row-link:focus-visible {
-  outline: none;
-}
-
-.table tbody tr:has(.row-link:focus-visible) {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
-  border-radius: 4px;
 }
 
 .model {
@@ -164,235 +19,46 @@
   color: var(--text-3);
 }
 
-/* Status ----------------------------------------------------------------- */
-
-.pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  padding: 3px 11px 3px 9px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.pill-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-}
-
-.pill-active {
-  color: var(--text-2);
-}
-
-.pill-active .pill-dot {
-  background: var(--ok);
-  box-shadow: 0 0 0 3px var(--ok-glow);
-}
-
-.pill-archived {
-  color: var(--text-3);
-  background: var(--bg-sunken);
-}
-
-.pill-archived .pill-dot {
-  background: var(--text-3);
-  opacity: 0.6;
-}
-
-/* Loading ---------------------------------------------------------------- */
-
-.bar {
-  display: block;
-  height: 11px;
-  border-radius: 5.5px;
-  background: linear-gradient(90deg, var(--bg-sunken), var(--hover), var(--bg-sunken));
-  background-size: 220% 100%;
-  animation: bar-shimmer 1.5s linear infinite;
-}
-
-.bar-id {
-  width: 268px;
-}
-
 .bar-model {
   width: 60%;
 }
 
-.bar-status {
-  width: 72px;
-}
-
-.bar-when {
-  width: 84px;
-}
-
-/* Error / empty ---------------------------------------------------------- */
-
-.notice {
-  display: grid;
-  justify-items: center;
-  gap: 9px;
-  padding: 46px 24px;
-  border: 1px dashed var(--border-strong);
-  border-radius: var(--r-lg);
-  background: var(--bg-elev);
-  text-align: center;
-}
-
-.notice-icon {
-  display: grid;
-  place-items: center;
-  width: 42px;
-  height: 42px;
-  margin-bottom: 2px;
-  border: 1px solid var(--border);
-  border-radius: 13px;
-  background: linear-gradient(180deg, var(--bg-elev), var(--accent-soft));
-  color: var(--accent);
-}
-
-.notice-title {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text);
-}
-
-.notice-body {
-  max-width: 52ch;
-  font-size: 13.5px;
-  line-height: 1.6;
-  color: var(--text-2);
-}
-
-.notice .btn {
-  margin-top: 8px;
-}
-
-/* Pagination ------------------------------------------------------------- */
-
-.agents-more {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  margin-top: 16px;
-}
-
-.agents-more-error {
-  font-size: 12.5px;
-  color: var(--text-3);
-}
-
-@keyframes agents-in {
-  from {
-    opacity: 0;
-    transform: translateY(9px);
-  }
-}
-
-@keyframes bar-shimmer {
-  from {
-    background-position: 130% 0;
-  }
-  to {
-    background-position: -30% 0;
-  }
-}
-
-/* Narrow pane: the four columns need about 790px before Created starts
-   getting clipped, and reaching it would mean scrolling the card sideways.
-   Under that, each row becomes a stacked card instead — the id, then the
-   model beside its status, then when it was created. The header row has
-   nothing left to label, so it goes with them.
-
-   Keyed to the pane rather than the window (see .content in App.css): a
-   1000px window still leaves this only ~700px once the sidebar is out. */
+/* Card layout (list.css turns the rows into cards at this width; this says
+   where this table's cells go): the id, then the model beside its status,
+   then when it was created. */
 @container pane (max-width: 790px) {
-  .table {
-    min-width: 0;
-  }
-
-  .table thead {
-    display: none;
-  }
-
-  .table,
-  .table tbody,
-  .table td {
-    display: block;
-  }
-
-  .table tr {
-    display: grid;
-    grid-template-columns: 1fr auto;
+  .agents .table tr {
     grid-template-areas:
       "id id"
       "model status"
       "when when";
-    gap: 5px 12px;
-    padding: 14px 16px;
-    border-bottom: 1px solid var(--border);
   }
 
-  .table tbody tr:last-child {
-    border-bottom: none;
-  }
-
-  .table td {
-    padding: 0;
-    border: none;
-    white-space: normal;
-  }
-
-  /* Hover lands on the whole card now, not one cell of it. */
-  .table tbody tr:hover {
-    background: var(--hover);
-  }
-
-  .table tbody tr:hover td {
-    background: none;
-  }
-
-  .table td:nth-child(1) {
+  .agents .table td:nth-child(1) {
     grid-area: id;
   }
 
-  .table td:nth-child(2) {
+  .agents .table td:nth-child(2) {
     grid-area: model;
   }
 
-  .table td:nth-child(3) {
+  .agents .table td:nth-child(3) {
     grid-area: status;
     align-self: center;
     justify-self: end;
   }
 
-  .table td:nth-child(4) {
+  .agents .table td:nth-child(4) {
     grid-area: when;
     font-size: 12.5px;
     color: var(--text-3);
-  }
-
-  /* A uuid is 36 characters: let it break rather than push the card wide. */
-  .id {
-    overflow-wrap: anywhere;
-  }
-
-  .bar-id {
-    width: 100%;
-  }
-
-  .notice {
-    padding: 38px 18px;
   }
 }
 
 /* A card with room for two columns: the status and the age sit beside the
    id and the model rather than under them, so the row stays two lines. */
 @container pane (min-width: 520px) and (max-width: 790px) {
-  .table tr {
+  .agents .table tr {
     grid-template-areas:
       "id status"
       "model when";
@@ -400,7 +66,7 @@
     gap: 7px 16px;
   }
 
-  .table td:nth-child(4) {
+  .agents .table td:nth-child(4) {
     justify-self: end;
   }
 }

--- a/apps/web/src/pages/AgentConfigs.tsx
+++ b/apps/web/src/pages/AgentConfigs.tsx
@@ -9,28 +9,16 @@
 // make this a changelog rather than an inventory.
 import { useEffect, useRef, useState } from "react";
 import { type AgentConfig, listAgentConfigs } from "../lib/api";
-import { absoluteTime, relativeTime } from "../lib/format";
+import { RELATIVE_TICK_MS, absoluteTime, relativeTime } from "../lib/format";
+import { SKELETON, useList } from "../lib/useList";
 import { useNow } from "../lib/useNow";
 import { AgentIcon, PlusIcon, RefreshIcon } from "../components/Icons";
+import { Status } from "../components/Status";
 import type { PageProps } from "../nav";
 import { CreateAgentConfig } from "./CreateAgentConfig";
 import { EditAgentConfig } from "./EditAgentConfig";
+import "./list.css";
 import "./AgentConfigs.css";
-
-type State =
-  | { status: "loading" }
-  | { status: "error"; message: string }
-  | { status: "ready"; configs: AgentConfig[]; hasMore: boolean; cursor?: string };
-
-/** Placeholder rows while the first page is in flight — same shape, so
- *  arriving data replaces them without the layout jumping. */
-const SKELETON = [0, 1, 2];
-
-/** How often the Created column re-reads the clock. Fine enough that the
- *  coarsest thing it prints — "1 minute ago" — is never a minute stale. */
-const TICK_MS = 30_000;
-
-const messageOf = (err: unknown) => (err instanceof Error ? err.message : String(err));
 
 /** This section's own route. Rows link into it by id, and closing the editor
  *  goes back to it — one place that spells the section's hash. */
@@ -42,54 +30,16 @@ const SECTION = "#/agent";
  * of its own, and stays linkable, back-navigable and reloadable.
  */
 export function AgentConfigs({ route }: PageProps) {
-  const [state, setState] = useState<State>({ status: "loading" });
-  const [more, setMore] = useState<{ busy: boolean; error?: string }>({ busy: false });
-  // Bumped to re-run the effect — refresh and retry both go through
-  // reload(), so a reload is one code path.
-  const [reloads, setReloads] = useState(0);
+  const { state, more, reload, loadMore, prepend, replace } =
+    useList<AgentConfig>(listAgentConfigs);
   // Relative timestamps are only true at the moment they render, so the
   // clock they read has to keep moving.
-  const now = useNow(TICK_MS);
-  // The in-flight next-page request, if any. Held so a reload can cancel
-  // it: its rows belong to the walk being replaced, not to the new one.
-  const pagination = useRef<AbortController | null>(null);
+  const now = useNow(RELATIVE_TICK_MS);
   const [creating, setCreating] = useState(false);
   // The header's Create button, which every state of this page renders. It
   // is where the dialog puts focus back when what opened it was the empty
   // state's button — the row it creates is what replaces that button.
   const createButton = useRef<HTMLButtonElement>(null);
-
-  // The reset lives here rather than in the effect: the click is what makes
-  // this loading again, and the effect's job is only to fetch.
-  function reload() {
-    setState({ status: "loading" });
-    setMore({ busy: false });
-    setReloads((n) => n + 1);
-  }
-
-  useEffect(() => {
-    const abort = new AbortController();
-    listAgentConfigs({ signal: abort.signal }).then(
-      (page) =>
-        setState({
-          status: "ready",
-          configs: page.data,
-          hasMore: page.hasMore,
-          cursor: page.lastId,
-        }),
-      (err: unknown) => {
-        if (abort.signal.aborted) return;
-        setState({ status: "error", message: messageOf(err) });
-      },
-    );
-    return () => {
-      abort.abort();
-      // Same generation, same fate: a page still arriving would otherwise
-      // append itself to — and move the cursor of — a list it is no longer
-      // part of, dropping or duplicating rows on the next Load more.
-      pagination.current?.abort();
-    };
-  }, [reloads]);
 
   // Whether the editor's history entry is one a row click pushed, rather
   // than where the page was opened. Closing has to UNDO a push — otherwise
@@ -105,7 +55,7 @@ export function AgentConfigs({ route }: PageProps) {
   // The row the editor is open on, when this page already has it. A deep
   // link can name one from a page the walk hasn't reached; the dialog
   // fetches that itself rather than making the list chase it.
-  const editing = state.status === "ready" ? state.configs.find((c) => c.id === route) : undefined;
+  const editing = state.status === "ready" ? state.items.find((c) => c.id === route) : undefined;
 
   /** Leaves `#/agent/<id>` for `#/agent` without leaving a dialog behind
    *  the Back button. */
@@ -123,69 +73,22 @@ export function AgentConfigs({ route }: PageProps) {
 
   // An update lands as a new version of the same config and an archive
   // marks that same config terminal, so either way the row is replaced
-  // where it is: this list is ordered by creation, which neither changes.
+  // where it is.
   function changed(config: AgentConfig) {
-    setState((prev) =>
-      prev.status === "ready"
-        ? { ...prev, configs: prev.configs.map((c) => (c.id === config.id ? config : c)) }
-        : prev,
-    );
+    replace(config);
     closeEditor();
   }
 
-  // A new config is the newest, and this list is newest-first, so it goes on
-  // the front. The cursor is a keyset rather than an offset, so a row
-  // arriving at the head leaves the rest of the walk exactly where it was —
-  // there is nothing to re-fetch.
   function added(config: AgentConfig) {
     setCreating(false);
-    // Off the ready path there is no list to add it to; the load that was
-    // already needed is what will show it.
-    if (state.status !== "ready") {
-      reload();
-      return;
-    }
-    setState((prev) =>
-      prev.status === "ready" ? { ...prev, configs: [config, ...prev.configs] } : prev,
-    );
-  }
-
-  // The next page, appended. `cursor` is the previous page's last id — the
-  // keyset the api hands back, not an offset, so rows created meanwhile
-  // never shift the walk.
-  async function loadMore() {
-    if (state.status !== "ready" || state.cursor === undefined || more.busy) return;
-    const abort = new AbortController();
-    pagination.current = abort;
-    setMore({ busy: true });
-    try {
-      const page = await listAgentConfigs({ after: state.cursor, signal: abort.signal });
-      setState((prev) =>
-        prev.status === "ready"
-          ? {
-              ...prev,
-              configs: [...prev.configs, ...page.data],
-              hasMore: page.hasMore,
-              cursor: page.lastId,
-            }
-          : prev,
-      );
-      setMore({ busy: false });
-    } catch (err) {
-      // Superseded by a reload, which has already reset this — nothing to
-      // report, and nothing of this walk left to report it against.
-      if (err instanceof DOMException && err.name === "AbortError") return;
-      // The rows already on screen are still good: only the page that
-      // failed is news, so it reports beside the button, not over the list.
-      setMore({ busy: false, error: messageOf(err) });
-    }
+    prepend(config);
   }
 
   return (
-    <section className="agents">
-      <header className="agents-head">
-        <h1 className="agents-title">Agent configs</h1>
-        <div className="agents-actions">
+    <section className="list agents">
+      <header className="list-head">
+        <h1 className="list-title">Agent configs</h1>
+        <div className="list-actions">
           <button
             className="btn"
             type="button"
@@ -216,7 +119,7 @@ export function AgentConfigs({ route }: PageProps) {
             Try again
           </button>
         </div>
-      ) : state.status === "ready" && state.configs.length === 0 ? (
+      ) : state.status === "ready" && state.items.length === 0 ? (
         <div className="notice">
           <span className="notice-icon" aria-hidden="true">
             <AgentIcon width={22} height={22} strokeWidth={1.6} />
@@ -260,7 +163,7 @@ export function AgentConfigs({ route }: PageProps) {
                       </td>
                     </tr>
                   ))
-                : state.configs.map((config) => (
+                : state.items.map((config) => (
                     <tr key={config.id}>
                       <td>
                         {/* One real anchor, stretched over the row by CSS:
@@ -309,30 +212,13 @@ export function AgentConfigs({ route }: PageProps) {
       )}
 
       {state.status === "ready" && state.hasMore ? (
-        <div className="agents-more">
+        <div className="list-more">
           <button className="btn" type="button" onClick={loadMore} disabled={more.busy}>
             {more.busy ? "Loading…" : "Load more"}
           </button>
-          {more.error ? <span className="agents-more-error">{more.error}</span> : null}
+          {more.error ? <span className="list-more-error">{more.error}</span> : null}
         </div>
       ) : null}
     </section>
-  );
-}
-
-/** Archive is the one terminal transition, so this is a state, not a toggle. */
-function Status({ archivedAt }: { archivedAt?: string }) {
-  return (
-    <span
-      className={archivedAt ? "pill pill-archived" : "pill pill-active"}
-      title={
-        archivedAt
-          ? `Archived ${absoluteTime(archivedAt)} — read-only, and no new session can use it`
-          : "Accepts updates and new sessions"
-      }
-    >
-      <span className="pill-dot" aria-hidden="true" />
-      {archivedAt ? "Archived" : "Active"}
-    </span>
   );
 }

--- a/apps/web/src/pages/EnvConfigs.css
+++ b/apps/web/src/pages/EnvConfigs.css
@@ -1,0 +1,36 @@
+/* apps/web/src/pages/EnvConfigs.css
+   What only the env list draws: where its three columns land once the pane
+   is too narrow for a table. Everything else — the header, the table, the
+   pill, the skeleton, the notices — is pages/list.css.
+
+   Three columns fit further down than the agent list's four, but they
+   reflow at the same width all the same (see the breakpoint's note in
+   list.css). */
+
+/* Card layout: the id on its own line, then the status with the age
+   opposite it — two short cells that stay side by side at any width the
+   pane reaches. */
+@container pane (max-width: 790px) {
+  .envs .table tr {
+    grid-template-areas:
+      "id id"
+      "status when";
+    align-items: center;
+    gap: 7px 16px;
+  }
+
+  .envs .table td:nth-child(1) {
+    grid-area: id;
+  }
+
+  .envs .table td:nth-child(2) {
+    grid-area: status;
+  }
+
+  .envs .table td:nth-child(3) {
+    grid-area: when;
+    justify-self: end;
+    font-size: 12.5px;
+    color: var(--text-3);
+  }
+}

--- a/apps/web/src/pages/EnvConfigs.tsx
+++ b/apps/web/src/pages/EnvConfigs.tsx
@@ -1,0 +1,123 @@
+// apps/web/src/pages/EnvConfigs.tsx
+// The Environment section: the namespace's env configs, newest first.
+//
+// An env config is the sandbox recipe — the network policy and the packages
+// a session's commands run inside. Unlike an agent config it is updated IN
+// PLACE, so there is no version to show: every row IS the current recipe,
+// and a session that already started carries its own copy of the one it
+// provisioned from.
+//
+// Three columns, and no row link: there is nothing to open yet. Creating
+// and editing recipes from here comes next, the way the agent section got
+// them — the list first, alone.
+import { type EnvConfig, listEnvConfigs } from "../lib/api";
+import { RELATIVE_TICK_MS, absoluteTime, relativeTime } from "../lib/format";
+import { SKELETON, useList } from "../lib/useList";
+import { useNow } from "../lib/useNow";
+import { EnvironmentIcon, RefreshIcon } from "../components/Icons";
+import { Status } from "../components/Status";
+import "./list.css";
+import "./EnvConfigs.css";
+
+/** Takes no route: this section is one view, so `#/environment` addresses
+ *  all of it. */
+export function EnvConfigs() {
+  const { state, more, reload, loadMore } = useList<EnvConfig>(listEnvConfigs);
+  // Relative timestamps are only true at the moment they render, so the
+  // clock they read has to keep moving.
+  const now = useNow(RELATIVE_TICK_MS);
+
+  return (
+    <section className="list envs">
+      <header className="list-head">
+        <h1 className="list-title">Env configs</h1>
+        <div className="list-actions">
+          <button
+            className="btn"
+            type="button"
+            onClick={reload}
+            disabled={state.status === "loading"}
+          >
+            <RefreshIcon />
+            Refresh
+          </button>
+        </div>
+      </header>
+
+      {state.status === "error" ? (
+        <div className="notice">
+          <p className="notice-title">Couldn&rsquo;t load env configs</p>
+          <p className="notice-body">{state.message}</p>
+          <button className="btn" type="button" onClick={reload}>
+            <RefreshIcon />
+            Try again
+          </button>
+        </div>
+      ) : state.status === "ready" && state.items.length === 0 ? (
+        <div className="notice">
+          <span className="notice-icon" aria-hidden="true">
+            <EnvironmentIcon width={22} height={22} strokeWidth={1.6} />
+          </span>
+          <p className="notice-title">No env configs yet</p>
+          <p className="notice-body">
+            A recipe is the sandbox a session&rsquo;s commands run inside — its network policy and
+            its packages. Post one to <code>/v1/env-configs</code> — creating them from here comes
+            next.
+          </p>
+        </div>
+      ) : (
+        <div className="table-wrap">
+          <table className="table">
+            <thead>
+              <tr>
+                <th className="col-id">Id</th>
+                <th className="col-status">Status</th>
+                <th className="col-when">Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              {state.status === "loading"
+                ? SKELETON.map((row) => (
+                    <tr key={row}>
+                      <td>
+                        <span className="bar bar-id" />
+                      </td>
+                      <td>
+                        <span className="bar bar-status" />
+                      </td>
+                      <td>
+                        <span className="bar bar-when" />
+                      </td>
+                    </tr>
+                  ))
+                : state.items.map((config) => (
+                    <tr key={config.id}>
+                      <td>
+                        <span className="id">{config.id}</span>
+                      </td>
+                      <td>
+                        <Status archivedAt={config.archivedAt} />
+                      </td>
+                      <td>
+                        <time dateTime={config.createdAt} title={absoluteTime(config.createdAt)}>
+                          {relativeTime(config.createdAt, now)}
+                        </time>
+                      </td>
+                    </tr>
+                  ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {state.status === "ready" && state.hasMore ? (
+        <div className="list-more">
+          <button className="btn" type="button" onClick={loadMore} disabled={more.busy}>
+            {more.busy ? "Loading…" : "Load more"}
+          </button>
+          {more.error ? <span className="list-more-error">{more.error}</span> : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/pages/list.css
+++ b/apps/web/src/pages/list.css
@@ -1,0 +1,316 @@
+/* apps/web/src/pages/list.css
+   What every resource list draws: a header, a table of rows, the states
+   around it, and the walk to the next page. A section's own stylesheet adds
+   only what is particular to ITS table — the extra columns and, in the card
+   layout below, where they sit. Every colour resolves to a token in
+   index.css. */
+
+.list {
+  align-self: start;
+  width: 100%;
+  max-width: 900px;
+  /* A grid item's auto min-width is min-content — which the table's own
+     min-width sets. Without this the section grows past the pane and the
+     page overflows sideways, instead of .table-wrap scrolling. */
+  min-width: 0;
+  animation: list-in 420ms var(--ease);
+}
+
+/* Header ----------------------------------------------------------------- */
+
+.list-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.list-title {
+  font-size: 21px;
+  font-weight: 600;
+  letter-spacing: -0.35px;
+  color: var(--text);
+}
+
+/* .btn itself lives in index.css — the modal uses it too, and a shared
+   control shouldn't be defined by one page's stylesheet. */
+.list-actions {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: 10px;
+}
+
+/* Table ------------------------------------------------------------------ */
+
+/* The id column is a uuid: rather than truncate it, the table keeps its
+   natural width and this scrolls when the pane is narrower. */
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--bg-elev);
+  box-shadow: var(--shadow-sm);
+  scrollbar-width: thin;
+}
+
+.table {
+  width: 100%;
+  min-width: 700px;
+  border-collapse: collapse;
+}
+
+.table th {
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-sunken);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  text-align: left;
+  color: var(--text-3);
+  white-space: nowrap;
+}
+
+/* The two columns every list ends with: one pill, and one relative time. */
+.col-status {
+  width: 122px;
+}
+
+.col-when {
+  width: 138px;
+}
+
+.table td {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  font-size: 13.5px;
+  color: var(--text-2);
+  white-space: nowrap;
+  transition: background-color var(--dur) var(--ease);
+}
+
+.table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+/* Only a row that opens something highlights under the cursor: a list with
+   nowhere to click shouldn't offer the affordance. */
+.table tbody tr:has(.row-link):hover td {
+  background: var(--hover);
+}
+
+.id {
+  font: 500 12.5px var(--mono);
+  color: var(--text);
+}
+
+/* A row is one link, stretched. The anchor lives in the id cell — so the
+   link's text is the id, which is what it addresses — and its ::after
+   covers the row, making the whole row the hit area without nesting
+   anything clickable inside anything else clickable. */
+.table tbody tr {
+  position: relative;
+}
+
+.row-link {
+  text-decoration: none;
+}
+
+.row-link::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  /* Above the cells, below nothing: no other control lives in a row. */
+  z-index: 1;
+}
+
+.table tbody tr:hover .row-link {
+  text-decoration: underline;
+  text-underline-offset: 2.5px;
+}
+
+/* The row is the target, so it is the row that shows the focus ring. */
+.row-link:focus-visible {
+  outline: none;
+}
+
+.table tbody tr:has(.row-link:focus-visible) {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  border-radius: 4px;
+}
+
+/* Loading ---------------------------------------------------------------- */
+
+.bar {
+  display: block;
+  height: 11px;
+  border-radius: 5.5px;
+  background: linear-gradient(90deg, var(--bg-sunken), var(--hover), var(--bg-sunken));
+  background-size: 220% 100%;
+  animation: bar-shimmer 1.5s linear infinite;
+}
+
+.bar-id {
+  width: 268px;
+}
+
+.bar-status {
+  width: 72px;
+}
+
+.bar-when {
+  width: 84px;
+}
+
+/* Error / empty ---------------------------------------------------------- */
+
+.notice {
+  display: grid;
+  justify-items: center;
+  gap: 9px;
+  padding: 46px 24px;
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--r-lg);
+  background: var(--bg-elev);
+  text-align: center;
+}
+
+.notice-icon {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  margin-bottom: 2px;
+  border: 1px solid var(--border);
+  border-radius: 13px;
+  background: linear-gradient(180deg, var(--bg-elev), var(--accent-soft));
+  color: var(--accent);
+}
+
+.notice-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.notice-body {
+  max-width: 52ch;
+  font-size: 13.5px;
+  line-height: 1.6;
+  color: var(--text-2);
+}
+
+.notice-body code {
+  padding: 1px 5px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-elev);
+  font: 500 12px var(--mono);
+  color: var(--text-2);
+}
+
+.notice .btn {
+  margin-top: 8px;
+}
+
+/* Pagination ------------------------------------------------------------- */
+
+.list-more {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.list-more-error {
+  font-size: 12.5px;
+  color: var(--text-3);
+}
+
+@keyframes list-in {
+  from {
+    opacity: 0;
+    transform: translateY(9px);
+  }
+}
+
+@keyframes bar-shimmer {
+  from {
+    background-position: 130% 0;
+  }
+  to {
+    background-position: -30% 0;
+  }
+}
+
+/* Narrow pane: the widest table here needs about 790px before its last
+   column starts getting clipped, and reaching that would mean scrolling the
+   card sideways. Under it, every row becomes a stacked card instead, and the
+   header row — with nothing left to label — goes away.
+
+   One breakpoint for every list rather than one per column count: two
+   sections a click apart shouldn't change shape at different widths. What
+   differs per table is only which cell lands where, which each page's own
+   stylesheet spells out as grid areas.
+
+   Keyed to the pane rather than the window (see .content in App.css): a
+   1000px window still leaves this only ~700px once the sidebar is out. */
+@container pane (max-width: 790px) {
+  .table {
+    min-width: 0;
+  }
+
+  .table thead {
+    display: none;
+  }
+
+  .table,
+  .table tbody,
+  .table td {
+    display: block;
+  }
+
+  .table tr {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 5px 12px;
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .table tbody tr:last-child {
+    border-bottom: none;
+  }
+
+  .table td {
+    padding: 0;
+    border: none;
+    white-space: normal;
+  }
+
+  /* Hover lands on the whole card now, not one cell of it. */
+  .table tbody tr:has(.row-link):hover {
+    background: var(--hover);
+  }
+
+  .table tbody tr:hover td {
+    background: none;
+  }
+
+  /* A uuid is 36 characters: let it break rather than push the card wide. */
+  .id {
+    overflow-wrap: anywhere;
+  }
+
+  .bar-id {
+    width: 100%;
+  }
+
+  .notice {
+    padding: 38px 18px;
+  }
+}


### PR DESCRIPTION
The Environment section now renders a real page instead of the placeholder: one page of the namespace's env configs, newest first, in three columns — id, status, created — with archived recipes listed beside live ones. There is no row link and no Create button because nothing sits behind a recipe yet, so the empty state points at `POST /v1/env-configs` instead. Building a second list meant sharing the first one's machinery rather than copying it, so `pages/list.css` now holds the table, notices, skeleton and pagination chrome every list draws, `lib/useList.ts` holds the fetch/abort/keyset walk, and `components/Status.tsx` holds the Active/Archived pill. `AgentConfigs` moves onto all three with no change in behaviour, and both tables reflow to cards at the same pane width so switching sections doesn't move the shared columns. Verified against a live stack — the row, empty, error and narrow-card states all render, and the Agent page is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)