### PR TITLE
Add env config creation to the console

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -260,6 +260,35 @@ export function archiveAgentConfig(
 }
 
 /**
+ * The create body, minus the namespace this console pins for every call.
+ * Every field is optional because every one has a default the api resolves
+ * at create — an absent network is unrestricted, absent packages are none —
+ * so what this omits is a decision left to the api, not one left unmade.
+ */
+export type CreateEnvConfigInput = {
+  network?: NetworkPolicy;
+  packages?: Packages;
+  metadata?: unknown;
+};
+
+/**
+ * Creates an env config and returns it MATERIALIZED: the defaults resolved,
+ * so the answer is the recipe as stored rather than the request that was
+ * sent. The namespace rides in the body here, as it does for agent configs.
+ */
+export function createEnvConfig(
+  input: CreateEnvConfigInput = {},
+  opts: { signal?: AbortSignal } = {},
+): Promise<EnvConfig> {
+  return post<EnvConfig>(
+    "/v1/env-configs",
+    { namespace: DEFAULT_NAMESPACE, ...input },
+    {},
+    opts.signal,
+  );
+}
+
+/**
  * One page of the namespace's env configs, newest first. Archived recipes
  * are listed beside live ones — they stay readable, and the sessions that
  * copied them keep running — so a row's status is worth a column.

--- a/apps/web/src/pages/CreateEnvConfig.tsx
+++ b/apps/web/src/pages/CreateEnvConfig.tsx
@@ -1,0 +1,169 @@
+// apps/web/src/pages/CreateEnvConfig.tsx
+// The Create Env dialog: the POST /v1/env-configs body as a form.
+//
+// The form writes the network policy and nothing else. Packages are the
+// recipe's other half and this dialog doesn't offer them yet — left out of
+// the body they are left absent, which the api resolves to {} at create, so
+// what lands is a recipe that installs nothing rather than a half-written
+// one. Metadata is omitted the way the agent dialog omits its optional
+// parts: it belongs to a recipe being tuned, not to one being made. Post the
+// body directly, or update the recipe afterwards, when either is what you
+// want.
+//
+// Namespace is omitted for the same reason as everywhere else: the console
+// addresses exactly one (see DEFAULT_NAMESPACE in lib/api.ts) and has no
+// switcher, so offering the field would let a recipe land somewhere the
+// list can't show it.
+import { type FormEvent, type RefObject, useState } from "react";
+import {
+  type CreateEnvConfigInput,
+  createEnvConfig,
+  DEFAULT_NAMESPACE,
+  type EnvConfig,
+  type NetworkPolicy,
+} from "../lib/api";
+import { Field } from "../components/Field";
+import { Modal } from "../components/Modal";
+
+/** The three policies core defines, in the order they narrow: reach
+ *  anything, reach a named few, reach nothing. */
+const POLICIES = [
+  { id: "unrestricted", label: "Unrestricted — reach anything" },
+  { id: "allowlist", label: "Allowlist — reach only these domains" },
+  { id: "none", label: "None — no network at all" },
+];
+
+/** Only the allowlist carries anything beyond its own name, so `domains` is
+ *  held beside the type rather than inside it: switching policies twice
+ *  comes back to what was typed. */
+type Fields = { type: NetworkPolicy["type"]; domains: string };
+
+const messageOf = (err: unknown) => (err instanceof Error ? err.message : String(err));
+
+/**
+ * The domains as typed, one per line or comma-separated, in the order they
+ * were written. Blanks are dropped and repeats collapsed — neither is a
+ * domain the sandbox could be told about twice — but nothing else is
+ * touched: the api takes these as strings and this console is in no
+ * position to decide what a hostname may look like.
+ */
+function parseDomains(text: string): string[] {
+  const seen = new Set<string>();
+  for (const entry of text.split(/[\n,]/)) {
+    const domain = entry.trim();
+    if (domain !== "") seen.add(domain);
+  }
+  return [...seen];
+}
+
+export function CreateEnvConfig({
+  onCreated,
+  onClose,
+  returnFocus,
+}: {
+  /** The new recipe, materialized — the caller puts it on the list. */
+  onCreated: (config: EnvConfig) => void;
+  onClose: () => void;
+  /** Focus lands here if creating the recipe removed whatever opened this
+   *  (Modal's `returnFocus`) — the first row replaces the empty state. */
+  returnFocus?: RefObject<HTMLElement | null>;
+}) {
+  // The api's own default is where the form starts: an unrestricted recipe
+  // is what posting an empty body would have made.
+  const [fields, setFields] = useState<Fields>({ type: "unrestricted", domains: "" });
+  const [busy, setBusy] = useState(false);
+  // The api's refusal — a 400, or an api that isn't there.
+  const [failure, setFailure] = useState<string>();
+
+  const allowlist = fields.type === "allowlist";
+  const domains = allowlist ? parseDomains(fields.domains) : [];
+  // An allowlist of nothing reaches nothing, which is what `none` already
+  // says — and says legibly. So the form asks for the domain rather than
+  // taking a recipe whose type and effect disagree.
+  const incomplete = allowlist && domains.length === 0;
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    if (busy || incomplete) return;
+
+    const network: NetworkPolicy = allowlist
+      ? { type: "allowlist", domains }
+      : { type: fields.type as "unrestricted" | "none" };
+    const input: CreateEnvConfigInput = { network };
+
+    setFailure(undefined);
+    setBusy(true);
+    try {
+      // No abort signal: a create in flight is a row that may well exist, so
+      // the dialog refuses to close (dismissible below) rather than walk
+      // away from an answer it would then have to guess at.
+      onCreated(await createEnvConfig(input));
+      // Created — the caller unmounts this, so there is no state to reset.
+    } catch (err) {
+      setFailure(messageOf(err));
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Modal
+      title="Create env config"
+      description={
+        <>
+          The network a session&rsquo;s commands can reach. Lands in the{" "}
+          <code>{DEFAULT_NAMESPACE}</code> namespace with no packages — those aren&rsquo;t set here
+          yet.
+        </>
+      }
+      dismissible={!busy}
+      returnFocus={returnFocus}
+      onClose={onClose}
+    >
+      <form className="modal-form" onSubmit={submit} noValidate>
+        <div className="modal-body form-fields">
+          <Field
+            label="Network"
+            name="network"
+            value={fields.type}
+            onChange={(type) =>
+              setFields((prev) => ({ ...prev, type: type as NetworkPolicy["type"] }))
+            }
+            options={POLICIES}
+            autoFocus
+            required
+          />
+
+          {/* The one policy with anything to say beyond its name. Keyed to
+              nothing and mounted only here: a recipe that isn't an allowlist
+              has no domains to show, and an empty box would suggest it did. */}
+          {allowlist ? (
+            <Field
+              label="Domains"
+              name="domains"
+              value={fields.domains}
+              onChange={(text) => setFields((prev) => ({ ...prev, domains: text }))}
+              placeholder={"pypi.org\nfiles.pythonhosted.org"}
+              rows={4}
+              multiline
+              required
+            />
+          ) : null}
+        </div>
+
+        <footer className="modal-foot">
+          {failure ? (
+            <p className="form-failure" role="alert">
+              {failure}
+            </p>
+          ) : null}
+          <button className="btn" type="button" onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+          <button className="btn btn-primary" type="submit" disabled={busy || incomplete}>
+            {busy ? "Creating…" : "Create"}
+          </button>
+        </footer>
+      </form>
+    </Modal>
+  );
+}

--- a/apps/web/src/pages/EnvConfigs.tsx
+++ b/apps/web/src/pages/EnvConfigs.tsx
@@ -7,25 +7,37 @@
 // and a session that already started carries its own copy of the one it
 // provisioned from.
 //
-// Three columns, and no row link: there is nothing to open yet. Creating
-// and editing recipes from here comes next, the way the agent section got
-// them — the list first, alone.
+// Three columns, and no row link: there is nothing to open yet. Create
+// writes the network policy only; packages are the recipe's other half and
+// come later (see CreateEnvConfig).
+import { useRef, useState } from "react";
 import { type EnvConfig, listEnvConfigs } from "../lib/api";
 import { RELATIVE_TICK_MS, absoluteTime, relativeTime } from "../lib/format";
 import { SKELETON, useList } from "../lib/useList";
 import { useNow } from "../lib/useNow";
-import { EnvironmentIcon, RefreshIcon } from "../components/Icons";
+import { EnvironmentIcon, PlusIcon, RefreshIcon } from "../components/Icons";
 import { Status } from "../components/Status";
+import { CreateEnvConfig } from "./CreateEnvConfig";
 import "./list.css";
 import "./EnvConfigs.css";
 
 /** Takes no route: this section is one view, so `#/environment` addresses
  *  all of it. */
 export function EnvConfigs() {
-  const { state, more, reload, loadMore } = useList<EnvConfig>(listEnvConfigs);
+  const { state, more, reload, loadMore, prepend } = useList<EnvConfig>(listEnvConfigs);
   // Relative timestamps are only true at the moment they render, so the
   // clock they read has to keep moving.
   const now = useNow(RELATIVE_TICK_MS);
+  const [creating, setCreating] = useState(false);
+  // The header's Create button, which every state of this page renders. It
+  // is where the dialog puts focus back when what opened it was the empty
+  // state's button — the row it creates is what replaces that button.
+  const createButton = useRef<HTMLButtonElement>(null);
+
+  function added(config: EnvConfig) {
+    setCreating(false);
+    prepend(config);
+  }
 
   return (
     <section className="list envs">
@@ -40,6 +52,15 @@ export function EnvConfigs() {
           >
             <RefreshIcon />
             Refresh
+          </button>
+          <button
+            className="btn btn-primary"
+            type="button"
+            ref={createButton}
+            onClick={() => setCreating(true)}
+          >
+            <PlusIcon />
+            Create
           </button>
         </div>
       </header>
@@ -61,9 +82,12 @@ export function EnvConfigs() {
           <p className="notice-title">No env configs yet</p>
           <p className="notice-body">
             A recipe is the sandbox a session&rsquo;s commands run inside — its network policy and
-            its packages. Post one to <code>/v1/env-configs</code> — creating them from here comes
-            next.
+            its packages. Create the first one, or post it yourself to <code>/v1/env-configs</code>.
           </p>
+          <button className="btn btn-primary" type="button" onClick={() => setCreating(true)}>
+            <PlusIcon />
+            Create env config
+          </button>
         </div>
       ) : (
         <div className="table-wrap">
@@ -109,6 +133,14 @@ export function EnvConfigs() {
           </table>
         </div>
       )}
+
+      {creating ? (
+        <CreateEnvConfig
+          onCreated={added}
+          onClose={() => setCreating(false)}
+          returnFocus={createButton}
+        />
+      ) : null}
 
       {state.status === "ready" && state.hasMore ? (
         <div className="list-more">


### PR DESCRIPTION
The Environment section gets a Create button — in the header and in the empty state — over a dialog that writes the network policy: a select over the three policies core defines (unrestricted, allowlist, none), with a domains box that appears only for the allowlist, the one policy carrying anything beyond its own name. Domains are read one per line or comma-separated, trimmed, with blanks dropped and repeats collapsed; nothing else is touched, since the api takes them as strings and the console can't decide what a hostname may look like. An allowlist with no domains reaches nothing, which is what `none` already says legibly, so Create stays disabled until there is at least one. Packages are the recipe's other half and aren't offered yet — they're left out of the body rather than sent empty, which the api resolves to `{}` at create, and the dialog's description says as much. Verified against a live stack: the dialog posts, the row lands at the top of the list, and the api stored `{"type":"allowlist","domains":["pypi.org","files.pythonhosted.org"]}` with `packages: {}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)