### PR TITLE
Add the session list to the console

### DIFF
--- a/apps/web/src/components/Status.tsx
+++ b/apps/web/src/components/Status.tsx
@@ -1,19 +1,37 @@
 // apps/web/src/components/Status.tsx
-// The one status a config has. Shared by the resource lists, which all
-// front the same lifecycle: a config is live until it is archived, and the
-// api has no route back.
+// The one lifecycle every resource in this console shares: a row is live
+// until it is archived, and the api has no route back. What archiving
+// COSTS differs by resource, though — a config stops taking updates, a
+// session stops taking messages — so the pill is shared and the hover
+// text that explains it is the list's own.
 import { absoluteTime } from "../lib/format";
 import "./Status.css";
 
+/** What each state means for the row it marks. `archived` reads as a clause
+ *  after "Archived <when> — ". */
+export type StatusMeaning = { active: string; archived: string };
+
+/** The config lists' meaning, and the default because both of them front
+ *  the same rule. A session's archive costs something else, so that list
+ *  passes its own (pages/Sessions.tsx). */
+const CONFIG: StatusMeaning = {
+  active: "Accepts updates and new sessions",
+  archived: "read-only, and no new session can use it",
+};
+
 /** Archive is the one terminal transition, so this is a state, not a toggle. */
-export function Status({ archivedAt }: { archivedAt?: string }) {
+export function Status({
+  archivedAt,
+  meaning = CONFIG,
+}: {
+  archivedAt?: string;
+  meaning?: StatusMeaning;
+}) {
   return (
     <span
       className={archivedAt ? "pill pill-archived" : "pill pill-active"}
       title={
-        archivedAt
-          ? `Archived ${absoluteTime(archivedAt)} — read-only, and no new session can use it`
-          : "Accepts updates and new sessions"
+        archivedAt ? `Archived ${absoluteTime(archivedAt)} — ${meaning.archived}` : meaning.active
       }
     >
       <span className="pill-dot" aria-hidden="true" />

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -373,3 +373,76 @@ export function archiveEnvConfig(
     opts.signal,
   );
 }
+
+/**
+ * The env recipe as it read when a session was created. A session COPIES
+ * the recipe rather than pointing at it — env configs update in place, so
+ * there is no version to pin — which is what keeps a run's world fixed
+ * once it has started.
+ */
+export type EnvConfigSnapshot = {
+  network: NetworkPolicy;
+  packages: Packages;
+};
+
+/**
+ * One session: an agent config at one pinned version, a copy of an env
+ * recipe, and the durable append-only entry log the two run against.
+ *
+ * There is no state field here, and its absence is the point: funky
+ * derives whether a session is running from its work items and its log
+ * rather than storing it on the row, so the only status a session carries
+ * on the wire is the lifecycle one below.
+ */
+export type Session = {
+  id: string;
+  namespace: string;
+  agentConfigId: string;
+  /** Pinned at creation, so a later update to the config cannot reshape a
+   *  run already under way. */
+  agentConfigVersion: number;
+  /** Provenance for the snapshot beside it; nothing resolves through it. */
+  envConfigId: string;
+  envConfigSnapshot: EnvConfigSnapshot;
+  /** The session's one workspace, registered when a worker first runs tools
+   *  for it. Absent until then. */
+  sandboxId?: string;
+  createdAt: string;
+  /** Set once retired. Archive is terminal, so absence is the active state. */
+  archivedAt?: string;
+  metadata?: unknown;
+};
+
+/**
+ * One page of the namespace's sessions, newest first.
+ *
+ * `includeArchived` mirrors the api's own switch, default and all: the api
+ * lists ACTIVE rows only unless asked, because archived history grows
+ * without bound and a caller asking for its sessions usually means the live
+ * ones. A caller that draws a status column wants both — that is the
+ * console's editorial call, so the page makes it (see pages/Sessions.tsx).
+ */
+export function listSessions(
+  opts: {
+    after?: string;
+    limit?: number;
+    includeArchived?: boolean;
+    signal?: AbortSignal;
+  } = {},
+): Promise<Page<Session>> {
+  return get<Page<Session>>(
+    "/v1/sessions",
+    {
+      namespace: DEFAULT_NAMESPACE,
+      limit: opts.limit === undefined ? undefined : String(opts.limit),
+      after: opts.after,
+      // snake_case because the wire is, and spelled as a word rather than a
+      // flag: the route parses "true"/"false" by name — JavaScript
+      // truthiness would read "false" as true — so an absent switch has to
+      // be absent from the query, not sent as an empty string.
+      include_archived:
+        opts.includeArchived === undefined ? undefined : String(opts.includeArchived),
+    },
+    opts.signal,
+  );
+}

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -6,6 +6,7 @@ import type { ReactElement, SVGProps } from "react";
 import { AgentIcon, BoltIcon, EnvironmentIcon, SessionIcon } from "./components/Icons";
 import { AgentConfigs } from "./pages/AgentConfigs";
 import { EnvConfigs } from "./pages/EnvConfigs";
+import { Sessions } from "./pages/Sessions";
 
 /** What a page is handed: the part of the route below its own section, so
  *  a section can address something inside itself (`#/agent/<id>`) without
@@ -64,6 +65,7 @@ export const NAV_ITEMS: [NavItem, ...NavItem[]] = [
     blurb:
       "A session is one agent config plus one env config plus a durable, append-only entry log — the log a fresh worker resumes from with nothing lost.",
     chip: "/v1/sessions",
+    Page: Sessions,
   },
 ];
 

--- a/apps/web/src/pages/Sessions.css
+++ b/apps/web/src/pages/Sessions.css
@@ -1,0 +1,37 @@
+/* apps/web/src/pages/Sessions.css
+   What only the session list draws: where its three columns land once the
+   pane is too narrow for a table. Everything else — the header, the table,
+   the pill, the skeleton, the notices — is pages/list.css.
+
+   Same three columns as the env list, and the same card, but spelled here
+   rather than shared: which cell lands where is each table's own business
+   (see the breakpoint's note in list.css), and these two agree today only
+   because neither has grown a column yet. */
+
+/* Card layout: the id on its own line, then the status with the age
+   opposite it — two short cells that stay side by side at any width the
+   pane reaches. */
+@container pane (max-width: 790px) {
+  .sessions .table tr {
+    grid-template-areas:
+      "id id"
+      "status when";
+    align-items: center;
+    gap: 7px 16px;
+  }
+
+  .sessions .table td:nth-child(1) {
+    grid-area: id;
+  }
+
+  .sessions .table td:nth-child(2) {
+    grid-area: status;
+  }
+
+  .sessions .table td:nth-child(3) {
+    grid-area: when;
+    justify-self: end;
+    font-size: 12.5px;
+    color: var(--text-3);
+  }
+}

--- a/apps/web/src/pages/Sessions.tsx
+++ b/apps/web/src/pages/Sessions.tsx
@@ -1,0 +1,145 @@
+// apps/web/src/pages/Sessions.tsx
+// The Session section: the namespace's sessions, newest first.
+//
+// A session is one agent config version, one copy of an env recipe, and the
+// durable entry log the two run against. This is an inventory read — three
+// columns, no row link, nothing to open — because what makes a session
+// worth clicking into is its log and its message box, and those come later.
+// Nothing here creates one either: that takes an agent config AND an env
+// config, which is the Quick Start flow rather than a button on a list.
+//
+// "Status" here is the LIFECYCLE — active or archived — not liveness. There
+// is no running/idle column because the api has no such field: funky
+// derives whether a session is working from its work items and its log
+// rather than storing it on the row (see lib/api.ts Session).
+import { type Session, listSessions } from "../lib/api";
+import { RELATIVE_TICK_MS, absoluteTime, relativeTime } from "../lib/format";
+import { type FetchPage, SKELETON, useList } from "../lib/useList";
+import { useNow } from "../lib/useNow";
+import { RefreshIcon, SessionIcon } from "../components/Icons";
+import { Status, type StatusMeaning } from "../components/Status";
+import "./list.css";
+import "./Sessions.css";
+
+/**
+ * The api hides archived sessions unless asked; this list asks. Archive is
+ * a state this table has a whole column for, and a status column whose
+ * every row reads "Active" is a column that says nothing. The unbounded
+ * growth that default guards against is a page-size problem, and this list
+ * is a keyset walk — it shows twenty rows either way.
+ *
+ * Module-level so it is stable: useList holds it as an effect dependency,
+ * and a function rebuilt each render would re-fetch on every one.
+ */
+const listAll: FetchPage<Session> = (opts) => listSessions({ ...opts, includeArchived: true });
+
+/** What the pill means on a session, which is not what it means on a config
+ *  (components/Status.tsx): archiving one closes client writes rather than
+ *  edits, and the log it leaves behind stays readable. */
+const MEANING: StatusMeaning = {
+  active: "Accepts messages, and a worker can pick its work up",
+  archived: "read-only: it takes no new message, and its log stays readable",
+};
+
+export function Sessions() {
+  const { state, more, reload, loadMore } = useList<Session>(listAll);
+  // Relative timestamps are only true at the moment they render, so the
+  // clock they read has to keep moving.
+  const now = useNow(RELATIVE_TICK_MS);
+
+  return (
+    <section className="list sessions">
+      <header className="list-head">
+        <h1 className="list-title">Sessions</h1>
+        <div className="list-actions">
+          <button
+            className="btn"
+            type="button"
+            onClick={reload}
+            disabled={state.status === "loading"}
+          >
+            <RefreshIcon />
+            Refresh
+          </button>
+        </div>
+      </header>
+
+      {state.status === "error" ? (
+        <div className="notice">
+          <p className="notice-title">Couldn&rsquo;t load sessions</p>
+          <p className="notice-body">{state.message}</p>
+          <button className="btn" type="button" onClick={reload}>
+            <RefreshIcon />
+            Try again
+          </button>
+        </div>
+      ) : state.status === "ready" && state.items.length === 0 ? (
+        <div className="notice">
+          <span className="notice-icon" aria-hidden="true">
+            <SessionIcon width={22} height={22} strokeWidth={1.6} />
+          </span>
+          <p className="notice-title">No sessions yet</p>
+          <p className="notice-body">
+            A session pairs an agent config with an env config and runs them against an append-only
+            log. Start one by posting both ids to <code>/v1/sessions</code>.
+          </p>
+        </div>
+      ) : (
+        <div className="table-wrap">
+          <table className="table">
+            <thead>
+              <tr>
+                <th className="col-id">Id</th>
+                <th className="col-status">Status</th>
+                <th className="col-when">Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              {state.status === "loading"
+                ? SKELETON.map((row) => (
+                    <tr key={row}>
+                      <td>
+                        <span className="bar bar-id" />
+                      </td>
+                      <td>
+                        <span className="bar bar-status" />
+                      </td>
+                      <td>
+                        <span className="bar bar-when" />
+                      </td>
+                    </tr>
+                  ))
+                : state.items.map((session) => (
+                    <tr key={session.id}>
+                      {/* Plain text, not a link: there is nowhere to go yet,
+                          and list.css only highlights a row that opens
+                          something. */}
+                      <td>
+                        <span className="id">{session.id}</span>
+                      </td>
+                      <td>
+                        <Status archivedAt={session.archivedAt} meaning={MEANING} />
+                      </td>
+                      <td>
+                        <time dateTime={session.createdAt} title={absoluteTime(session.createdAt)}>
+                          {relativeTime(session.createdAt, now)}
+                        </time>
+                      </td>
+                    </tr>
+                  ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {state.status === "ready" && state.hasMore ? (
+        <div className="list-more">
+          <button className="btn" type="button" onClick={loadMore} disabled={more.busy}>
+            {more.busy ? "Loading…" : "Load more"}
+          </button>
+          {more.error ? <span className="list-more-error">{more.error}</span> : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}


### PR DESCRIPTION
The Session section renders a page instead of the placeholder — one page of the namespace's sessions, newest first, in three columns (id, status, created), on the list machinery the agent and env sections already share; there is no row link and no Create, since nothing sits behind a session yet and starting one takes both configs, so the empty state points at `POST /v1/sessions`.

That status is the lifecycle (active or archived), not liveness — a session carries no state field on the wire, funky deriving whether one is running from its work items and its log — and the page asks for `include_archived=true` because a column that always reads "Active" says nothing, with `listSessions` still mirroring the api's active-only default so the page owns the override.

`Status`'s hover text was written for the config lists ("Accepts updates and new sessions"), which says nothing true about a session, so the pill takes an optional `meaning` that defaults to the config wording and leaves both config pages untouched.

Verified against the live api: the wire shape matches the hand-mirrored `Session` type field for field, and the list came back through the vite proxy with one active and one archived row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)