### PR TITLE
Make env configs clickable and editable in the console

### DIFF
--- a/apps/web/src/components/Modal.css
+++ b/apps/web/src/components/Modal.css
@@ -103,6 +103,32 @@ body:has(dialog.modal[open]) {
   color: var(--text-2);
 }
 
+/* A boxed aside above the fields — what a dialog has to say about the
+   thing before offering it, like a config that takes no more updates. */
+.note {
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--bg-sunken);
+  font-size: 12.5px;
+}
+
+/* The id under the title, and whatever fact sits under that — what an edit
+   is being made against. Both belong to Modal's `description` slot, so they
+   live with it rather than in whichever dialog used them first. */
+.mono-id {
+  font: 500 12px var(--mono);
+  color: var(--text-2);
+  overflow-wrap: anywhere;
+}
+
+.meta {
+  display: block;
+  margin-top: 3px;
+  font-size: 12px;
+  color: var(--text-3);
+}
+
 /* Any literal in a body — an env var, an endpoint, an id — reads as one. */
 .modal-body code {
   padding: 1px 5px;

--- a/apps/web/src/components/NetworkFields.tsx
+++ b/apps/web/src/components/NetworkFields.tsx
@@ -1,0 +1,50 @@
+// apps/web/src/components/NetworkFields.tsx
+// The network policy as two controls: the policy itself, and — for the one
+// policy that carries anything beyond its own name — the domains on it.
+// Shared by the create and edit dialogs so the field a recipe is written
+// with is the same field it is edited through.
+import { Field } from "./Field";
+import { type NetworkFields as Fields, POLICIES } from "../lib/network";
+
+export function NetworkFields({
+  fields,
+  onChange,
+  /** An archived recipe takes no update, so its policy is shown rather
+   *  than offered. */
+  disabled,
+}: {
+  fields: Fields;
+  onChange: (fields: Fields) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <>
+      <Field
+        label="Network"
+        name="network"
+        value={fields.type}
+        onChange={(type) => onChange({ ...fields, type: type as Fields["type"] })}
+        options={POLICIES}
+        disabled={disabled}
+        autoFocus
+        required
+      />
+
+      {/* Mounted only for the allowlist: a recipe that isn't one has no
+          domains to show, and an empty box would suggest it did. */}
+      {fields.type === "allowlist" ? (
+        <Field
+          label="Domains"
+          name="domains"
+          value={fields.domains}
+          onChange={(domains) => onChange({ ...fields, domains })}
+          placeholder={"pypi.org\nfiles.pythonhosted.org"}
+          rows={4}
+          disabled={disabled}
+          multiline
+          required
+        />
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -306,3 +306,42 @@ export function listEnvConfigs(
     opts.signal,
   );
 }
+
+/** One recipe by id. What a deep link resolves against when the row isn't
+ *  on a page the list has walked to yet. */
+export function getEnvConfig(id: string, opts: { signal?: AbortSignal } = {}): Promise<EnvConfig> {
+  return get<EnvConfig>(
+    `/v1/env-configs/${encodeURIComponent(id)}`,
+    { namespace: DEFAULT_NAMESPACE },
+    opts.signal,
+  );
+}
+
+/**
+ * A partial update, applied IN PLACE. Absent fields are left as they were,
+ * so what a caller doesn't send — packages, metadata — survives the edit.
+ *
+ * There is no `version` here, and its absence is the point: an env config
+ * has no immutable version to pin, so this carries no optimistic-concurrency
+ * precondition the way an agent config's update does. Two edits racing means
+ * the later write wins outright. An archived recipe takes no update at all —
+ * the api answers 409 rather than reviving it.
+ */
+export type UpdateEnvConfigInput = {
+  network?: NetworkPolicy;
+  packages?: Packages;
+  metadata?: unknown;
+};
+
+export function updateEnvConfig(
+  id: string,
+  input: UpdateEnvConfigInput,
+  opts: { signal?: AbortSignal } = {},
+): Promise<EnvConfig> {
+  return post<EnvConfig>(
+    `/v1/env-configs/${encodeURIComponent(id)}`,
+    input,
+    { namespace: DEFAULT_NAMESPACE },
+    opts.signal,
+  );
+}

--- a/apps/web/src/lib/network.ts
+++ b/apps/web/src/lib/network.ts
@@ -1,0 +1,66 @@
+// apps/web/src/lib/network.ts
+// The network policy as a form: the choices a dialog offers, the reading of
+// what gets typed into the one choice that carries anything, and the two
+// conversions between a stored policy and the fields holding it. Shared by
+// the create and edit dialogs, which write the same field of the same
+// recipe and must not drift apart in how they read it.
+import type { NetworkPolicy } from "./api";
+
+/** The three policies core defines, in the order they narrow: reach
+ *  anything, reach a named few, reach nothing. */
+export const POLICIES = [
+  { id: "unrestricted", label: "Unrestricted — reach anything" },
+  { id: "allowlist", label: "Allowlist — reach only these domains" },
+  { id: "none", label: "None — no network at all" },
+];
+
+/** What a form holds while it is being filled. `domains` sits BESIDE the
+ *  type rather than inside it, so switching policies twice comes back to
+ *  what was typed rather than to nothing. */
+export type NetworkFields = { type: NetworkPolicy["type"]; domains: string };
+
+/**
+ * The domains as typed, one per line or comma-separated, in the order they
+ * were written. Blanks are dropped and repeats collapsed — neither is a
+ * domain the sandbox could be told about twice — but nothing else is
+ * touched: the api takes these as strings and this console is in no
+ * position to decide what a hostname may look like.
+ */
+export function parseDomains(text: string): string[] {
+  const seen = new Set<string>();
+  for (const entry of text.split(/[\n,]/)) {
+    const domain = entry.trim();
+    if (domain !== "") seen.add(domain);
+  }
+  return [...seen];
+}
+
+/**
+ * The fields as a policy — or nothing, when the allowlist has no domain on
+ * it. An allowlist of nothing reaches nothing, which is what `none` already
+ * says legibly, so a form asks for the domain rather than writing a recipe
+ * whose type and effect disagree. Callers read the absence as "not ready".
+ */
+export function toPolicy(fields: NetworkFields): NetworkPolicy | undefined {
+  if (fields.type === "unrestricted") return { type: "unrestricted" };
+  if (fields.type === "none") return { type: "none" };
+  const domains = parseDomains(fields.domains);
+  return domains.length === 0 ? undefined : { type: "allowlist", domains };
+}
+
+/** A stored policy as fields, for a form that starts from one. */
+export function fieldsOf(network: NetworkPolicy): NetworkFields {
+  return {
+    type: network.type,
+    domains: network.type === "allowlist" ? network.domains.join("\n") : "",
+  };
+}
+
+/** Whether two policies say the same thing: the same type, and for an
+ *  allowlist the same domains in the same order. What an edit compares
+ *  against to know whether there is anything to save. */
+export function samePolicy(a: NetworkPolicy, b: NetworkPolicy): boolean {
+  if (a.type !== b.type) return false;
+  if (a.type !== "allowlist" || b.type !== "allowlist") return true;
+  return a.domains.length === b.domains.length && a.domains.every((d, i) => d === b.domains[i]);
+}

--- a/apps/web/src/lib/useList.ts
+++ b/apps/web/src/lib/useList.ts
@@ -29,6 +29,25 @@ export const SKELETON = [0, 1, 2];
 const messageOf = (err: unknown) => (err instanceof Error ? err.message : String(err));
 
 /**
+ * Whether an answer may still land when its token TIES the one already held
+ * — the other half of a `supersedes` test (see replace()).
+ *
+ * The tie is not hypothetical: archiving mints no token of its own. An env
+ * config's updatedAt marks the last edit and archiving is not one; an agent
+ * config's archive writes no version. So the archived answer and the update
+ * just before it carry the same token, and whichever arrived second would
+ * otherwise win — letting a late update answer show a retired row as active.
+ * Archive is terminal, so at a tie it is the later fact, and the only answer
+ * that may still land is one that does not undo it.
+ */
+export function keepsArchive(
+  incoming: { archivedAt?: string },
+  held: { archivedAt?: string },
+): boolean {
+  return incoming.archivedAt !== undefined || held.archivedAt === undefined;
+}
+
+/**
  * Rows keyed by `id`, newest first, with `prepend`/`replace` for the ones a
  * page changes itself: this console's lists are ordered by creation, and no
  * edit it can make moves a row, so a changed row is replaced where it is
@@ -123,11 +142,34 @@ export function useList<T extends { id: string }>(fetchPage: FetchPage<T>) {
     );
   }
 
-  /** A row that changed, put back where it was — see the header. */
-  function replace(item: T) {
+  /**
+   * A row that changed, put back where it was — unless the copy already held
+   * is the fresher one.
+   *
+   * Writes to a single row can overlap: an editor is not the only thing that
+   * can have one in flight, and a save outliving the dialog that sent it can
+   * land after a later one. Their answers need not arrive in the order the
+   * api committed them, so a list that always took the newest ANSWER would
+   * settle on a row the api no longer holds — and the next editor would
+   * start from it.
+   *
+   * `supersedes` is how a caller says which of two copies is the later one,
+   * using whatever monotonic token its resource has; only the caller knows
+   * what that is — and keepsArchive() below settles the ties that token
+   * cannot. Without one the incoming row wins, which is right for a list
+   * whose rows are replaced only by writes that cannot overlap.
+   */
+  function replace(item: T, supersedes?: (incoming: T, held: T) => boolean) {
     setState((prev) =>
       prev.status === "ready"
-        ? { ...prev, items: prev.items.map((row) => (row.id === item.id ? item : row)) }
+        ? {
+            ...prev,
+            items: prev.items.map((row) =>
+              row.id !== item.id || (supersedes !== undefined && !supersedes(item, row))
+                ? row
+                : item,
+            ),
+          }
         : prev,
     );
   }

--- a/apps/web/src/pages/AgentConfigs.tsx
+++ b/apps/web/src/pages/AgentConfigs.tsx
@@ -10,7 +10,7 @@
 import { useEffect, useRef, useState } from "react";
 import { type AgentConfig, listAgentConfigs } from "../lib/api";
 import { RELATIVE_TICK_MS, absoluteTime, relativeTime } from "../lib/format";
-import { SKELETON, useList } from "../lib/useList";
+import { keepsArchive, SKELETON, useList } from "../lib/useList";
 import { useNow } from "../lib/useNow";
 import { AgentIcon, PlusIcon, RefreshIcon } from "../components/Icons";
 import { Status } from "../components/Status";
@@ -74,9 +74,23 @@ export function AgentConfigs({ route }: PageProps) {
   // An update lands as a new version of the same config and an archive
   // marks that same config terminal, so either way the row is replaced
   // where it is.
+  //
+  // Only the row: closing is the dialog's own to do. A write is not aborted
+  // when its editor goes away, and the route it was sent from does not
+  // identify that editor — reopening the same config gives the same route a
+  // different dialog. Only the dialog knows whether it is still the one
+  // open, so it is the one that decides whether to close (see
+  // EditAgentConfig).
   function changed(config: AgentConfig) {
-    replace(config);
-    closeEditor();
+    // Never older than what is already held — see EnvConfigs for why answers
+    // can arrive out of commit order. Here the token is the version, which is
+    // monotonic by construction; an archive writes no version, so it ties
+    // with the update before it and keepsArchive() settles which one wins.
+    replace(config, (incoming, held) =>
+      incoming.version === held.version
+        ? keepsArchive(incoming, held)
+        : incoming.version > held.version,
+    );
   }
 
   function added(config: AgentConfig) {

--- a/apps/web/src/pages/CreateEnvConfig.tsx
+++ b/apps/web/src/pages/CreateEnvConfig.tsx
@@ -20,41 +20,12 @@ import {
   createEnvConfig,
   DEFAULT_NAMESPACE,
   type EnvConfig,
-  type NetworkPolicy,
 } from "../lib/api";
-import { Field } from "../components/Field";
+import { type NetworkFields, toPolicy } from "../lib/network";
+import { NetworkFields as NetworkFieldset } from "../components/NetworkFields";
 import { Modal } from "../components/Modal";
 
-/** The three policies core defines, in the order they narrow: reach
- *  anything, reach a named few, reach nothing. */
-const POLICIES = [
-  { id: "unrestricted", label: "Unrestricted — reach anything" },
-  { id: "allowlist", label: "Allowlist — reach only these domains" },
-  { id: "none", label: "None — no network at all" },
-];
-
-/** Only the allowlist carries anything beyond its own name, so `domains` is
- *  held beside the type rather than inside it: switching policies twice
- *  comes back to what was typed. */
-type Fields = { type: NetworkPolicy["type"]; domains: string };
-
 const messageOf = (err: unknown) => (err instanceof Error ? err.message : String(err));
-
-/**
- * The domains as typed, one per line or comma-separated, in the order they
- * were written. Blanks are dropped and repeats collapsed — neither is a
- * domain the sandbox could be told about twice — but nothing else is
- * touched: the api takes these as strings and this console is in no
- * position to decide what a hostname may look like.
- */
-function parseDomains(text: string): string[] {
-  const seen = new Set<string>();
-  for (const entry of text.split(/[\n,]/)) {
-    const domain = entry.trim();
-    if (domain !== "") seen.add(domain);
-  }
-  return [...seen];
-}
 
 export function CreateEnvConfig({
   onCreated,
@@ -70,25 +41,19 @@ export function CreateEnvConfig({
 }) {
   // The api's own default is where the form starts: an unrestricted recipe
   // is what posting an empty body would have made.
-  const [fields, setFields] = useState<Fields>({ type: "unrestricted", domains: "" });
+  const [fields, setFields] = useState<NetworkFields>({ type: "unrestricted", domains: "" });
   const [busy, setBusy] = useState(false);
   // The api's refusal — a 400, or an api that isn't there.
   const [failure, setFailure] = useState<string>();
 
-  const allowlist = fields.type === "allowlist";
-  const domains = allowlist ? parseDomains(fields.domains) : [];
-  // An allowlist of nothing reaches nothing, which is what `none` already
-  // says — and says legibly. So the form asks for the domain rather than
-  // taking a recipe whose type and effect disagree.
-  const incomplete = allowlist && domains.length === 0;
+  // Absent while the allowlist has no domain on it — the one state of this
+  // form that isn't a policy yet (see toPolicy).
+  const network = toPolicy(fields);
 
   async function submit(event: FormEvent) {
     event.preventDefault();
-    if (busy || incomplete) return;
+    if (busy || network === undefined) return;
 
-    const network: NetworkPolicy = allowlist
-      ? { type: "allowlist", domains }
-      : { type: fields.type as "unrestricted" | "none" };
     const input: CreateEnvConfigInput = { network };
 
     setFailure(undefined);
@@ -121,33 +86,9 @@ export function CreateEnvConfig({
     >
       <form className="modal-form" onSubmit={submit} noValidate>
         <div className="modal-body form-fields">
-          <Field
-            label="Network"
-            name="network"
-            value={fields.type}
-            onChange={(type) =>
-              setFields((prev) => ({ ...prev, type: type as NetworkPolicy["type"] }))
-            }
-            options={POLICIES}
-            autoFocus
-            required
-          />
-
-          {/* The one policy with anything to say beyond its name. Keyed to
-              nothing and mounted only here: a recipe that isn't an allowlist
-              has no domains to show, and an empty box would suggest it did. */}
-          {allowlist ? (
-            <Field
-              label="Domains"
-              name="domains"
-              value={fields.domains}
-              onChange={(text) => setFields((prev) => ({ ...prev, domains: text }))}
-              placeholder={"pypi.org\nfiles.pythonhosted.org"}
-              rows={4}
-              multiline
-              required
-            />
-          ) : null}
+          {/* The body went to the api when the click did, so a form still
+              taking edits would be collecting what the close discards. */}
+          <NetworkFieldset fields={fields} onChange={setFields} disabled={busy} />
         </div>
 
         <footer className="modal-foot">
@@ -159,7 +100,11 @@ export function CreateEnvConfig({
           <button className="btn" type="button" onClick={onClose} disabled={busy}>
             Cancel
           </button>
-          <button className="btn btn-primary" type="submit" disabled={busy || incomplete}>
+          <button
+            className="btn btn-primary"
+            type="submit"
+            disabled={busy || network === undefined}
+          >
             {busy ? "Creating…" : "Create"}
           </button>
         </footer>

--- a/apps/web/src/pages/EditAgentConfig.css
+++ b/apps/web/src/pages/EditAgentConfig.css
@@ -1,32 +1,8 @@
 /* apps/web/src/pages/EditAgentConfig.css
-   What only the edit dialog draws. The panel, body and footer are
-   components/Modal.css; the fields are components/Field.css. Every colour
+   What only the agent edit dialog draws — Archive, the one action here that
+   isn't an edit. The panel, body and footer are components/Modal.css (.note
+   and .mono-id with them); the fields are components/Field.css. Every colour
    resolves to a token in index.css. */
-
-/* The id and what version it is at, under the title — the two facts an edit
-   is made against. */
-.mono-id {
-  font: 500 12px var(--mono);
-  color: var(--text-2);
-  overflow-wrap: anywhere;
-}
-
-.meta {
-  display: block;
-  margin-top: 3px;
-  font-size: 12px;
-  color: var(--text-3);
-}
-
-/* A config with no way back to editable says so above the fields it has
-   disabled, not after a Save the api would refuse. */
-.archived-note {
-  padding: 10px 12px;
-  border: 1px solid var(--border);
-  border-radius: var(--r-sm);
-  background: var(--bg-sunken);
-  font-size: 12.5px;
-}
 
 /* Archive is the footer's left-hand action, so the two buttons that answer
    the form — Cancel and Save — stay together on the right, and the one that

--- a/apps/web/src/pages/EditAgentConfig.tsx
+++ b/apps/web/src/pages/EditAgentConfig.tsx
@@ -19,7 +19,7 @@
 // api would refuse. Archiving is what puts a config there, and it archives
 // on the click: no confirmation step, so the red label on its button is the
 // whole of the warning.
-import { type FormEvent, type RefObject, useEffect, useState } from "react";
+import { type FormEvent, type RefObject, useEffect, useRef, useState } from "react";
 import {
   type AgentConfig,
   archiveAgentConfig,
@@ -118,9 +118,13 @@ export function EditAgentConfig({
       onChanged={onChanged}
       onClose={onClose}
       returnFocus={returnFocus}
-      // A save replaces the config the form was built from, so the form
-      // starts again from what came back rather than from what was typed.
-      key={`${loaded.id}@${loaded.version}`}
+      // Keyed on the config, and deliberately NOT on its version: a dialog
+      // that saves or archives closes itself, so the only thing a fresher
+      // `loaded` can mean here is that someone ELSE moved the row — a write
+      // from a previous instance of this editor landing late, say.
+      // Remounting on that would throw away whatever is typed in this one to
+      // show a version nobody in this dialog asked for.
+      key={loaded.id}
     />
   );
 }
@@ -143,6 +147,24 @@ function EditForm({
   // either, so one value says it — and each button can still name its own.
   const [pending, setPending] = useState<"saving" | "archiving">();
   const busy = pending !== undefined;
+
+  // Whether this editor is still the one on screen. Nothing aborts a write
+  // when its dialog goes away — pressing Back, leaving the section, or
+  // reopening the same config all unmount THIS instance while the request
+  // is still out — and a completion arriving afterwards must not navigate:
+  // the dialog it would close belongs to a later instance, quite possibly
+  // with edits in it. The row it carries is still worth handing up, and
+  // fresher for it; only the closing is conditional.
+  const live = useRef(true);
+  useEffect(() => {
+    // Set on the way in as well as cleared on the way out: StrictMode mounts
+    // twice, and an effect that only cleared would leave this false for the
+    // whole life of the second mount — closing nothing, ever.
+    live.current = true;
+    return () => {
+      live.current = false;
+    };
+  }, []);
 
   const archived = config.archivedAt !== undefined;
   const saved = fieldsOf(config);
@@ -196,6 +218,7 @@ function EditForm({
     setPending("saving");
     try {
       onChanged(await updateAgentConfig(config.id, input));
+      if (live.current) onClose();
     } catch (err) {
       setFailure(messageOf(err));
       setPending(undefined);
@@ -211,6 +234,7 @@ function EditForm({
     setPending("archiving");
     try {
       onChanged(await archiveAgentConfig(config.id));
+      if (live.current) onClose();
     } catch (err) {
       setFailure(messageOf(err));
       setPending(undefined);
@@ -235,12 +259,15 @@ function EditForm({
       <form className="modal-form" onSubmit={submit} noValidate>
         <div className="modal-body form-fields">
           {archived ? (
-            <p className="prose archived-note">
+            <p className="prose note">
               This config is archived: it stays readable, and the sessions that pinned it keep
               running, but it takes no further updates and no new session can use it.
             </p>
           ) : null}
 
+          {/* Disabled while a write is in flight as well as when archived:
+              the body went to the api when the click did, so anything typed
+              after it would be silently dropped by the close that follows. */}
           <div className="field-row">
             <Field
               label="Provider"
@@ -251,7 +278,7 @@ function EditForm({
                 PROVIDERS.map((entry) => ({ id: entry.id, label: entry.label })),
                 fields.provider,
               )}
-              disabled={archived}
+              disabled={archived || busy}
               autoFocus
               required
             />
@@ -261,7 +288,7 @@ function EditForm({
               value={fields.model}
               onChange={(model) => setFields((prev) => ({ ...prev, model }))}
               options={models}
-              disabled={archived}
+              disabled={archived || busy}
               required
             />
           </div>
@@ -273,7 +300,7 @@ function EditForm({
             onChange={(systemPrompt) => setFields((prev) => ({ ...prev, systemPrompt }))}
             placeholder="You are a data analyst."
             rows={6}
-            disabled={archived}
+            disabled={archived || busy}
             multiline
           />
         </div>

--- a/apps/web/src/pages/EditEnvConfig.tsx
+++ b/apps/web/src/pages/EditEnvConfig.tsx
@@ -1,0 +1,239 @@
+// apps/web/src/pages/EditEnvConfig.tsx
+// The Edit Env dialog, at `#/environment/<id>`: the network policy the
+// create dialog writes, over POST /v1/env-configs/:id.
+//
+// Two things the api's update semantics dictate, both load-bearing:
+//
+//  - It is a PARTIAL update applied IN PLACE. An absent field is left as it
+//    was, so the packages and metadata this form doesn't show survive an
+//    edit untouched — which is what lets a network-only dialog edit a recipe
+//    that has more on it than a network. Nothing is sent when nothing
+//    changed: opening a dialog is not an edit.
+//  - There is no version, so there is no precondition to send with the
+//    write. An agent config's update can answer 409 when someone else got
+//    there first; this one cannot, and the later write simply wins. That is
+//    the api's model, not an omission here.
+//
+// An archived recipe is read-only — the api answers 409 rather than reviving
+// it — so the dialog shows it and says so rather than offering a Save that
+// would be refused. Archiving is not offered here yet; it is its own action,
+// the way it was for agent configs.
+import { type FormEvent, type RefObject, useEffect, useRef, useState } from "react";
+import {
+  type EnvConfig,
+  getEnvConfig,
+  type UpdateEnvConfigInput,
+  updateEnvConfig,
+} from "../lib/api";
+import { fieldsOf, type NetworkFields, samePolicy, toPolicy } from "../lib/network";
+import { NetworkFields as NetworkFieldset } from "../components/NetworkFields";
+import { Modal } from "../components/Modal";
+import { absoluteTime } from "../lib/format";
+
+const messageOf = (err: unknown) => (err instanceof Error ? err.message : String(err));
+
+/** The recipe's packages as one line per manager, or nothing when it has
+ *  none. Read-only: this dialog writes the network policy, and a recipe's
+ *  packages are the half of it that isn't offered here yet. */
+function packageLines(config: EnvConfig): Array<[string, string[]]> {
+  return Object.entries(config.packages).filter(([, specs]) => specs.length > 0);
+}
+
+export function EditEnvConfig({
+  id,
+  config,
+  onChanged,
+  onClose,
+  returnFocus,
+}: {
+  id: string;
+  /** The row, when the list already has it. Absent on a deep link into a
+   *  page the walk hasn't reached, which is what the fetch below is for. */
+  config?: EnvConfig;
+  /** The recipe as the api now holds it — the caller's row is stale once a
+   *  save lands, and this is what replaces it. */
+  onChanged: (config: EnvConfig) => void;
+  onClose: () => void;
+  returnFocus?: RefObject<HTMLElement | null>;
+}) {
+  const [fetched, setFetched] = useState<EnvConfig>();
+  const [loadError, setLoadError] = useState<string>();
+  // The list's copy wins when it has one — it is the fresher of the two, and
+  // preferring it here is also what keeps a list that finishes loading AFTER
+  // this opened from stranding the dialog: the effect below aborts its fetch
+  // when `config` arrives, so the answer has to be able to come from either.
+  const loaded = config ?? fetched;
+
+  useEffect(() => {
+    if (config !== undefined) return;
+    const abort = new AbortController();
+    getEnvConfig(id, { signal: abort.signal }).then(setFetched, (err: unknown) => {
+      if (abort.signal.aborted) return;
+      setLoadError(messageOf(err));
+    });
+    return () => abort.abort();
+  }, [id, config]);
+
+  if (loaded === undefined) {
+    return (
+      <Modal
+        title={loadError ? "Couldn't load that recipe" : "Loading…"}
+        description={<code className="mono-id">{id}</code>}
+        returnFocus={returnFocus}
+        onClose={onClose}
+      >
+        <div className="modal-body">
+          <p className="prose">{loadError ?? "Fetching it by id…"}</p>
+        </div>
+        <footer className="modal-foot">
+          <button className="btn" type="button" onClick={onClose} data-autofocus="">
+            Close
+          </button>
+        </footer>
+      </Modal>
+    );
+  }
+
+  return (
+    <EditForm
+      config={loaded}
+      onChanged={onChanged}
+      onClose={onClose}
+      returnFocus={returnFocus}
+      // Keyed on the recipe, and deliberately NOT on updatedAt: a dialog
+      // that saves closes itself, so the only thing a fresher `loaded` can
+      // mean here is that someone ELSE moved the row — a save from a
+      // previous instance of this editor landing late, say. Remounting on
+      // that would throw away whatever is typed in this one to show a
+      // version of the recipe nobody in this dialog asked for.
+      key={loaded.id}
+    />
+  );
+}
+
+function EditForm({
+  config,
+  onChanged,
+  onClose,
+  returnFocus,
+}: {
+  config: EnvConfig;
+  onChanged: (config: EnvConfig) => void;
+  onClose: () => void;
+  returnFocus?: RefObject<HTMLElement | null>;
+}) {
+  const [fields, setFields] = useState<NetworkFields>(() => fieldsOf(config.network));
+  const [busy, setBusy] = useState(false);
+  const [failure, setFailure] = useState<string>();
+
+  // Whether this editor is still the one on screen. Nothing aborts a write
+  // when its dialog goes away — pressing Back, leaving the section, or
+  // reopening the same recipe all unmount THIS instance while the request
+  // is still out — and a completion arriving afterwards must not navigate:
+  // the dialog it would close belongs to a later instance, quite possibly
+  // with edits in it. The row it carries is still worth handing up, and
+  // fresher for it; only the closing is conditional.
+  const live = useRef(true);
+  useEffect(() => {
+    // Set on the way in as well as cleared on the way out: StrictMode mounts
+    // twice, and an effect that only cleared would leave this false for the
+    // whole life of the second mount — closing nothing, ever.
+    live.current = true;
+    return () => {
+      live.current = false;
+    };
+  }, []);
+
+  const archived = config.archivedAt !== undefined;
+  // Absent while the allowlist has no domain on it — the one state of this
+  // form that isn't a policy yet (see toPolicy).
+  const network = toPolicy(fields);
+  const changed = network !== undefined && !samePolicy(network, config.network);
+  const packages = packageLines(config);
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    if (busy || archived || network === undefined) return;
+    // Nothing to send is nothing to write. Closing IS the save.
+    if (!changed) {
+      onClose();
+      return;
+    }
+
+    // Only the network: packages and metadata are absent from the body and
+    // therefore left exactly as the recipe already holds them.
+    const input: UpdateEnvConfigInput = { network };
+
+    setFailure(undefined);
+    setBusy(true);
+    try {
+      onChanged(await updateEnvConfig(config.id, input));
+      if (live.current) onClose();
+    } catch (err) {
+      setFailure(messageOf(err));
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Modal
+      title="Edit env config"
+      description={
+        <>
+          <code className="mono-id">{config.id}</code>
+          <span className="meta">updated {absoluteTime(config.updatedAt)}</span>
+        </>
+      }
+      dismissible={!busy}
+      returnFocus={returnFocus}
+      onClose={onClose}
+    >
+      <form className="modal-form" onSubmit={submit} noValidate>
+        <div className="modal-body form-fields">
+          {archived ? (
+            <p className="prose note">
+              This recipe is archived: it stays readable, and the sessions that copied it keep
+              running, but it takes no further updates and no new session can use it.
+            </p>
+          ) : null}
+
+          {/* Disabled while a save is in flight as well as when archived:
+              the body went to the api when the click did, so anything typed
+              after it would be silently dropped by the close that follows. */}
+          <NetworkFieldset fields={fields} onChange={setFields} disabled={archived || busy} />
+
+          {packages.length > 0 ? (
+            <p className="prose note">
+              Packages are left as they are — this dialog writes the network policy only.
+              {packages.map(([manager, specs]) => (
+                <span className="meta" key={manager}>
+                  {manager}: {specs.join(", ")}
+                </span>
+              ))}
+            </p>
+          ) : null}
+        </div>
+
+        <footer className="modal-foot">
+          {failure ? (
+            <p className="form-failure" role="alert">
+              {failure}
+            </p>
+          ) : null}
+          <button className="btn" type="button" onClick={onClose} disabled={busy}>
+            {archived || !changed ? "Close" : "Cancel"}
+          </button>
+          {archived ? null : (
+            <button
+              className="btn btn-primary"
+              type="submit"
+              disabled={busy || network === undefined || !changed}
+            >
+              {busy ? "Saving…" : "Save"}
+            </button>
+          )}
+        </footer>
+      </form>
+    </Modal>
+  );
+}

--- a/apps/web/src/pages/EnvConfigs.tsx
+++ b/apps/web/src/pages/EnvConfigs.tsx
@@ -7,24 +7,33 @@
 // and a session that already started carries its own copy of the one it
 // provisioned from.
 //
-// Three columns, and no row link: there is nothing to open yet. Create
-// writes the network policy only; packages are the recipe's other half and
-// come later (see CreateEnvConfig).
-import { useRef, useState } from "react";
+// Three columns, and every row a link into the editor. Create and edit both
+// write the network policy only; packages are the recipe's other half and
+// come later (see CreateEnvConfig and EditEnvConfig).
+import { useEffect, useRef, useState } from "react";
 import { type EnvConfig, listEnvConfigs } from "../lib/api";
 import { RELATIVE_TICK_MS, absoluteTime, relativeTime } from "../lib/format";
-import { SKELETON, useList } from "../lib/useList";
+import { keepsArchive, SKELETON, useList } from "../lib/useList";
 import { useNow } from "../lib/useNow";
 import { EnvironmentIcon, PlusIcon, RefreshIcon } from "../components/Icons";
 import { Status } from "../components/Status";
+import type { PageProps } from "../nav";
 import { CreateEnvConfig } from "./CreateEnvConfig";
+import { EditEnvConfig } from "./EditEnvConfig";
 import "./list.css";
 import "./EnvConfigs.css";
 
-/** Takes no route: this section is one view, so `#/environment` addresses
- *  all of it. */
-export function EnvConfigs() {
-  const { state, more, reload, loadMore, prepend } = useList<EnvConfig>(listEnvConfigs);
+/** This section's own route. Rows link into it by id, and closing the editor
+ *  goes back to it — one place that spells the section's hash. */
+const SECTION = "#/environment";
+
+/**
+ * `route` is the recipe id below this section, so `#/environment/<id>` IS the
+ * editor being open: the dialog is a state of this page rather than a page of
+ * its own, and stays linkable, back-navigable and reloadable.
+ */
+export function EnvConfigs({ route }: PageProps) {
+  const { state, more, reload, loadMore, prepend, replace } = useList<EnvConfig>(listEnvConfigs);
   // Relative timestamps are only true at the moment they render, so the
   // clock they read has to keep moving.
   const now = useNow(RELATIVE_TICK_MS);
@@ -34,9 +43,61 @@ export function EnvConfigs() {
   // state's button — the row it creates is what replaces that button.
   const createButton = useRef<HTMLButtonElement>(null);
 
+  // Whether the editor's history entry is one a row click pushed, rather
+  // than where the page was opened. Closing has to UNDO a push — otherwise
+  // Back returns to the dialog the user just closed — but must not walk out
+  // of the app when there is no entry of ours behind it.
+  const pushed = useRef(false);
+  const previousRoute = useRef(route);
+  useEffect(() => {
+    pushed.current = previousRoute.current === "" && route !== "";
+    previousRoute.current = route;
+  }, [route]);
+
+  // The row the editor is open on, when this page already has it. A deep
+  // link can name one from a page the walk hasn't reached; the dialog
+  // fetches that itself rather than making the list chase it.
+  const editing = state.status === "ready" ? state.items.find((c) => c.id === route) : undefined;
+
+  /** Leaves `#/environment/<id>` for `#/environment` without leaving a dialog
+   *  behind the Back button. */
+  function closeEditor() {
+    if (pushed.current) {
+      window.history.back();
+      return;
+    }
+    // Opened straight at this route — a deep link or a reload — so there is
+    // nothing of ours to go back to and the entry is rewritten instead.
+    window.history.replaceState(null, "", SECTION);
+    // replaceState fires no hashchange, and the route is read from one.
+    window.dispatchEvent(new HashChangeEvent("hashchange"));
+  }
+
   function added(config: EnvConfig) {
     setCreating(false);
     prepend(config);
+  }
+
+  // An edit rewrites the recipe in place — same id, same creation time, and
+  // this list is ordered by creation — so the row is replaced where it is.
+  //
+  // Only the row: closing is the dialog's own to do. A save is not aborted
+  // when its editor goes away, and the route it was sent from does not
+  // identify that editor — reopening the same recipe gives the same route a
+  // different dialog. Only the dialog knows whether it is still the one
+  // open, so it is the one that decides whether to close (see EditEnvConfig).
+  function changed(config: EnvConfig) {
+    // Never older than what is already held: two writes to one recipe can be
+    // in flight at once — a save outliving the dialog that sent it, then a
+    // second from the editor that replaced it — and their answers need not
+    // come back in the order the api committed them. A recipe has no version
+    // to arbitrate with, so updatedAt is the token, and a tie in it is
+    // settled by keepsArchive().
+    replace(config, (incoming, held) =>
+      incoming.updatedAt === held.updatedAt
+        ? keepsArchive(incoming, held)
+        : incoming.updatedAt > held.updatedAt,
+    );
   }
 
   return (
@@ -117,7 +178,12 @@ export function EnvConfigs() {
                 : state.items.map((config) => (
                     <tr key={config.id}>
                       <td>
-                        <span className="id">{config.id}</span>
+                        {/* One real anchor, stretched over the row by CSS:
+                            the whole row is clickable, and it is still a
+                            link — focusable, middle-clickable, copyable. */}
+                        <a className="id row-link" href={`${SECTION}/${config.id}`}>
+                          {config.id}
+                        </a>
                       </td>
                       <td>
                         <Status archivedAt={config.archivedAt} />
@@ -141,6 +207,17 @@ export function EnvConfigs() {
           returnFocus={createButton}
         />
       ) : null}
+
+      {route === "" ? null : (
+        <EditEnvConfig
+          key={route}
+          id={route}
+          config={editing}
+          onChanged={changed}
+          onClose={closeEditor}
+          returnFocus={createButton}
+        />
+      )}
 
       {state.status === "ready" && state.hasMore ? (
         <div className="list-more">


### PR DESCRIPTION
Every row in the Environment section links to `#/environment/<id>`, and that route *is* the editor being open — a state of the list page, so it stays linkable, back-navigable and reloadable, with a deep link fetching the recipe by id when the list hasn't walked to it. The dialog writes the network policy over `POST /v1/env-configs/:id`: a partial update, so the packages it doesn't offer survive untouched and are shown read-only rather than passed over in silence, and an archived recipe is read-only with a note since the api answers 409. The policy fieldset the create dialog wrote is now shared (`lib/network.ts`, `components/NetworkFields.tsx`) so a recipe is edited through the same field it was made with, and `.mono-id`/`.meta`/`.note` moved into `Modal.css`, which owns the description slot they style.

Four races share one root — nothing aborts a write, so it can outlive the dialog that sent it — and are fixed here and in the agent dialog, which already had the first two: a form stayed editable while its own body was in flight; a completion navigated unconditionally, closing whichever dialog was open by the time it landed; overlapping writes answered out of commit order and left the cached row stale; and archiving mints no token, so it tied with the update before it and a late answer showed a retired row as active. Each was reproduced against a live stack before fixing and re-checked after — the last one with a control run on the old comparator to confirm the test was actually sensitive to the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)