### PR TITLE
Add the session conversation and the Start dialog to the console

### DIFF
--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -93,6 +93,25 @@ export function ChevronDownIcon(props: SVGProps<SVGSVGElement>) {
   );
 }
 
+/** Back to the list a detail page was opened from. */
+export function ArrowLeftIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <Stroke width={15} height={15} {...props}>
+      <path d="M19 12H5" />
+      <path d="M11 6 5 12l6 6" />
+    </Stroke>
+  );
+}
+
+/** Send the composed message. */
+export function SendIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <Stroke width={15} height={15} {...props}>
+      <path d="M4.5 12 20 4.5 15.5 20l-3.4-6.1L4.5 12Z" />
+    </Stroke>
+  );
+}
+
 /** Topbar docs link. */
 export function ExternalLinkIcon(props: SVGProps<SVGSVGElement>) {
   return (

--- a/apps/web/src/components/Markdown.css
+++ b/apps/web/src/components/Markdown.css
@@ -1,0 +1,105 @@
+/* apps/web/src/components/Markdown.css
+   A model's answer, styled as prose inside a chat bubble — so everything
+   here is scaled to sit in one, not to be a document. The gaps between
+   blocks are the bubble's own (see .bubble-agent in pages/Transcript.css),
+   which is what lets a fold and a paragraph stack the same way. Every
+   colour resolves to a token in index.css. */
+
+.md-p {
+  /* A single newline is a line break, the way the parser reads it — a model
+     that wrote two lines meant two. */
+  white-space: pre-wrap;
+}
+
+/* Not <h1>–<h6> (see Markdown.tsx): a heading here is emphasis inside one
+   message, so it reads as one step louder than the text and no more. */
+.md-h {
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--text);
+}
+
+.md-h1,
+.md-h2 {
+  font-size: 15.5px;
+}
+
+.md-h3,
+.md-h4,
+.md-h5,
+.md-h6 {
+  font-size: 14.5px;
+}
+
+.md-code {
+  padding: 1px 5px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-sunken);
+  font: 500 12px var(--mono);
+  /* An identifier shouldn't stretch the bubble; it breaks like a url. */
+  overflow-wrap: anywhere;
+}
+
+/* A fence is the one block that keeps its own whitespace exactly, so it is
+   the one that scrolls sideways rather than wrapping: a wrapped line of code
+   reads as two lines of code. */
+.md-pre {
+  margin: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--bg-sunken);
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.md-pre code {
+  font: 400 12px/1.6 var(--mono);
+  color: var(--text-2);
+}
+
+.md-list {
+  margin: 0;
+  /* Room for the marker inside the bubble rather than hanging out of it. */
+  padding-left: 22px;
+}
+
+.md-li::marker {
+  color: var(--text-3);
+}
+
+/* Nested content — a second paragraph, a nested list — stacks the way the
+   bubble's own children do. */
+.md-li > * + * {
+  margin-top: 7px;
+}
+
+.md-li + .md-li {
+  margin-top: 4px;
+}
+
+.md-quote {
+  margin: 0;
+  padding-left: 12px;
+  border-left: 2px solid var(--border-strong);
+  color: var(--text-2);
+}
+
+.md-quote > * + * {
+  margin-top: 8px;
+}
+
+.md-rule {
+  height: 0;
+  margin: 0;
+  border: none;
+  border-top: 1px solid var(--border);
+}
+
+.md-link {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2.5px;
+  overflow-wrap: anywhere;
+}

--- a/apps/web/src/components/Markdown.tsx
+++ b/apps/web/src/components/Markdown.tsx
@@ -1,0 +1,97 @@
+// apps/web/src/components/Markdown.tsx
+// A model's answer, rendered as what it was written as. The reading is
+// lib/markdown.ts; this turns its tree into elements.
+//
+// Elements, never markup: nothing here takes a string of html, so a message
+// cannot inject one however it is written. The only value that reaches an
+// attribute is a link's href, and the parser has already refused every
+// scheme but http, https and mailto — an unsafe one never becomes a link.
+//
+// Headings render as styled paragraphs rather than <h1>–<h6>. A heading
+// inside one message of a conversation isn't a heading of the PAGE, and
+// putting six levels of a model's own outline into the document's would
+// leave a reader navigating by heading somewhere they didn't ask to be.
+import type { ReactNode } from "react";
+import { type Block, type Inline, parseBlocks } from "../lib/markdown";
+import "./Markdown.css";
+
+function inline(nodes: Inline[]): ReactNode {
+  return nodes.map((node, index) => {
+    switch (node.type) {
+      case "text":
+        return node.text;
+      case "code":
+        return (
+          <code className="md-code" key={index}>
+            {node.text}
+          </code>
+        );
+      case "strong":
+        return <strong key={index}>{inline(node.children)}</strong>;
+      case "em":
+        return <em key={index}>{inline(node.children)}</em>;
+      case "del":
+        return <del key={index}>{inline(node.children)}</del>;
+      case "link":
+        // A link out of a message goes to another site by definition, so it
+        // opens in its own tab — and noreferrer, because where a model's
+        // link came from is nobody's business but this console's.
+        return (
+          <a className="md-link" href={node.href} target="_blank" rel="noreferrer" key={index}>
+            {inline(node.children)}
+          </a>
+        );
+    }
+  });
+}
+
+function block(node: Block, key: number): ReactNode {
+  switch (node.type) {
+    case "paragraph":
+      return (
+        <p className="md-p" key={key}>
+          {inline(node.content)}
+        </p>
+      );
+    case "heading":
+      return (
+        <p className={`md-h md-h${node.level}`} key={key}>
+          {inline(node.content)}
+        </p>
+      );
+    case "code":
+      return (
+        <pre className="md-pre" key={key}>
+          <code>{node.text}</code>
+        </pre>
+      );
+    case "list": {
+      const items = node.items.map((blocks, index) => (
+        <li className="md-li" key={index}>
+          {blocks.map(block)}
+        </li>
+      ));
+      return node.ordered ? (
+        <ol className="md-list" start={node.start} key={key}>
+          {items}
+        </ol>
+      ) : (
+        <ul className="md-list" key={key}>
+          {items}
+        </ul>
+      );
+    }
+    case "quote":
+      return (
+        <blockquote className="md-quote" key={key}>
+          {node.children.map(block)}
+        </blockquote>
+      );
+    case "rule":
+      return <hr className="md-rule" key={key} />;
+  }
+}
+
+export function Markdown({ text }: { text: string }) {
+  return <>{parseBlocks(text).map(block)}</>;
+}

--- a/apps/web/src/components/Status.tsx
+++ b/apps/web/src/components/Status.tsx
@@ -1,28 +1,16 @@
 // apps/web/src/components/Status.tsx
 // The one lifecycle every resource in this console shares: a row is live
 // until it is archived, and the api has no route back. What archiving
-// COSTS differs by resource, though — a config stops taking updates, a
-// session stops taking messages — so the pill is shared and the hover
-// text that explains it is the list's own.
+// COSTS differs by resource, and that wording lives in lib/status.ts —
+// the config lists take the default, and the session pages pass their own.
 import { absoluteTime } from "../lib/format";
+import { CONFIG_STATUS, type StatusMeaning } from "../lib/status";
 import "./Status.css";
-
-/** What each state means for the row it marks. `archived` reads as a clause
- *  after "Archived <when> — ". */
-export type StatusMeaning = { active: string; archived: string };
-
-/** The config lists' meaning, and the default because both of them front
- *  the same rule. A session's archive costs something else, so that list
- *  passes its own (pages/Sessions.tsx). */
-const CONFIG: StatusMeaning = {
-  active: "Accepts updates and new sessions",
-  archived: "read-only, and no new session can use it",
-};
 
 /** Archive is the one terminal transition, so this is a state, not a toggle. */
 export function Status({
   archivedAt,
-  meaning = CONFIG,
+  meaning = CONFIG_STATUS,
 }: {
   archivedAt?: string;
   meaning?: StatusMeaning;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -446,3 +446,194 @@ export function listSessions(
     opts.signal,
   );
 }
+
+/** One session by id. What the detail page resolves a link against — the
+ *  list is a page of rows, and a session can be addressed without it. */
+export function getSession(id: string, opts: { signal?: AbortSignal } = {}): Promise<Session> {
+  return get<Session>(
+    `/v1/sessions/${encodeURIComponent(id)}`,
+    { namespace: DEFAULT_NAMESPACE },
+    opts.signal,
+  );
+}
+
+/** The create body, minus the namespace this console pins for every call.
+ *  Omitting `agentConfigVersion` pins the config's latest version at create,
+ *  which is what a console starting a session from a picker means. */
+export type CreateSessionInput = {
+  agentConfigId: string;
+  agentConfigVersion?: number;
+  envConfigId: string;
+  metadata?: unknown;
+};
+
+/**
+ * Creates a session and returns it materialized: the agent version pinned
+ * and the env recipe copied, so the answer is the world the run will have
+ * rather than the request that asked for it. The namespace rides in the
+ * body here, as it does for both config creates.
+ *
+ * An archived config answers 409 and an unknown one 400 — the api's words
+ * either way, which is why the dialog shows only active configs.
+ */
+export function createSession(
+  input: CreateSessionInput,
+  opts: { signal?: AbortSignal } = {},
+): Promise<Session> {
+  return post<Session>("/v1/sessions", { namespace: DEFAULT_NAMESPACE, ...input }, {}, opts.signal);
+}
+
+// --- the session log ---
+//
+// Messages are what the model sees; entries are what the store owns. The
+// console only reads them, so what follows mirrors the payloads without the
+// vocabulary core needs to write them.
+
+/** A vendor's own continuity data, keyed by vendor namespace. Opaque here
+ *  exactly as it is in core: the console renders parts, never replays them. */
+type ProviderMetadata = unknown;
+
+export type TextContent = { type: "text"; text: string; providerMetadata?: ProviderMetadata };
+export type ImageContent = { type: "image"; data: string; mimeType: string };
+export type ThinkingContent = {
+  type: "thinking";
+  /** Empty for a redacted block — the vendor keeps the text. */
+  thinking: string;
+  providerMetadata?: ProviderMetadata;
+  /** Legacy, Anthropic-only, no longer written; rows older than
+   *  providerMetadata carry the signature here. */
+  thinkingSignature?: string;
+  redacted?: boolean;
+};
+export type ToolCall = {
+  type: "toolCall";
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+  providerMetadata?: ProviderMetadata;
+};
+
+/** Token counts only — cost is computed at display time from pricing, never
+ *  stored, so a price change can't reinterpret an old session. */
+export type Usage = {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  /** A subset of `output`, when the provider reports the breakdown. */
+  reasoning?: number;
+};
+
+/** Why a turn ended. The last two are the harness's own outcomes, not the
+ *  provider's, and such messages are kept in the log but left out of the
+ *  context a later turn is built from. */
+export type StopReason = "end_turn" | "tool_use" | "max_tokens" | "aborted" | "error";
+
+export type UserMessage = { role: "user"; content: Array<TextContent | ImageContent> };
+
+export type AssistantMessage = {
+  role: "assistant";
+  content: Array<TextContent | ThinkingContent | ToolCall>;
+  model: string;
+  stopReason: StopReason;
+  /** Absent when the stream died before the provider reported usage. */
+  usage?: Usage;
+  /** Set when stopReason is "error". */
+  errorMessage?: string;
+};
+
+export type ToolResultMessage = {
+  role: "toolResult";
+  toolCallId: string;
+  toolName: string;
+  content: Array<TextContent | ImageContent>;
+  /** Tool-specific payload for a UI to render; never sent to the model. */
+  details?: unknown;
+  isError: boolean;
+};
+
+export type AgentMessage = UserMessage | AssistantMessage | ToolResultMessage;
+
+/** The envelope the store mints around every payload: an id, the session's
+ *  own gapless ordering, and when it landed. */
+type EntryBase = { id: string; seq: number; timestamp: string };
+
+/**
+ * One row of the session log. `message` is the transcript; the other three
+ * are the log's other tenants — an app's own payload, a reserved compaction
+ * marker, and the harness control plane — and a reader that doesn't know a
+ * type must skip it rather than guess.
+ */
+export type SessionEntry =
+  | (EntryBase & { type: "message"; message: AgentMessage })
+  | (EntryBase & { type: "custom"; namespace: string; data: unknown })
+  | (EntryBase & { type: "compaction"; summary: string; upToSeq: number })
+  | (EntryBase & { type: "control"; control: "cancel" });
+
+/**
+ * What a message did, decided inside intake's transaction: it either
+ * started a run or queued behind the one already going.
+ *
+ * The difference is visible, and a chat has to say so — a queued message is
+ * NOT in the log yet. It waits in its own table and is appended when the
+ * run it arrived behind ends, so until then the only place it exists for a
+ * reader is the client that sent it.
+ */
+export type IntakeResult =
+  { kind: "started"; itemId: string } | { kind: "queued"; inputId: string };
+
+/** The log from `after` on, in seq order — the whole log when `after` is
+ *  absent. A bare array rather than a page: a session's log is read in
+ *  full, and the stream below is how a caller follows it. */
+export function readEntries(
+  id: string,
+  opts: { after?: number; signal?: AbortSignal } = {},
+): Promise<SessionEntry[]> {
+  return get<SessionEntry[]>(
+    `/v1/sessions/${encodeURIComponent(id)}/entries`,
+    {
+      namespace: DEFAULT_NAMESPACE,
+      after: opts.after === undefined ? undefined : String(opts.after),
+    },
+    opts.signal,
+  );
+}
+
+/**
+ * The URL an EventSource tails the log from — a path, not a fetch, because
+ * following the log is the browser's job here: EventSource reconnects on
+ * its own and resumes with Last-Event-ID, which this route honors over
+ * `after`. Same-origin, so it carries the proxy's auth like every other
+ * call; EventSource could not have set a header anyway.
+ */
+export function entryStreamUrl(id: string, after?: number): string {
+  return (
+    `/v1/sessions/${encodeURIComponent(id)}/stream` +
+    search({
+      namespace: DEFAULT_NAMESPACE,
+      after: after === undefined ? undefined : String(after),
+    })
+  );
+}
+
+/**
+ * Sends a user message. 202 either way — the answer says what intake did
+ * with it, never what the agent will do about it, which happens in a worker
+ * afterwards. Plain text is the wire's other accepted spelling for content;
+ * the api normalizes it and stamps the role.
+ *
+ * An archived session answers 409: it keeps its log readable and takes no
+ * further client write.
+ */
+export function sendMessage(
+  id: string,
+  text: string,
+  opts: { signal?: AbortSignal } = {},
+): Promise<IntakeResult> {
+  return post<IntakeResult>(
+    `/v1/sessions/${encodeURIComponent(id)}/messages`,
+    { content: text },
+    { namespace: DEFAULT_NAMESPACE },
+    opts.signal,
+  );
+}

--- a/apps/web/src/lib/markdown.ts
+++ b/apps/web/src/lib/markdown.ts
@@ -1,0 +1,291 @@
+// apps/web/src/lib/markdown.ts
+// Markdown as far as a model writes it, parsed to a tree the renderer turns
+// into elements (components/Markdown.tsx).
+//
+// Hand-rolled, because the console has no runtime dependency but React and a
+// parser is not where that should change: what an assistant turn actually
+// contains is code fences, inline code, bold, lists, headings and links, and
+// that is what this reads. What it doesn't recognise stays as the text it
+// was — an unclosed fence, a table, raw html — so nothing is ever swallowed.
+//
+// It emits a TREE, never a string of html, which is what makes rendering
+// model output safe: the renderer builds elements from these nodes, so there
+// is no markup for a message to inject. The one place a message could still
+// reach the browser is a link's href, and that is filtered here (see safe).
+//
+// Two deliberate omissions:
+// - `_` is not emphasis. snake_case is everywhere in a console, and
+//   `some_var_name` reading as "some<em>var</em>name" is worse than a rare
+//   underscore italic going unrendered. `*` and `**` are what models write.
+// - A single newline inside a paragraph stays a line break, as it does on
+//   GitHub: in a chat, a model that wrote two lines meant two lines.
+
+export type Inline =
+  | { type: "text"; text: string }
+  | { type: "code"; text: string }
+  | { type: "strong"; children: Inline[] }
+  | { type: "em"; children: Inline[] }
+  | { type: "del"; children: Inline[] }
+  | { type: "link"; href: string; children: Inline[] };
+
+export type Block =
+  | { type: "paragraph"; content: Inline[] }
+  | { type: "heading"; level: number; content: Inline[] }
+  | { type: "code"; language?: string; text: string }
+  | { type: "list"; ordered: boolean; start: number; items: Block[][] }
+  | { type: "quote"; children: Block[] }
+  | { type: "rule" };
+
+// --- inline ---
+
+/**
+ * A url this console is willing to make clickable. Anything else — a
+ * `javascript:` scheme most of all — is not a link at all; the caller keeps
+ * the markdown as literal text, so the reader sees exactly what the model
+ * wrote and nothing is hidden behind a label.
+ */
+function safe(href: string): string | undefined {
+  const url = href.trim();
+  return /^(https?:\/\/|mailto:)/i.test(url) ? url : undefined;
+}
+
+const text = (value: string): Inline => ({ type: "text", text: value });
+
+/** Each spelling this reads, in the order a tie at the same position is
+ *  settled: code before anything (its content is literal), and `**` before
+ *  `*` so bold isn't read as an italic wrapping an asterisk. */
+const INLINE: Array<{ re: RegExp; build: (m: RegExpExecArray) => Inline }> = [
+  { re: /`([^`\n]+)`/, build: (m) => ({ type: "code", text: m[1] }) },
+  {
+    re: /\[([^\]\n]*)\]\(([^)\s]*)(?:\s+"[^"\n]*")?\)/,
+    build: (m) => {
+      const href = safe(m[2]);
+      return href === undefined ? text(m[0]) : { type: "link", href, children: parseInline(m[1]) };
+    },
+  },
+  { re: /\*\*(\S[^\n]*?)\*\*/, build: (m) => ({ type: "strong", children: parseInline(m[1]) }) },
+  { re: /\*(\S[^\n]*?)\*/, build: (m) => ({ type: "em", children: parseInline(m[1]) }) },
+  // Its own node, not an em: ~~x~~ means deleted, and rendering it as
+  // italics would state the opposite of what the model wrote.
+  { re: /~~(\S[^\n]*?)~~/, build: (m) => ({ type: "del", children: parseInline(m[1]) }) },
+];
+
+/** One run of text, split at whichever spelling starts earliest. */
+export function parseInline(source: string): Inline[] {
+  const out: Inline[] = [];
+  let rest = source;
+  while (rest !== "") {
+    let best: { at: number; length: number; node: Inline } | undefined;
+    for (const matcher of INLINE) {
+      const match = matcher.re.exec(rest);
+      // `>=` rather than `>`: a tie goes to the matcher listed first, which
+      // is what keeps `**` from being read as `*`.
+      if (match === null || (best !== undefined && match.index >= best.at)) continue;
+      best = { at: match.index, length: match[0].length, node: matcher.build(match) };
+    }
+    if (best === undefined) {
+      out.push(text(rest));
+      break;
+    }
+    if (best.at > 0) out.push(text(rest.slice(0, best.at)));
+    out.push(best.node);
+    rest = rest.slice(best.at + best.length);
+  }
+  return out;
+}
+
+// --- blocks ---
+
+const FENCE = /^ {0,3}(`{3,}|~{3,})\s*([^\s`]+)?\s*$/;
+// The closing run of #s is optional AND must be separated from the text:
+// without that `# C#` reads as a heading called "C", and a console that
+// renames a language is worse than one that leaves a stray hash.
+const HEADING = /^ {0,3}(#{1,6})\s+(.*?)(?:\s+#+)?\s*$/;
+const RULE = /^ {0,3}([-*_])(?:[ \t]*\1){2,}[ \t]*$/;
+const QUOTE = /^ {0,3}> ?(.*)$/;
+const BULLET = /^(\s*)[-*+][ \t]+(.*)$/;
+const ORDERED = /^(\s*)(\d{1,9})[.)][ \t]+(.*)$/;
+
+/** Whether a line ends the paragraph it follows by starting something else. */
+function starts(line: string): boolean {
+  return (
+    FENCE.test(line) ||
+    HEADING.test(line) ||
+    RULE.test(line) ||
+    QUOTE.test(line) ||
+    BULLET.test(line) ||
+    ORDERED.test(line)
+  );
+}
+
+/** How far in a list item's own content sits: past the marker and its one
+ *  space, which is what a continuation line is indented by. */
+const contentIndent = (indent: string, marker: string) => indent.length + marker.length + 1;
+
+/** A continuation line, with the item's indentation taken off — no more than
+ *  that, so a code block indented inside an item keeps its own. */
+const dedent = (line: string, by: number) => {
+  const lead = line.length - line.trimStart().length;
+  return line.slice(Math.min(lead, by));
+};
+
+/**
+ * How far into the line its first non-space character sits, in COLUMNS — a
+ * tab is one character but advances to the next four-column stop, so
+ * counting characters would read a tab-indented line as barely indented at
+ * all.
+ */
+function indentOf(line: string): number {
+  let column = 0;
+  for (const glyph of line) {
+    if (glyph === " ") column += 1;
+    else if (glyph === "\t") column += 4 - (column % 4);
+    else break;
+  }
+  return column;
+}
+
+/**
+ * Whether a line closes a fence opened with `length` of `char`.
+ *
+ * The length matters: a four-backtick fence is how a model quotes a
+ * three-backtick example, so a closer must be at least as long as its
+ * opener. So does "nothing else on the line" — an inner ```js is an opening
+ * fence in someone else's code block, not the end of this one — and so does
+ * how far in it sits.
+ */
+function closesFence(line: string, char: string, length: number): boolean {
+  // Three columns of indent at most, the same bound the opener has: a fence
+  // indented further is a line of the block, not the end of it — which is
+  // exactly how a model writes a fenced example inside a list item.
+  if (indentOf(line) > 3) return false;
+  const marker = line.trim();
+  if (marker.length < length) return false;
+  for (const glyph of marker) {
+    if (glyph !== char) return false;
+  }
+  return true;
+}
+
+export function parseBlocks(source: string): Block[] {
+  const lines = source.replace(/\r\n?/g, "\n").split("\n");
+  const blocks: Block[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line.trim() === "") {
+      i++;
+      continue;
+    }
+
+    // A fence runs to its closing marker OR to the end of the text: a model
+    // still streaming has an open one, and the code inside it is worth
+    // showing before it closes.
+    const fence = FENCE.exec(line);
+    if (fence !== null) {
+      const body: string[] = [];
+      i++;
+      while (i < lines.length && !closesFence(lines[i], fence[1][0], fence[1].length)) {
+        body.push(lines[i]);
+        i++;
+      }
+      i++;
+      blocks.push({ type: "code", language: fence[2], text: body.join("\n") });
+      continue;
+    }
+
+    const heading = HEADING.exec(line);
+    if (heading !== null) {
+      blocks.push({
+        type: "heading",
+        level: heading[1].length,
+        content: parseInline(heading[2]),
+      });
+      i++;
+      continue;
+    }
+
+    if (RULE.test(line)) {
+      blocks.push({ type: "rule" });
+      i++;
+      continue;
+    }
+
+    const quote = QUOTE.exec(line);
+    if (quote !== null) {
+      const quoted: string[] = [];
+      while (i < lines.length) {
+        const inner = QUOTE.exec(lines[i]);
+        if (inner === null) break;
+        quoted.push(inner[1]);
+        i++;
+      }
+      blocks.push({ type: "quote", children: parseBlocks(quoted.join("\n")) });
+      continue;
+    }
+
+    const bullet = BULLET.exec(line);
+    const ordered = ORDERED.exec(line);
+    if (bullet !== null || ordered !== null) {
+      const isOrdered = ordered !== null;
+      const first = ordered ?? bullet;
+      if (first === null) continue; // unreachable; narrows for the compiler
+      const base = first[1].length;
+      const items: string[][] = [];
+      let item: string[] | undefined;
+
+      while (i < lines.length) {
+        const current = lines[i];
+        const next = isOrdered ? ORDERED.exec(current) : BULLET.exec(current);
+        // A marker no deeper than the list's own indent is the NEXT item;
+        // one deeper belongs to the item open now, and is parsed as part of
+        // it — which is where a nested list comes from.
+        if (next !== null && next[1].length <= base + 1) {
+          item = [isOrdered ? next[3] : next[2]];
+          items.push(item);
+          i++;
+          continue;
+        }
+        if (item === undefined) break;
+        if (current.trim() === "") {
+          // A blank line ends the list unless what follows is still indented
+          // under the item — a second paragraph, or a nested block.
+          const after = lines[i + 1];
+          if (after === undefined || after.trim() === "" || after.search(/\S/) <= base) break;
+          item.push("");
+          i++;
+          continue;
+        }
+        // A line at the list's own indent that is not a marker has left the
+        // item; anything further in is still inside it.
+        if (current.search(/\S/) <= base) break;
+        item.push(dedent(current, contentIndent(first[1], isOrdered ? `${first[2]}.` : "-")));
+        i++;
+      }
+
+      blocks.push({
+        type: "list",
+        ordered: isOrdered,
+        start: isOrdered ? Number(first[2]) : 1,
+        items: items.map((lines) => parseBlocks(lines.join("\n"))),
+      });
+      continue;
+    }
+
+    // Whatever is left is a paragraph, running to the blank line or the
+    // block that interrupts it.
+    const paragraph: string[] = [];
+    while (
+      i < lines.length &&
+      lines[i].trim() !== "" &&
+      !(paragraph.length > 0 && starts(lines[i]))
+    ) {
+      paragraph.push(lines[i]);
+      i++;
+    }
+    blocks.push({ type: "paragraph", content: parseInline(paragraph.join("\n")) });
+  }
+
+  return blocks;
+}

--- a/apps/web/src/lib/status.ts
+++ b/apps/web/src/lib/status.ts
@@ -1,0 +1,27 @@
+// apps/web/src/lib/status.ts
+// What the lifecycle pill MEANS, per resource.
+//
+// Every row this console lists shares one lifecycle — live until archived,
+// and archive is terminal with no route back — so one component draws it
+// (components/Status.tsx). What archiving COSTS is the resource's own: a
+// config stops taking updates, a session stops taking messages. That
+// wording is here rather than in the component because two pages front the
+// same session row and must not describe it differently, and because a
+// component file that also exports constants gives up fast refresh.
+
+/** What each state means for the row it marks. `archived` reads as a clause
+ *  after "Archived <when> — ". */
+export type StatusMeaning = { active: string; archived: string };
+
+/** The two config lists', which share one rule between them. */
+export const CONFIG_STATUS: StatusMeaning = {
+  active: "Accepts updates and new sessions",
+  archived: "read-only, and no new session can use it",
+};
+
+/** A session's, which is not that: archiving one closes client writes
+ *  rather than edits, and leaves a log that stays readable. */
+export const SESSION_STATUS: StatusMeaning = {
+  active: "Accepts messages, and a worker can pick its work up",
+  archived: "read-only: it takes no new message, and its log stays readable",
+};

--- a/apps/web/src/lib/useEntries.ts
+++ b/apps/web/src/lib/useEntries.ts
@@ -1,0 +1,114 @@
+// apps/web/src/lib/useEntries.ts
+// One session's log, loaded once and then followed: a read for what is
+// already there, an EventSource for what lands next.
+//
+// Two mechanisms because the api built each for its half. /entries answers
+// the whole log in one round trip, which is the right shape for a page
+// opening on a session that already has a hundred rows behind it, and
+// /stream replays from a cursor before it tails — so opening the stream at
+// the read's last seq loses nothing in the gap between the two calls.
+//
+// Following the log is the browser's job here rather than a poll of ours:
+// EventSource reconnects on its own and resumes with Last-Event-ID, which
+// the route honors over `after`. Every reconnect therefore picks up exactly
+// where the last delivered entry left off, with no cursor for this file to
+// keep.
+import { useEffect, useState } from "react";
+import { type SessionEntry, entryStreamUrl, readEntries } from "./api";
+
+/** What the log is showing. `ready` is the only state with rows; entries
+ *  arrive into it afterwards, so it is not a terminal state. */
+export type LogState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; entries: SessionEntry[] };
+
+const messageOf = (err: unknown) => (err instanceof Error ? err.message : String(err));
+
+/**
+ * The log, appended to as it grows.
+ *
+ * `tail` is whether to follow it at all: an archived session takes no
+ * further write, so there is nothing to wait for and the stream — which has
+ * no server-side end — would sit open forever heartbeating at a log that
+ * cannot change.
+ */
+export function useEntries(id: string, tail: boolean) {
+  const [state, setState] = useState<LogState>({ status: "loading" });
+  // Whether the connection has failed since it was opened. The only part of
+  // being live that this can't work out for itself — a drop is news from
+  // outside — so it is the only part that is state.
+  const [dropped, setDropped] = useState(false);
+  // Where the tail starts, and the fact that the read has finished: an
+  // object, because `after` is legitimately absent for an empty log and
+  // that must not read as "not loaded yet".
+  const [start, setStart] = useState<{ after?: number }>();
+  const [reloads, setReloads] = useState(0);
+
+  /**
+   * Whether the log on screen is one that keeps up.
+   *
+   * Attached, rather than "a byte has arrived": nothing reaches the client
+   * until the api writes one, and on a quiet session that is the keep-alive
+   * a whole heartbeat later — so a tail that works perfectly would report
+   * itself broken for as long as the session had nothing to say.
+   */
+  const live = tail && start !== undefined && !dropped;
+
+  function reload() {
+    setState({ status: "loading" });
+    setStart(undefined);
+    setDropped(false);
+    setReloads((n) => n + 1);
+  }
+
+  useEffect(() => {
+    const abort = new AbortController();
+    readEntries(id, { signal: abort.signal }).then(
+      (entries) => {
+        // The api answers in seq order and this sorts anyway: ordering is
+        // what the rest of this file's reasoning rests on — the tail cursor
+        // is the last row's seq — so it is established here rather than
+        // assumed from the store's ORDER BY.
+        const sorted = [...entries].sort((a, b) => a.seq - b.seq);
+        setState({ status: "ready", entries: sorted });
+        setStart({ after: sorted[sorted.length - 1]?.seq });
+      },
+      (err: unknown) => {
+        if (abort.signal.aborted) return;
+        setState({ status: "error", message: messageOf(err) });
+      },
+    );
+    return () => abort.abort();
+  }, [id, reloads]);
+
+  useEffect(() => {
+    // Nothing to follow, or nothing to follow FROM: opening the stream
+    // before the read lands would replay the whole log over it.
+    if (!tail || start === undefined) return;
+    const source = new EventSource(entryStreamUrl(id, start.after));
+    // A reconnect that got through, after `error` below marked one as
+    // dropped.
+    source.onopen = () => setDropped(false);
+    source.onmessage = (event: MessageEvent<string>) => {
+      const entry = JSON.parse(event.data) as SessionEntry;
+      setState((prev) => {
+        if (prev.status !== "ready") return prev;
+        // A session's log is append-only and its seq gapless, so anything
+        // at or behind the tail is a replay — a reconnect resuming one
+        // entry early, say — and never news.
+        const last = prev.entries[prev.entries.length - 1];
+        if (last !== undefined && entry.seq <= last.seq) return prev;
+        return { ...prev, entries: [...prev.entries, entry] };
+      });
+    };
+    // A dropped connection is retried by EventSource itself; an http
+    // failure closes it for good. Either way the log on screen is still
+    // what the read returned, so this dims the live mark rather than
+    // throwing the transcript away.
+    source.onerror = () => setDropped(true);
+    return () => source.close();
+  }, [id, tail, start]);
+
+  return { state, live, reload };
+}

--- a/apps/web/src/pages/CreateSession.tsx
+++ b/apps/web/src/pages/CreateSession.tsx
@@ -1,0 +1,353 @@
+// apps/web/src/pages/CreateSession.tsx
+// The Start Session dialog: the two configs a session is made of, and the
+// first thing to say to it.
+//
+// Two calls, not one. The api creates a session and takes messages through
+// separate routes — a session is a place, and a message is something that
+// happens in it — so this dialog does both and has to be honest about the
+// gap between them: if the message fails, the session still exists, and
+// saying so is the only answer that doesn't either lose it or create a
+// second one (see submit).
+//
+// Neither route takes an idempotency key, so a request whose ANSWER is lost
+// cannot be told apart from one that was refused — and nothing this console
+// can read settles it either. Only the api REFUSING a request proves it was
+// not taken, so that is the one failure either half offers to repeat:
+//
+//  - A refused create or message wrote nothing. Say so, and let it be sent
+//    again.
+//  - An unanswered one is unknown, and stays unknown. A create says a
+//    session may exist and to check the list; a message stops offering to
+//    be sent at all, and points at the conversation, where the log shows
+//    whether it arrived and the composer can send it if it didn't.
+//
+// The pickers offer ACTIVE configs only. An archived one is readable and
+// keeps its running sessions, but nothing new may name it — the api answers
+// 409 — so offering it would be offering a refusal.
+import { type FormEvent, type RefObject, useEffect, useState } from "react";
+import {
+  type AgentConfig,
+  ApiError,
+  DEFAULT_NAMESPACE,
+  type EnvConfig,
+  type NetworkPolicy,
+  type Session,
+  createSession,
+  listAgentConfigs,
+  listEnvConfigs,
+  sendMessage,
+} from "../lib/api";
+import { Field, type FieldOption } from "../components/Field";
+import { Modal } from "../components/Modal";
+
+/**
+ * How deep the pickers read. One page each, at the api's ceiling: a picker
+ * is a choice, not an inventory, and a namespace with more than this many
+ * configs is one where picking from a list has stopped being the way to
+ * start a session anyway. The sections themselves page properly.
+ */
+const PICKER_LIMIT = 100;
+
+const messageOf = (err: unknown) => (err instanceof Error ? err.message : String(err));
+
+const active = (config: { archivedAt?: string }) => config.archivedAt === undefined;
+
+/** Enough of an id to tell two rows apart at a glance; the session's page
+ *  shows every id it was made from in full. */
+const short = (id: string) => id.slice(0, 8);
+
+/** What a recipe does to the network, which is the whole of what an env
+ *  config currently decides. */
+function networkLabel(network: NetworkPolicy): string {
+  return network.type === "allowlist"
+    ? `allowlist of ${network.domains.length}`
+    : network.type === "none"
+      ? "no network"
+      : "unrestricted";
+}
+
+const agentOptions = (configs: AgentConfig[]): FieldOption[] =>
+  configs.map((config) => ({
+    id: config.id,
+    label: `${config.inference.model} · v${config.version} · ${short(config.id)}`,
+  }));
+
+const envOptions = (configs: EnvConfig[]): FieldOption[] =>
+  configs.map((config) => ({
+    id: config.id,
+    label: `${networkLabel(config.network)} · ${short(config.id)}`,
+  }));
+
+/** The active configs a session can be made from, once both lists land. */
+type Choices = { agents: AgentConfig[]; envs: EnvConfig[] };
+
+export function CreateSession({
+  onCreated,
+  onClose,
+  returnFocus,
+}: {
+  /** The new session. The caller opens it — creating one is how you get to
+   *  the conversation, not an end in itself. */
+  onCreated: (session: Session) => void;
+  onClose: () => void;
+  /** Focus lands here if creating the session removed whatever opened this
+   *  (Modal's `returnFocus`) — the first row replaces the empty state. */
+  returnFocus?: RefObject<HTMLElement | null>;
+}) {
+  const [choices, setChoices] = useState<Choices>();
+  /**
+   * How the last request ended, when it didn't go through, and which one
+   * it was.
+   *
+   * "refused" is the api rejecting it, which proves the write never ran, so
+   * making it again is safe. "unconfirmed" is no answer at all — and no
+   * read settles that, however new the session is: a client disconnecting
+   * does not cancel the request, so a transaction still committing looks
+   * exactly like one that never started, and asking too early then trying
+   * again is how one session, or one instruction, becomes two.
+   *
+   * The stage is what the dialog can offer afterwards. An unconfirmed
+   * message leaves a session to open; an unconfirmed create leaves nothing
+   * at all — no id to show, and no way to ask — so the only honest move is
+   * out of the dialog and into the list.
+   */
+  const [outcome, setOutcome] = useState<{
+    stage: "create" | "message";
+    kind: "refused" | "unconfirmed";
+  }>();
+  const [agentConfigId, setAgentConfigId] = useState("");
+  const [envConfigId, setEnvConfigId] = useState("");
+  const [text, setText] = useState("");
+  const [busy, setBusy] = useState(false);
+  // The session, once it exists. Set before the message is sent, so a
+  // failure after this point knows there is a row to answer for.
+  const [created, setCreated] = useState<Session>();
+  // The api's refusal — from either call, or from the reads that fill the
+  // pickers.
+  const [failure, setFailure] = useState<string>();
+
+  useEffect(() => {
+    const abort = new AbortController();
+    Promise.all([
+      listAgentConfigs({ limit: PICKER_LIMIT, signal: abort.signal }),
+      listEnvConfigs({ limit: PICKER_LIMIT, signal: abort.signal }),
+    ]).then(
+      ([agents, envs]) => {
+        const usable = { agents: agents.data.filter(active), envs: envs.data.filter(active) };
+        setChoices(usable);
+        // The newest of each, which is what the lists lead with — the
+        // likeliest choice, and never an empty select showing nothing.
+        setAgentConfigId(usable.agents[0]?.id ?? "");
+        setEnvConfigId(usable.envs[0]?.id ?? "");
+      },
+      (err: unknown) => {
+        if (abort.signal.aborted) return;
+        setFailure(messageOf(err));
+      },
+    );
+    return () => abort.abort();
+  }, []);
+
+  const message = text.trim();
+  const ready =
+    choices !== undefined && agentConfigId !== "" && envConfigId !== "" && message !== "";
+  /** Whether trying again is something this dialog may offer at all —
+   *  false for either half once a request has gone unanswered. */
+  const resendable = outcome?.kind !== "unconfirmed";
+  /** The create is the half with nothing to fall back to. */
+  const strandedCreate = outcome?.stage === "create" && outcome.kind === "unconfirmed";
+  // What the pickers can't offer, said once: a session needs one of each,
+  // and neither section is reachable from inside a dialog.
+  const missing =
+    choices === undefined
+      ? undefined
+      : choices.agents.length === 0 && choices.envs.length === 0
+        ? "an agent config and an env config"
+        : choices.agents.length === 0
+          ? "an agent config"
+          : choices.envs.length === 0
+            ? "an env config"
+            : undefined;
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    if (busy || !ready || !resendable) return;
+
+    setFailure(undefined);
+    setBusy(true);
+
+    // The session, made once and kept. Held locally as well as in state
+    // because state does not move inside this call: a failure after the
+    // create must know a session exists, and `created` would still read
+    // undefined in this closure.
+    let session = created;
+    if (session === undefined) {
+      try {
+        // No abort signal: a create in flight is a row that may well exist,
+        // so the dialog refuses to close rather than walk away from an
+        // answer it would have to guess at.
+        session = await createSession({ agentConfigId, envConfigId });
+      } catch (err) {
+        // Only the api refusing the REQUEST proves nothing was written. No
+        // answer at all, a body that stopped arriving mid-json, a 5xx
+        // raised after the row was committed — none of those say, and there
+        // is no idempotency key to make pressing Start again safe.
+        const refused = err instanceof ApiError && err.status !== undefined && err.status < 500;
+        setOutcome({ stage: "create", kind: refused ? "refused" : "unconfirmed" });
+        setFailure(
+          refused ? messageOf(err) : `${messageOf(err)} A session may have been created even so.`,
+        );
+        setBusy(false);
+        return;
+      }
+      setCreated(session);
+    }
+
+    try {
+      await sendMessage(session.id, message);
+      onCreated(session);
+      // Opened — the caller unmounts this, so there is no state to reset.
+    } catch (err) {
+      // The same rule as the create above, and the same reason: only a
+      // refusal is definite. An unanswered send leaves this dialog with
+      // nothing safe to offer, so it stops offering to send.
+      const refused = err instanceof ApiError && err.status !== undefined && err.status < 500;
+      setOutcome({ stage: "message", kind: refused ? "refused" : "unconfirmed" });
+      setFailure(messageOf(err));
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Modal
+      title="Start session"
+      description={
+        <>
+          One agent config, one env config, and the message that sets it going. Lands in the{" "}
+          <code>{DEFAULT_NAMESPACE}</code> namespace.
+        </>
+      }
+      dismissible={!busy}
+      returnFocus={returnFocus}
+      onClose={onClose}
+    >
+      <form className="modal-form" onSubmit={submit} noValidate>
+        <div className="modal-body form-fields">
+          {strandedCreate ? (
+            <p className="note">
+              The api never answered, so a session may exist and may not. There is no id to show for
+              it and no route that would say, so this dialog won&rsquo;t start another — close it
+              and check the list.
+            </p>
+          ) : null}
+          {created === undefined ? null : (
+            <p className="note">
+              Session <code>{created.id}</code> was created,{" "}
+              {resendable
+                ? "but the api refused its first message. Try again, or open the session and send it there."
+                : "but the api never answered its first message — it may or may not have been sent. Open the session to see, and send it there if it wasn't."}
+            </p>
+          )}
+          {missing === undefined ? null : (
+            <p className="note">
+              There is no active {missing} to start a session with. Make one in its own section
+              first — an archived config keeps its sessions but can&rsquo;t take a new one.
+            </p>
+          )}
+
+          <Field
+            label="Agent config"
+            name="agentConfigId"
+            value={agentConfigId}
+            onChange={setAgentConfigId}
+            options={agentOptions(choices?.agents ?? [])}
+            // Frozen once the session exists: it was made from these, and a
+            // retry sends the message to THAT session. A select still
+            // offering a choice it could no longer apply would be lying —
+            // as would one on a form that has stopped being submittable.
+            disabled={
+              busy ||
+              !resendable ||
+              created !== undefined ||
+              choices === undefined ||
+              choices.agents.length === 0
+            }
+            required
+          />
+          <Field
+            label="Env config"
+            name="envConfigId"
+            value={envConfigId}
+            onChange={setEnvConfigId}
+            options={envOptions(choices?.envs ?? [])}
+            disabled={
+              busy ||
+              !resendable ||
+              created !== undefined ||
+              choices === undefined ||
+              choices.envs.length === 0
+            }
+            required
+          />
+          <Field
+            label="First message"
+            name="message"
+            value={text}
+            onChange={setText}
+            multiline
+            rows={4}
+            placeholder="What should the agent do?"
+            disabled={busy || !resendable}
+            autoFocus
+            required
+          />
+        </div>
+
+        <footer className="modal-foot">
+          {failure ? (
+            <p className="form-failure" role="alert">
+              {failure}
+            </p>
+          ) : null}
+          {created === undefined ? (
+            // The only way on, once a create has gone unanswered: there is
+            // no session to open and nothing safe to send, so leaving is
+            // the action and it says so.
+            <button
+              className={resendable ? "btn" : "btn btn-primary"}
+              type="button"
+              onClick={onClose}
+              disabled={busy}
+            >
+              {resendable ? "Cancel" : "Close"}
+            </button>
+          ) : (
+            // The session exists, so there is nothing left to cancel — only
+            // a message that hasn't landed, which the conversation itself
+            // can take instead. Where resending isn't safe this IS the way
+            // on, so it leads.
+            <button
+              className={resendable ? "btn" : "btn btn-primary"}
+              type="button"
+              onClick={() => onCreated(created)}
+              disabled={busy}
+            >
+              Open session
+            </button>
+          )}
+          {resendable ? (
+            <button className="btn btn-primary" type="submit" disabled={busy || !ready}>
+              {busy
+                ? created === undefined
+                  ? "Starting…"
+                  : "Sending…"
+                : created === undefined
+                  ? "Start"
+                  : "Try again"}
+            </button>
+          ) : null}
+        </footer>
+      </form>
+    </Modal>
+  );
+}

--- a/apps/web/src/pages/SessionDetail.css
+++ b/apps/web/src/pages/SessionDetail.css
@@ -1,0 +1,340 @@
+/* apps/web/src/pages/SessionDetail.css
+   The frame around one session: the header that identifies it, the card
+   that holds the log, and the composer pinned to the bottom of that card.
+   What goes INSIDE the log — the bubbles and the folds — is
+   pages/Transcript.css. Every colour resolves to a token in index.css. */
+
+/* The shell scrolls the WINDOW: .app is min-height: 100svh, so a page
+   taller than the viewport makes the whole document taller. A conversation
+   must not do that — its composer belongs at the bottom of the view, with
+   the log scrolling behind it — so while one is open the shell is pinned to
+   the viewport and .chat-log takes the overflow instead.
+
+   Written here, scoped with :has(), rather than changed in App.css: it is
+   this page's requirement and no other page's, the same way Modal.css locks
+   body scroll only while a dialog is open. The height goes on .app so the
+   narrow layout gets it too — there the sidebar is a row of that same grid,
+   and .main is what's left. */
+.app:has(.chat) {
+  height: 100svh;
+}
+
+/* Grid and flex items floor at their content size; both have to be told
+   they may be shorter than the log inside them, or the pinning above just
+   moves the overflow rather than containing it. */
+.app:has(.chat) .main {
+  min-height: 0;
+}
+
+.app:has(.chat) .content {
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* The pane centres and tops its page; this one takes the height instead, so
+   the composer sits at the bottom of the view rather than wherever the log
+   happens to end. */
+.chat {
+  align-self: stretch;
+  justify-self: center;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 900px;
+  min-width: 0;
+  min-height: 0;
+}
+
+/* Head ------------------------------------------------------------------- */
+
+.chat-head {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+/* A back link that looks like the button it behaves as, but stays an
+   anchor: the browser's history, middle-click and focus ring come free. */
+.chat-back {
+  text-decoration: none;
+}
+
+/* Whether the tail is connected. Dimmed until it is — a reconnect is
+   ordinary, so this reports rather than warns. */
+.live {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  color: var(--text-3);
+}
+
+.live-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-3);
+  opacity: 0.55;
+}
+
+.live-on .live-dot {
+  background: var(--ok);
+  box-shadow: 0 0 0 3px var(--ok-glow);
+  opacity: 1;
+}
+
+.chat-id {
+  flex: none;
+  font: 500 13px var(--mono);
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+/* What this session was made of, on one wrapping line: the ids are the
+   point of a console, so they are shown whole rather than shortened into
+   something you can't paste back. */
+.chat-meta {
+  display: flex;
+  flex: none;
+  flex-wrap: wrap;
+  gap: 4px 14px;
+  margin-top: 5px;
+  margin-bottom: 14px;
+  font-size: 12px;
+  color: var(--text-3);
+}
+
+.chat-meta code {
+  font: 500 11.5px var(--mono);
+  color: var(--text-2);
+  overflow-wrap: anywhere;
+}
+
+/* Card ------------------------------------------------------------------- */
+
+/* min-height: 0, or the log refuses to shrink below its content and pushes
+   the composer off the bottom of the pane instead of scrolling. */
+.chat-card {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--bg-elev);
+  box-shadow: var(--shadow-sm);
+}
+
+.chat-log {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 20px;
+  scrollbar-width: thin;
+}
+
+.chat-turns {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* Loading, failed, and empty — all of them the card with a line in the
+   middle rather than a block over the page, because the card is already
+   the thing that would be holding the log. */
+.chat-state {
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  gap: 8px;
+  min-height: 100%;
+  padding: 24px;
+  text-align: center;
+  font-size: 13.5px;
+  color: var(--text-3);
+}
+
+.chat-state-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.chat-state .btn {
+  margin-top: 6px;
+}
+
+/* Composer --------------------------------------------------------------- */
+
+.chat-compose {
+  flex: none;
+  padding: 12px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-sunken);
+  border-radius: 0 0 calc(var(--r-lg) - 1px) calc(var(--r-lg) - 1px);
+}
+
+/* The queue: sent, not in the log yet. It belongs to the composer rather
+   than the transcript — a queued message hasn't reached the agent at all
+   until the current turn ends, so drawing it as a line of the conversation
+   would be claiming something the log doesn't say.
+
+   One line each, with the whole text on hover: this is an acknowledgement
+   that the message is on its way, and a long one shouldn't eat the log it
+   is waiting to join. */
+.chat-queue {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0 0 10px;
+  padding: 0;
+  list-style: none;
+}
+
+.chat-queued {
+  min-width: 0;
+  padding: 7px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--bg-elev);
+  font-size: 13px;
+  color: var(--text-2);
+}
+
+.chat-queued-row {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+}
+
+/* A refusal is the one state of a queued message that needs answering, so
+   it is the one that gets a border you can find. */
+.chat-queued-bad {
+  border-color: var(--bad);
+}
+
+.chat-queued-state {
+  flex: none;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+
+.chat-queued-text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-queued-bad .chat-queued-state {
+  color: var(--bad);
+}
+
+/* Two words, not two pills: this row is already an interruption, and a
+   pair of buttons styled like the Send beside it would read as more
+   important than the message they belong to. */
+.chat-queued-actions {
+  display: flex;
+  flex: none;
+  gap: 12px;
+}
+
+.chat-queued-actions button {
+  padding: 0;
+  border: none;
+  background: none;
+  font: 500 12px var(--sans);
+  color: var(--text-2);
+  text-decoration: underline;
+  text-underline-offset: 2.5px;
+  cursor: pointer;
+}
+
+.chat-queued-actions button:hover {
+  color: var(--text);
+}
+
+.chat-queued-error {
+  margin-top: 5px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--bad);
+}
+
+.chat-compose-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+}
+
+/* The box grows with its content up to the cap SessionDetail.tsx sets, so
+   the height is written on the element and this only says where to start.
+   field-sizing would replace both, once Safari has it. */
+.compose-box {
+  flex: 1;
+  min-width: 0;
+  padding: 9px 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-md);
+  background: var(--bg);
+  font: 400 13.5px/1.55 var(--sans);
+  color: var(--text);
+  /* The height is scripted; a drag handle would fight it. */
+  resize: none;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  transition:
+    border-color var(--dur) var(--ease),
+    box-shadow var(--dur) var(--ease);
+}
+
+.compose-box::placeholder {
+  color: var(--text-3);
+}
+
+.compose-box:hover:not(:focus) {
+  border-color: var(--text-3);
+}
+
+.compose-box:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+
+.compose-box:disabled {
+  background: var(--bg-sunken);
+  color: var(--text-3);
+}
+
+/* Aligned to the box's bottom edge (the row is flex-end), so a box that has
+   grown leaves the button where the thumb last saw it. */
+.compose-send {
+  padding-top: 9px;
+  padding-bottom: 9px;
+}
+
+/* An archived session takes no message, so it gets no box — saying why is
+   more use than a disabled control that doesn't. */
+.chat-closed {
+  flex: none;
+  padding: 14px 16px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-sunken);
+  border-radius: 0 0 calc(var(--r-lg) - 1px) calc(var(--r-lg) - 1px);
+  font-size: 12.5px;
+  color: var(--text-3);
+}
+
+@container pane (max-width: 620px) {
+  .chat-log {
+    padding: 16px 14px;
+  }
+}

--- a/apps/web/src/pages/SessionDetail.tsx
+++ b/apps/web/src/pages/SessionDetail.tsx
@@ -1,0 +1,505 @@
+// apps/web/src/pages/SessionDetail.tsx
+// One session, as the conversation it is: the log above, a box to add to
+// it below.
+//
+// A page rather than a dialog, unlike the config editors. A config is a
+// form — a handful of fields you change and close — where a session is a
+// place you stay, reading a log that grows while you watch it, so it gets
+// the pane, the back link and its own route (`#/session/<id>`).
+//
+// The transcript is pages/Transcript.tsx; the loading and following of the
+// log is lib/useEntries.ts. What is left here is the session row itself,
+// the composer, and the one thing neither of those can know: which of the
+// messages this client has sent are still missing from the log (Sent).
+import {
+  type FormEvent,
+  type KeyboardEvent,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import {
+  ApiError,
+  type Session,
+  type SessionEntry,
+  type UserMessage,
+  getSession,
+  sendMessage,
+} from "../lib/api";
+import { RELATIVE_TICK_MS, absoluteTime, relativeTime } from "../lib/format";
+import { useEntries } from "../lib/useEntries";
+import { useNow } from "../lib/useNow";
+import { ArrowLeftIcon, RefreshIcon, SendIcon } from "../components/Icons";
+import { Status } from "../components/Status";
+import { SESSION_STATUS } from "../lib/status";
+import { Transcript } from "./Transcript";
+import "./SessionDetail.css";
+
+/** The section this page sits under — where its back link goes. */
+const SECTION = "#/session";
+
+/** How tall the composer may grow before it scrolls instead. */
+const COMPOSE_MAX = 168;
+
+/** Within this far of the bottom counts as reading the tail, so a new entry
+ *  scrolls into view; further up is reading history, which must not be
+ *  yanked away. */
+const PINNED_PX = 64;
+
+const messageOf = (err: unknown) => (err instanceof Error ? err.message : String(err));
+
+/** One array for every "no log yet", so a render before the read lands
+ *  doesn't look like a change to the one after it. */
+const EMPTY: SessionEntry[] = [];
+
+/** What a user message's text was — how a pending bubble recognises itself
+ *  arriving in the log. The composer only ever sends text, so the parts it
+ *  can't have (images) are not part of the comparison. */
+function sentText(message: UserMessage): string {
+  return message.content
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("\n");
+}
+
+/**
+ * A message this client has sent that the log doesn't hold yet.
+ *
+ * `queued` is not a spinner: intake either starts a run or parks the message
+ * behind the one already going, and a parked one is appended to the log only
+ * when that run ends. Until then this client is the only place it exists —
+ * which is why it is drawn beside the composer rather than in the
+ * transcript, where it would be claiming to be part of a log it isn't in.
+ *
+ * `sinceSeq` is the log position it was sent at: an entry BEHIND that point
+ * is not this message, however alike it reads.
+ */
+type Sent = {
+  /** Local, and never a log id: this message has no seq yet. */
+  id: string;
+  text: string;
+  sinceSeq: number;
+  /**
+   * Where it has got to. A send that stopped stays HERE rather than going
+   * back into the draft — two sends can be in flight at once, so one box is
+   * not somewhere two failures can both be put.
+   *
+   * "failed" and "unconfirmed" are the two ways it can stop, and the
+   * difference is whether a retry is safe (see deliver).
+   */
+  state: "sending" | "queued" | "failed" | "unconfirmed";
+  /** Whether the api answered that it took this message. An acknowledged
+   *  send HAS an entry, or will have one when the current turn ends; an
+   *  unanswered one may never. Which is what decides who claims what in
+   *  outstanding(). */
+  acknowledged: boolean;
+  /** The api's own words, when it gave any. */
+  error?: string;
+};
+
+/** Whether a send is still on its way, as against stopped. */
+const inFlight = (message: Sent) => message.state === "sending" || message.state === "queued";
+
+/**
+ * The sends the log hasn't caught up with — which is at once for one that
+ * started a run, and only at the end of the current turn for one that
+ * queued behind it.
+ *
+ * Matched ONE FOR ONE. Two identical messages sent before either lands
+ * share a sinceSeq and read alike, so a test applied per message would let
+ * the first entry to arrive settle both and hide a message still waiting.
+ * Each entry is claimed by at most one send.
+ *
+ * Who claims first is not send order but CERTAINTY, in two passes:
+ *
+ *  - A send the api acknowledged has an entry coming, so it claims one
+ *    before anything else does.
+ *  - An unanswered one may have no entry at all, so it takes only what is
+ *    left. Oldest-first alone would let an older unconfirmed row take the
+ *    entry belonging to a later accepted resend of the same text — hiding a
+ *    warning that still stands, and leaving the accepted send waiting on an
+ *    entry that has already been spoken for.
+ *  - A refused one claims nothing ever: the api did not take it, so no
+ *    entry in this log is it.
+ *
+ * The walk is bounded by the oldest send's position rather than the whole
+ * log: everything at or behind that was already there, so it cannot be any
+ * of these.
+ */
+function outstanding(entries: SessionEntry[], sent: Sent[]): Sent[] {
+  if (sent.length === 0) return sent;
+  const earliest = Math.min(...sent.map((message) => message.sinceSeq));
+  const arrived: Array<{ seq: number; text: string; taken: boolean }> = [];
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (entry.seq <= earliest) break;
+    if (entry.type === "message" && entry.message.role === "user") {
+      arrived.push({ seq: entry.seq, text: sentText(entry.message), taken: false });
+    }
+  }
+  arrived.reverse();
+
+  const settled = new Set<string>();
+  const claim = (message: Sent) => {
+    const match = arrived.find(
+      (entry) => !entry.taken && entry.seq > message.sinceSeq && entry.text === message.text,
+    );
+    if (match === undefined) return;
+    match.taken = true;
+    settled.add(message.id);
+  };
+  for (const message of sent) {
+    if (message.acknowledged) claim(message);
+  }
+  for (const message of sent) {
+    if (!message.acknowledged && message.state !== "failed") claim(message);
+  }
+  return sent.filter((message) => !settled.has(message.id));
+}
+
+export function SessionDetail({ id }: { id: string }) {
+  const [session, setSession] = useState<Session>();
+  const [failure, setFailure] = useState<string>();
+  const [draft, setDraft] = useState("");
+  const [sent, setSent] = useState<Sent[]>([]);
+  // Bumped to re-read the session row. Its own counter, because the log has
+  // one of its own (useEntries) and either read can fail without the other.
+  const [reads, setReads] = useState(0);
+  const now = useNow(RELATIVE_TICK_MS);
+
+  const archived = session?.archivedAt !== undefined;
+  // Follow the log only while there is something that could still write to
+  // it, and only once the row that says so has arrived.
+  const { state, live, reload } = useEntries(id, session !== undefined && !archived);
+
+  const log = useRef<HTMLDivElement>(null);
+  const box = useRef<HTMLTextAreaElement>(null);
+  // Whether the reader is at the tail. A ref, not state: it is read when an
+  // entry lands, and nothing renders differently for it.
+  const pinned = useRef(true);
+
+  // No reset before the read: `id` never changes under this component —
+  // Sessions.tsx keys it by the route — so every id starts from a fresh
+  // mount, and there is no previous session's row to clear.
+  useEffect(() => {
+    const abort = new AbortController();
+    getSession(id, { signal: abort.signal }).then(setSession, (err: unknown) => {
+      if (abort.signal.aborted) return;
+      setFailure(messageOf(err));
+    });
+    return () => abort.abort();
+  }, [id, reads]);
+
+  /** Both reads again, after either of them failed — a session that could
+   *  not be fetched once is not a session this page should be stuck on. */
+  function reread() {
+    setFailure(undefined);
+    setReads((n) => n + 1);
+    reload();
+  }
+
+  const entries = state.status === "ready" ? state.entries : EMPTY;
+
+  // A sent message stops being this client's business the moment the log
+  // holds it, so which ones are still outstanding is READ from the log
+  // rather than tracked against it — there is no second copy of the truth
+  // to keep in step, and an entry arriving resolves its bubble by itself.
+  const pending = outstanding(entries, sent);
+
+  // The box grows with what is in it, up to the point where it scrolls: a
+  // chat message has no length a fixed height would be right for.
+  //
+  // Keyed on the draft rather than done in the change handler, so every way
+  // the draft moves resizes it — typing, the clear on send, the text coming
+  // back after a failure — and so the FIRST render sizes it too. A textarea
+  // left at its rows=1 default is a couple of pixels short of its own line
+  // box, which is enough to put a scrollbar on an empty composer.
+  useLayoutEffect(() => {
+    const el = box.current;
+    if (el === null) return;
+    el.style.height = "auto";
+    // scrollHeight covers the content and the padding but not the border,
+    // and every box here is border-box (index.css) — so the border has to be
+    // added back, or the box is set two pixels short of its own text and an
+    // empty composer carries a scrollbar.
+    const border = el.offsetHeight - el.clientHeight;
+    el.style.height = `${Math.min(el.scrollHeight + border, COMPOSE_MAX)}px`;
+  }, [draft]);
+
+  // After the paint that added a turn, not before: scrollHeight has to
+  // include it. Layout effect, so the jump is never a visible frame.
+  useLayoutEffect(() => {
+    const pane = log.current;
+    if (pane === null || !pinned.current) return;
+    pane.scrollTop = pane.scrollHeight;
+  }, [entries, pending]);
+
+  /** One message on its way, from the post to whatever the api answers. */
+  async function deliver(message: Sent) {
+    const settle = (change: Partial<Sent>) =>
+      setSent((prev) => prev.map((row) => (row.id === message.id ? { ...row, ...change } : row)));
+    try {
+      const result = await sendMessage(id, message.text);
+      // "started" means it is already in the log, so it leaves this list on
+      // the next entry rather than by anything said here. Either way the api
+      // has taken it, which is what lets its entry be claimed for it.
+      settle({
+        state: result.kind === "queued" ? "queued" : "sending",
+        acknowledged: true,
+        error: undefined,
+      });
+    } catch (err) {
+      // Whether the api REFUSED it, which is the only answer proving it was
+      // not accepted: intake runs after those checks, or not at all.
+      //
+      // Nothing else can be resolved, and a fresh read of the log will not
+      // help. Intake either appends the message or PARKS it — a message
+      // arriving behind a running turn waits in its own table until that
+      // turn ends — and a parked one appears in no read this console has: it
+      // is absent from /entries, and there is no route that lists it. So an
+      // unanswered send is genuinely unknown, and the row says so instead of
+      // offering a retry that could give the agent the same instruction
+      // twice. If it did land, the log settles the row itself: at once when
+      // it started a turn, and at the end of the current one when it queued.
+      const refused = err instanceof ApiError && err.status !== undefined && err.status < 500;
+      settle({ state: refused ? "failed" : "unconfirmed", error: messageOf(err) });
+    }
+  }
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    const text = draft.trim();
+    if (text === "" || archived) return;
+
+    // Sent at the tail as this client last saw it. Anything at or behind
+    // this seq was already in the log, so it cannot be this message.
+    const sinceSeq = entries.length === 0 ? -1 : entries[entries.length - 1].seq;
+    const message: Sent = {
+      id: crypto.randomUUID(),
+      text,
+      sinceSeq,
+      state: "sending",
+      acknowledged: false,
+    };
+    setDraft("");
+    // Optimistic, and honest about it: the row reads "Sending…" until the
+    // api answers, then either leaves on the log's arrival or says "Queued".
+    //
+    // The ones the log has already caught up with are dropped in the same
+    // move, so `sent` only ever holds what might still be outstanding and
+    // outstanding()'s walk never lengthens with the conversation.
+    setSent((prev) => [...outstanding(entries, prev), message]);
+    // Nothing gates a second send: two messages in flight is a state the
+    // api has an answer for — the later one queues — so the composer stays
+    // open rather than pretending the conversation is turn-locked.
+    await deliver(message);
+  }
+
+  /** Send a refused message again. Offered only where the api refused it —
+   *  an unconfirmed one has no retry, because nothing this console can read
+   *  would say whether it needs one (see deliver). */
+  function retry(message: Sent) {
+    setSent((prev) =>
+      prev.map((row) =>
+        row.id === message.id
+          ? { ...row, state: "sending", acknowledged: false, error: undefined }
+          : row,
+      ),
+    );
+    void deliver(message);
+  }
+
+  /** Give up on one. A refusal the api will keep making — an archived
+   *  session, a message it won't take — needs a way out that isn't a
+   *  reload, and an unconfirmed send has no other way out at all. */
+  function discard(message: Sent) {
+    setSent((prev) => prev.filter((row) => row.id !== message.id));
+  }
+
+  function keyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
+    // Enter sends and Shift+Enter breaks the line, the way every chat box
+    // does. An IME composing a character is mid-word, not mid-send.
+    if (event.key !== "Enter" || event.shiftKey || event.nativeEvent.isComposing) return;
+    event.preventDefault();
+    event.currentTarget.form?.requestSubmit();
+  }
+
+  return (
+    <section className="chat">
+      <header className="chat-head">
+        <a className="btn chat-back" href={SECTION}>
+          <ArrowLeftIcon />
+          Sessions
+        </a>
+        {session === undefined ? null : (
+          <>
+            <Status archivedAt={session.archivedAt} meaning={SESSION_STATUS} />
+            {archived ? null : (
+              <span className={live ? "live live-on" : "live"}>
+                <span className="live-dot" aria-hidden="true" />
+                {live ? "Live" : "Reconnecting…"}
+              </span>
+            )}
+          </>
+        )}
+      </header>
+
+      <p className="chat-id">{id}</p>
+
+      {session === undefined ? (
+        // Nothing to say twice: a failure is reported in the log pane below,
+        // which is where the retry lives.
+        failure === undefined ? (
+          <p className="chat-meta">Loading…</p>
+        ) : null
+      ) : (
+        <p className="chat-meta">
+          <time dateTime={session.createdAt} title={absoluteTime(session.createdAt)}>
+            Started {relativeTime(session.createdAt, now)}
+          </time>
+          <span>
+            agent <code>{session.agentConfigId}</code> v{session.agentConfigVersion}
+          </span>
+          <span>
+            env <code>{session.envConfigId}</code>
+          </span>
+          {session.sandboxId === undefined ? null : (
+            <span>
+              sandbox <code>{session.sandboxId}</code>
+            </span>
+          )}
+        </p>
+      )}
+
+      <div className="chat-card">
+        <div
+          className="chat-log"
+          ref={log}
+          onScroll={(event) => {
+            const pane = event.currentTarget;
+            pinned.current = pane.scrollHeight - pane.scrollTop - pane.clientHeight < PINNED_PX;
+          }}
+        >
+          {failure !== undefined ? (
+            <div className="chat-state">
+              <p className="chat-state-title">Couldn&rsquo;t load this session</p>
+              <p>{failure}</p>
+              <button className="btn" type="button" onClick={reread}>
+                <RefreshIcon />
+                Try again
+              </button>
+            </div>
+          ) : state.status === "error" ? (
+            <div className="chat-state">
+              <p className="chat-state-title">Couldn&rsquo;t load the log</p>
+              <p>{state.message}</p>
+              <button className="btn" type="button" onClick={reload}>
+                <RefreshIcon />
+                Try again
+              </button>
+            </div>
+          ) : state.status === "loading" ? (
+            <div className="chat-state">
+              <p>Loading the log…</p>
+            </div>
+          ) : // Nothing in the log, and nothing on its way to it. A REFUSED
+          // message doesn't count as on its way: leaving the pitch out for
+          // one would leave an empty card saying nothing at all.
+          state.entries.length === 0 && !pending.some(inFlight) ? (
+            <div className="chat-state">
+              <p className="chat-state-title">Nothing said yet</p>
+              <p>The first message you send is the one that starts the agent working.</p>
+            </div>
+          ) : (
+            <div className="chat-turns">
+              <Transcript entries={state.entries} now={now} />
+            </div>
+          )}
+        </div>
+
+        {archived ? (
+          <p className="chat-closed">
+            This session is archived. Its log stays readable, and it takes no new message.
+          </p>
+        ) : (
+          <form className="chat-compose" onSubmit={submit}>
+            {/* What has been sent but isn't in the log yet, stacked above
+                the box that sent it. Here rather than in the transcript
+                because that is exactly what it is: a message on its way,
+                not a line of the conversation — the agent has not been
+                given a queued one at all until its current turn ends. */}
+            {pending.length === 0 ? null : (
+              <ul className="chat-queue">
+                {pending.map((message) => (
+                  <li
+                    className={inFlight(message) ? "chat-queued" : "chat-queued chat-queued-bad"}
+                    key={message.id}
+                  >
+                    <span className="chat-queued-row">
+                      <span className="chat-queued-state">
+                        {message.state === "queued"
+                          ? "Queued"
+                          : message.state === "failed"
+                            ? "Failed"
+                            : message.state === "unconfirmed"
+                              ? "Unconfirmed"
+                              : "Sending…"}
+                      </span>
+                      <span className="chat-queued-text" title={message.text}>
+                        {message.text}
+                      </span>
+                      {inFlight(message) ? null : (
+                        <span className="chat-queued-actions">
+                          {/* Only a refusal may be sent again: see deliver. */}
+                          {message.state === "failed" ? (
+                            <button type="button" onClick={() => retry(message)}>
+                              Retry
+                            </button>
+                          ) : null}
+                          <button type="button" onClick={() => discard(message)}>
+                            Discard
+                          </button>
+                        </span>
+                      )}
+                    </span>
+                    {message.error === undefined ? null : (
+                      <p className="chat-queued-error" role="alert">
+                        {message.error}
+                        {message.state === "unconfirmed"
+                          ? " It may have been sent even so — if it was, it joins the conversation" +
+                            " when the current turn ends."
+                          : null}
+                      </p>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+            <div className="chat-compose-row">
+              <textarea
+                className="compose-box"
+                ref={box}
+                aria-label="Message"
+                rows={1}
+                value={draft}
+                placeholder="Send a message…"
+                disabled={session === undefined}
+                onChange={(event) => setDraft(event.target.value)}
+                onKeyDown={keyDown}
+              />
+              <button
+                className="btn btn-primary compose-send"
+                type="submit"
+                disabled={draft.trim() === "" || session === undefined}
+              >
+                <SendIcon />
+                Send
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/pages/Sessions.tsx
+++ b/apps/web/src/pages/Sessions.tsx
@@ -1,25 +1,32 @@
 // apps/web/src/pages/Sessions.tsx
-// The Session section: the namespace's sessions, newest first.
+// The Session section: the namespace's sessions, newest first, and the
+// conversation behind any one of them.
 //
-// A session is one agent config version, one copy of an env recipe, and the
-// durable entry log the two run against. This is an inventory read — three
-// columns, no row link, nothing to open — because what makes a session
-// worth clicking into is its log and its message box, and those come later.
-// Nothing here creates one either: that takes an agent config AND an env
-// config, which is the Quick Start flow rather than a button on a list.
+// `#/session/<id>` is a PAGE rather than a dialog over the list, which is
+// where this section parts company with the two config ones. A config is a
+// form you open, change and close; a session is a place you stay, watching
+// a log grow, so it takes the pane (see SessionDetail).
 //
 // "Status" here is the LIFECYCLE — active or archived — not liveness. There
 // is no running/idle column because the api has no such field: funky
 // derives whether a session is working from its work items and its log
 // rather than storing it on the row (see lib/api.ts Session).
+import { useRef, useState } from "react";
 import { type Session, listSessions } from "../lib/api";
 import { RELATIVE_TICK_MS, absoluteTime, relativeTime } from "../lib/format";
 import { type FetchPage, SKELETON, useList } from "../lib/useList";
 import { useNow } from "../lib/useNow";
-import { RefreshIcon, SessionIcon } from "../components/Icons";
-import { Status, type StatusMeaning } from "../components/Status";
+import { PlusIcon, RefreshIcon, SessionIcon } from "../components/Icons";
+import { Status } from "../components/Status";
+import { SESSION_STATUS } from "../lib/status";
+import type { PageProps } from "../nav";
+import { CreateSession } from "./CreateSession";
+import { SessionDetail } from "./SessionDetail";
 import "./list.css";
 import "./Sessions.css";
+
+/** This section's own route. Rows link into it by id. */
+const SECTION = "#/session";
 
 /**
  * The api hides archived sessions unless asked; this list asks. Archive is
@@ -33,19 +40,35 @@ import "./Sessions.css";
  */
 const listAll: FetchPage<Session> = (opts) => listSessions({ ...opts, includeArchived: true });
 
-/** What the pill means on a session, which is not what it means on a config
- *  (components/Status.tsx): archiving one closes client writes rather than
- *  edits, and the log it leaves behind stays readable. */
-const MEANING: StatusMeaning = {
-  active: "Accepts messages, and a worker can pick its work up",
-  archived: "read-only: it takes no new message, and its log stays readable",
-};
+/**
+ * `route` is the session id below this section. Keyed on it, so moving
+ * between two conversations starts the second one clean rather than
+ * showing it the first one's draft.
+ */
+export function Sessions({ route }: PageProps) {
+  return route === "" ? <SessionList /> : <SessionDetail id={route} key={route} />;
+}
 
-export function Sessions() {
+function SessionList() {
   const { state, more, reload, loadMore } = useList<Session>(listAll);
   // Relative timestamps are only true at the moment they render, so the
   // clock they read has to keep moving.
   const now = useNow(RELATIVE_TICK_MS);
+  const [creating, setCreating] = useState(false);
+  // The header's Start button, which every state of this page renders — and
+  // where focus goes back to if what opened the dialog was the empty
+  // state's button, since the row it creates replaces that button.
+  const startButton = useRef<HTMLButtonElement>(null);
+
+  /** A session just made, with its first message already sent. Creating one
+   *  is how you get to the conversation, so this goes there rather than
+   *  putting a row on a list the reader is about to leave. */
+  function opened(session: Session) {
+    setCreating(false);
+    // An assignment, so Back returns to this list — the same history the
+    // rows' own links write.
+    window.location.hash = `${SECTION}/${session.id}`;
+  }
 
   return (
     <section className="list sessions">
@@ -60,6 +83,15 @@ export function Sessions() {
           >
             <RefreshIcon />
             Refresh
+          </button>
+          <button
+            className="btn btn-primary"
+            type="button"
+            ref={startButton}
+            onClick={() => setCreating(true)}
+          >
+            <PlusIcon />
+            Start
           </button>
         </div>
       </header>
@@ -81,8 +113,12 @@ export function Sessions() {
           <p className="notice-title">No sessions yet</p>
           <p className="notice-body">
             A session pairs an agent config with an env config and runs them against an append-only
-            log. Start one by posting both ids to <code>/v1/sessions</code>.
+            log. Start one here, or post both ids to <code>/v1/sessions</code>.
           </p>
+          <button className="btn btn-primary" type="button" onClick={() => setCreating(true)}>
+            <PlusIcon />
+            Start session
+          </button>
         </div>
       ) : (
         <div className="table-wrap">
@@ -111,14 +147,17 @@ export function Sessions() {
                   ))
                 : state.items.map((session) => (
                     <tr key={session.id}>
-                      {/* Plain text, not a link: there is nowhere to go yet,
-                          and list.css only highlights a row that opens
-                          something. */}
                       <td>
-                        <span className="id">{session.id}</span>
+                        {/* One real anchor, stretched over the row by CSS:
+                            the whole row opens the conversation, and it is
+                            still a link — focusable, middle-clickable,
+                            copyable. */}
+                        <a className="id row-link" href={`${SECTION}/${session.id}`}>
+                          {session.id}
+                        </a>
                       </td>
                       <td>
-                        <Status archivedAt={session.archivedAt} meaning={MEANING} />
+                        <Status archivedAt={session.archivedAt} meaning={SESSION_STATUS} />
                       </td>
                       <td>
                         <time dateTime={session.createdAt} title={absoluteTime(session.createdAt)}>
@@ -131,6 +170,14 @@ export function Sessions() {
           </table>
         </div>
       )}
+
+      {creating ? (
+        <CreateSession
+          onCreated={opened}
+          onClose={() => setCreating(false)}
+          returnFocus={startButton}
+        />
+      ) : null}
 
       {state.status === "ready" && state.hasMore ? (
         <div className="list-more">

--- a/apps/web/src/pages/Transcript.css
+++ b/apps/web/src/pages/Transcript.css
@@ -1,0 +1,160 @@
+/* apps/web/src/pages/Transcript.css
+   The conversation itself: two kinds of bubble, the folds that hold what
+   happened between them, and the asides for a log row that is neither.
+   The frame around all of it — the header, the scroller, the composer —
+   is pages/SessionDetail.css. Every colour resolves to a token in
+   index.css. */
+
+.turn {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  max-width: 100%;
+}
+
+/* The side a turn sits on is who is speaking, which is the one thing a
+   transcript should never make you read to know. */
+.turn-user {
+  align-items: flex-end;
+}
+
+.turn-agent {
+  align-items: flex-start;
+}
+
+.bubble {
+  max-width: min(80%, 660px);
+  padding: 11px 14px;
+  border-radius: var(--r-lg);
+  font-size: 14px;
+  line-height: 1.62;
+  color: var(--text);
+  /* A url or a stack frame breaks rather than stretching the column. */
+  overflow-wrap: anywhere;
+}
+
+.bubble-user {
+  border: 1px solid var(--accent-line);
+  background: var(--accent-soft);
+  /* What was typed, newlines included. Only the user's side: an agent's
+     text is markdown, and its own blocks carry their own whitespace
+     (components/Markdown.css). */
+  white-space: pre-wrap;
+  /* The corner nearest its own edge, squared off, so the two sides read as
+     addressed rather than merely aligned. */
+  border-bottom-right-radius: var(--r-sm);
+}
+
+.bubble-agent {
+  border: 1px solid var(--border);
+  background: var(--bg-elev);
+  box-shadow: var(--shadow-sm);
+  border-bottom-left-radius: var(--r-sm);
+}
+
+/* Everything a turn is made of stacks the same way — a fold, a paragraph, a
+   code block, the line saying how it ended. The markdown blocks are children
+   of the bubble too (Markdown renders a fragment, not a wrapper), so one
+   rule spaces all of it and no block has to know what follows it. */
+.bubble-agent > * + * {
+  margin-top: 11px;
+}
+
+/* A heading earns a little more air above it than between two paragraphs;
+   that is most of what makes it read as a heading here. */
+.bubble-agent > * + .md-h {
+  margin-top: 15px;
+}
+
+/* Why a turn ended, when that isn't simply "it answered". */
+.turn-outcome {
+  font-size: 12.5px;
+  color: var(--text-3);
+}
+
+.turn-outcome.bad {
+  color: var(--bad);
+}
+
+.turn-meta,
+.turn-time {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 3px;
+  font-size: 11.5px;
+  color: var(--text-3);
+}
+
+.turn-model {
+  font: 500 11px var(--mono);
+}
+
+/* Folds ------------------------------------------------------------------
+   Thinking, tool calls and tool results: real rows of the log, and the
+   reason an answer says what it says. One line each until asked, so the
+   conversation stays a conversation. */
+
+.fold {
+  align-self: stretch;
+  max-width: 100%;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--bg-sunken);
+}
+
+.fold-head {
+  padding: 7px 12px;
+  font-size: 12.5px;
+  color: var(--text-3);
+  cursor: pointer;
+  /* The disclosure triangle is the affordance; the row is the target. */
+  list-style-position: inside;
+}
+
+.fold-head:hover {
+  color: var(--text-2);
+}
+
+.fold-name {
+  font: 500 12px var(--mono);
+  color: var(--text-2);
+}
+
+.fold-error .fold-head {
+  color: var(--bad);
+}
+
+.fold-body {
+  margin: 0;
+  padding: 0 12px 11px 12px;
+  max-height: 320px;
+  overflow: auto;
+  font: 400 12px var(--mono);
+  line-height: 1.55;
+  color: var(--text-2);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  scrollbar-width: thin;
+}
+
+/* Asides ----------------------------------------------------------------- */
+
+/* A log row a conversation has no line for — a cancel, a compaction, an
+   app's own payload. Marked rather than dropped: the log is additive, so
+   an unrecognised row means this reader is behind, not that nothing
+   happened. */
+.aside {
+  align-self: center;
+  padding: 2px 10px;
+  border-radius: 999px;
+  background: var(--bg-sunken);
+  font-size: 11.5px;
+  color: var(--text-3);
+}
+
+@container pane (max-width: 620px) {
+  .bubble {
+    max-width: 92%;
+  }
+}

--- a/apps/web/src/pages/Transcript.tsx
+++ b/apps/web/src/pages/Transcript.tsx
@@ -1,0 +1,173 @@
+// apps/web/src/pages/Transcript.tsx
+// The session log as a conversation: what the user said, what the model
+// answered, and — folded away — the work it did in between.
+//
+// Everything here is IN the log. A message this client has sent that the
+// log doesn't hold yet is not part of the transcript and isn't drawn as
+// one; it waits by the composer that sent it (see the queue in
+// SessionDetail.tsx).
+//
+// The log carries more than a chat does. Thinking blocks, tool calls and
+// tool results are all real rows of it, and dropping them would make the
+// transcript claim the model answered out of nowhere; showing them expanded
+// would bury the answer. Each is a native <details>, so the summary is one
+// line, the payload is one click, and no state here decides which.
+//
+// A type this file doesn't know is marked, never skipped silently: the log
+// is append-only and additive by design, so an unknown row means a reader
+// that is behind — which is worth saying rather than hiding.
+import type {
+  AssistantMessage,
+  SessionEntry,
+  TextContent,
+  ToolResultMessage,
+  UserMessage,
+} from "../lib/api";
+import { absoluteTime, relativeTime } from "../lib/format";
+import { Markdown } from "../components/Markdown";
+import "./Transcript.css";
+
+/** The plain text of a message's content, which is all a bubble shows.
+ *  Images are named rather than drawn — the log stores them base64, and a
+ *  transcript is not a gallery. */
+function textOf(message: UserMessage | ToolResultMessage): string {
+  return message.content
+    .map((part) => (part.type === "text" ? part.text : `[${part.mimeType}]`))
+    .join("\n");
+}
+
+/** How a turn ended, when that is not simply "it answered". Tool use is the
+ *  ordinary middle of a turn and says nothing worth a line. */
+function outcomeOf(message: AssistantMessage): string | undefined {
+  switch (message.stopReason) {
+    case "max_tokens":
+      return "Stopped at the token limit";
+    case "aborted":
+      return "Cancelled";
+    case "error":
+      return message.errorMessage ?? "The turn failed";
+    default:
+      return undefined;
+  }
+}
+
+function Time({ at, now }: { at: string; now: number }) {
+  return (
+    <time className="turn-time" dateTime={at} title={absoluteTime(at)}>
+      {relativeTime(at, now)}
+    </time>
+  );
+}
+
+/** One assistant turn: its text as prose, with the thinking and the calls
+ *  that produced it folded above it. */
+function Assistant({ message }: { message: AssistantMessage }) {
+  const text = message.content.filter((part): part is TextContent => part.type === "text");
+  const outcome = outcomeOf(message);
+  return (
+    <>
+      {message.content.map((part, index) =>
+        part.type === "thinking" ? (
+          <details className="fold" key={index}>
+            <summary className="fold-head">
+              {part.thinking === "" ? "Thinking (redacted by the provider)" : "Thinking"}
+            </summary>
+            {part.thinking === "" ? null : <p className="fold-body">{part.thinking}</p>}
+          </details>
+        ) : part.type === "toolCall" ? (
+          <details className="fold" key={index}>
+            <summary className="fold-head">
+              Called <span className="fold-name">{part.name}</span>
+            </summary>
+            <pre className="fold-body">{JSON.stringify(part.arguments, null, 2)}</pre>
+          </details>
+        ) : null,
+      )}
+      {/* Markdown, because that is what a model writes: fences, lists and
+          emphasis are the shape of the answer, not decoration on it. A
+          USER bubble stays literal text — nobody typing into a chat box
+          means their asterisks as italics. */}
+      {text.map((part, index) => (
+        <Markdown text={part.text} key={index} />
+      ))}
+      {outcome === undefined ? null : (
+        <p className={message.stopReason === "error" ? "turn-outcome bad" : "turn-outcome"}>
+          {outcome}
+        </p>
+      )}
+    </>
+  );
+}
+
+/** One entry, as a line of the conversation or as the aside that stands in
+ *  for one. */
+function Entry({ entry, now }: { entry: SessionEntry; now: number }) {
+  // Everything that is not a message, INCLUDING what this reader has never
+  // heard of. The wire types are hand-mirrored and the json is cast, not
+  // validated, so a newer api adding an entry type reaches here typed as
+  // something it isn't — and reading `entry.message` off it would take the
+  // whole transcript down. The log is additive by design, so this case is
+  // expected rather than exceptional, and the last branch is what the
+  // compiler calls unreachable and the network calls Tuesday.
+  if (entry.type !== "message") {
+    return (
+      <p className="aside">
+        {entry.type === "control"
+          ? "Cancel requested"
+          : entry.type === "compaction"
+            ? `Compacted through #${entry.upToSeq}`
+            : entry.type === "custom"
+              ? `Custom entry (${entry.namespace})`
+              : "An entry this console doesn't know yet"}
+      </p>
+    );
+  }
+
+  const { message } = entry;
+  if (message.role === "user") {
+    return (
+      <div className="turn turn-user">
+        <div className="bubble bubble-user">{textOf(message)}</div>
+        <Time at={entry.timestamp} now={now} />
+      </div>
+    );
+  }
+  if (message.role === "toolResult") {
+    return (
+      <details className={message.isError ? "fold fold-error" : "fold"}>
+        <summary className="fold-head">
+          {message.isError ? "Failed" : "Result"} from{" "}
+          <span className="fold-name">{message.toolName}</span>
+        </summary>
+        <pre className="fold-body">{textOf(message)}</pre>
+      </details>
+    );
+  }
+  // Same rule one level down: a role this console doesn't know is marked,
+  // not rendered as an assistant turn whose fields it would then be reading
+  // off a message that hasn't got them.
+  if (message.role !== "assistant") {
+    return <p className="aside">A message this console doesn&rsquo;t know yet</p>;
+  }
+  return (
+    <div className="turn turn-agent">
+      <div className="bubble bubble-agent">
+        <Assistant message={message} />
+      </div>
+      <span className="turn-meta">
+        <span className="turn-model">{message.model}</span>
+        <Time at={entry.timestamp} now={now} />
+      </span>
+    </div>
+  );
+}
+
+export function Transcript({ entries, now }: { entries: SessionEntry[]; now: number }) {
+  return (
+    <>
+      {entries.map((entry) => (
+        <Entry entry={entry} key={entry.id} now={now} />
+      ))}
+    </>
+  );
+}


### PR DESCRIPTION
The Session section gains a dialog that starts a session — agent config, env config and first message — and the route behind every row, `#/session/<id>`, which is a page rather than a dialog over the list: a session is somewhere you stay while a log grows, so it takes the pane, a transcript read once and then followed with an EventSource, and a composer at the bottom.

A queued message is not in the log — intake parks it in its own table until the current turn ends — so sends that haven't landed sit above the composer saying which they are rather than posing as transcript, and which entry settles which send is decided by acknowledgement rather than age.

Neither route takes an idempotency key, so only the api *refusing* a request is treated as proof it wasn't written: a refusal offers to be sent again, while anything unanswered doesn't — an unconfirmed message keeps its text and points at the conversation, and an unconfirmed create strands the dialog with a Close, since there's no id to open and no way to ask.

Assistant turns render as the markdown they were written as, hand-rolled at ~1 kB gzipped rather than taking the console's first runtime dependency past React (it emits a tree, never html, and leaves non-http link schemes as literal text); tool calls, results and thinking fold away, an unknown entry type is marked rather than crashing the transcript, and all of it was verified against the running stack in a real browser, including the lost-response paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)