### PR TITLE
Make sessions archivable from the console

### DIFF
--- a/apps/web/src/components/Modal.css
+++ b/apps/web/src/components/Modal.css
@@ -160,41 +160,32 @@ body:has(dialog.modal[open]) {
   color: var(--bad);
 }
 
-/* Archive is the footer's left-hand action, so the two buttons that answer
+/* Archive is the footer's LEFT-hand action, so the two buttons that answer
    the form — Cancel and Save — stay together on the right, and the one that
    ends the config isn't sitting among them.
 
-   Red in the label, not in a fill: this button archives on the click, but a
-   filled red beside the filled cobalt Save would fight it, and the
-   destructive one is the wrong one to win. The hue is the warning. */
-.btn-archive {
+   Placement only: the red label is .btn-archive's own (index.css), shared
+   with the session page, which places the same button for itself. Scoped to
+   this footer so that one is free to. */
+.modal-foot .btn-archive {
   margin-right: auto;
-  color: var(--bad);
 }
 
-/* .btn's hover resolves the label to var(--text), which would drop the one
-   thing this button says about itself. The surface is left alone, so the
-   label holds 5.25:1 (light) / 8.02:1 (dark) in every state. */
-.btn-archive:hover:not(:disabled) {
-  color: var(--bad);
-  border-color: var(--bad);
-}
-
-/* Modal.css gives .form-failure the auto margin that pushes it left. With
-   an Archive button already taking the footer's spare width there is none
-   left to share, and the refusal belongs beside the action that caused it
-   rather than spread away from it. */
-.btn-archive ~ .form-failure {
+/* .form-failure takes the footer's spare width to push itself left. With an
+   Archive button already taking it there is none left to share, and the
+   refusal belongs beside the action that caused it rather than spread away
+   from it. */
+.modal-foot .btn-archive ~ .form-failure {
   margin-right: 0;
 }
 
-/* Modal.css stacks the footer below 440px and stretches every button. An
-   auto margin in the cross axis takes precedence over align-items, so
-   leaving this one would strand Archive at content width beside two
-   full-width buttons — the placement it buys is a row concept only. Keep
-   this threshold in step with that one. */
+/* The footer stacks below 440px and stretches every button. An auto margin
+   in the cross axis takes precedence over align-items, so leaving this one
+   would strand Archive at content width beside two full-width buttons — the
+   placement it buys is a row concept only. Keep this threshold in step with
+   the one that does the stacking. */
 @media (max-width: 440px) {
-  .btn-archive {
+  .modal-foot .btn-archive {
     margin-right: 0;
   }
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -198,6 +198,25 @@ a {
   box-shadow: 0 6px 16px -6px var(--brand-shadow);
 }
 
+/* The destructive weight: red in the label, never in a fill. The filled red
+   was tried beside the filled cobalt Save and cut, because it out-shouted
+   it and the destructive one is the wrong one to win. The hue is the whole
+   of the warning — every surface that draws this button archives on the
+   click. Where it SITS is that surface's business (.modal-foot puts it at
+   the footer's left, .chat-head at the head's right); what it says about
+   itself is here, so the two cannot drift apart. */
+.btn-archive {
+  color: var(--bad);
+}
+
+/* .btn's hover resolves the label to var(--text), which would drop the one
+   thing this button says about itself. The surface is left alone, so the
+   label holds 5.25:1 (light) / 8.02:1 (dark) in every state. */
+.btn-archive:hover:not(:disabled) {
+  color: var(--bad);
+  border-color: var(--bad);
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -483,6 +483,34 @@ export function createSession(
   return post<Session>("/v1/sessions", { namespace: DEFAULT_NAMESPACE, ...input }, {}, opts.signal);
 }
 
+/**
+ * Archives a session and returns it carrying the mark. Terminal, and the
+ * api has no route back: the log stays readable and every client write
+ * closes with it — no further message, no cancel, no sandbox rebinding.
+ *
+ * Unlike a config's archive this one can be REFUSED. The api takes the
+ * transition only while the session is IDLE and answers 409 while a work
+ * item is still open, and nothing on the wire says which a session is —
+ * running is derived from its items rather than stored on the row (see
+ * Session) — so the refusal is the only way to find out.
+ *
+ * A message parked behind a cancelled run is drained into the log by the
+ * same transaction, so the log can grow at the very moment it closes.
+ * Idempotent otherwise: a second call answers with the first one's
+ * archivedAt rather than failing.
+ */
+export function archiveSession(id: string, opts: { signal?: AbortSignal } = {}): Promise<Session> {
+  return post<Session>(
+    `/v1/sessions/${encodeURIComponent(id)}/archive`,
+    // No body, because the route takes none — there is nothing to say
+    // beyond "retire this". JSON.stringify(undefined) is undefined, which
+    // fetch sends as no body at all.
+    undefined,
+    { namespace: DEFAULT_NAMESPACE },
+    opts.signal,
+  );
+}
+
 // --- the session log ---
 //
 // Messages are what the model sees; entries are what the store owns. The

--- a/apps/web/src/lib/useEntries.ts
+++ b/apps/web/src/lib/useEntries.ts
@@ -55,11 +55,31 @@ export function useEntries(id: string, tail: boolean) {
    */
   const live = tail && start !== undefined && !dropped;
 
-  function reload() {
-    setState({ status: "loading" });
+  /**
+   * Read the log again, keeping the rows already on screen until the answer
+   * lands: they are still true, and this is only asking what has joined
+   * them.
+   *
+   * What ARCHIVING needs. The transition can append — a message parked
+   * behind a cancelled run is drained into the log by the same transaction
+   * — and it closes the tail in the same move, since an archived session
+   * has nothing left to follow. The stream polls, so those last entries
+   * would be written just after the only thing watching for them went away,
+   * and the page would sit on a log one short of final with no way to ask
+   * again.
+   */
+  function refresh() {
     setStart(undefined);
     setDropped(false);
     setReloads((n) => n + 1);
+  }
+
+  /** The same read, from empty. What a failed load's retry does: what is on
+   *  screen there is an error rather than a log, so there is nothing to
+   *  hold on to while the read is in flight. */
+  function reload() {
+    setState({ status: "loading" });
+    refresh();
   }
 
   useEffect(() => {
@@ -110,5 +130,5 @@ export function useEntries(id: string, tail: boolean) {
     return () => source.close();
   }, [id, tail, start]);
 
-  return { state, live, reload };
+  return { state, live, reload, refresh };
 }

--- a/apps/web/src/pages/SessionDetail.css
+++ b/apps/web/src/pages/SessionDetail.css
@@ -47,9 +47,14 @@
 
 /* Head ------------------------------------------------------------------- */
 
+/* Wraps, because it is no longer three short marks: with Archive on the end
+   the row is four items wide, and the pane it sits in narrows to whatever
+   the window leaves it. A second line is better than an overflow, which has
+   no scrollbar here to find it with. */
 .chat-head {
   display: flex;
   flex: none;
+  flex-wrap: wrap;
   align-items: center;
   gap: 12px;
   margin-bottom: 12px;
@@ -83,6 +88,31 @@
   background: var(--ok);
   box-shadow: 0 0 0 3px var(--ok-glow);
   opacity: 1;
+}
+
+/* Pushed to the far end, so the head reads left to right as identity then
+   action: back, state, tail, and the one thing that ends it. On a wrapped
+   row it takes a line of its own, still right-aligned. */
+.chat-archive {
+  margin-left: auto;
+}
+
+/* The api's refusal of an archive. Under the head rather than in it: this
+   is a sentence, and the head is a row of things two words long — putting
+   it there would either clip it or push the button that caused it off the
+   end. */
+.chat-refused {
+  flex: none;
+  margin-bottom: 12px;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--bad);
+}
+
+/* What the refusal above MEANS, on its own line: the api's message is the
+   claim and this is the reading of it, and the two are not one sentence. */
+.chat-refused-why {
+  display: block;
 }
 
 .chat-id {
@@ -257,8 +287,16 @@
   cursor: pointer;
 }
 
-.chat-queued-actions button:hover {
+.chat-queued-actions button:hover:not(:disabled) {
   color: var(--text);
+}
+
+/* Retry is a send, so an archive in flight takes it away like it takes the
+   composer's (see SessionDetail.tsx submit). Discard stays: it writes
+   nothing, and it is the way out of a message that has none. */
+.chat-queued-actions button:disabled {
+  color: var(--text-3);
+  cursor: default;
 }
 
 .chat-queued-error {

--- a/apps/web/src/pages/SessionDetail.tsx
+++ b/apps/web/src/pages/SessionDetail.tsx
@@ -9,8 +9,10 @@
 //
 // The transcript is pages/Transcript.tsx; the loading and following of the
 // log is lib/useEntries.ts. What is left here is the session row itself,
-// the composer, and the one thing neither of those can know: which of the
-// messages this client has sent are still missing from the log (Sent).
+// the composer, Archive — the one control on this page that changes the
+// session rather than adding to it — and the one thing none of those can
+// know: which of the messages this client has sent are still missing from
+// the log (Sent).
 import {
   type FormEvent,
   type KeyboardEvent,
@@ -24,6 +26,7 @@ import {
   type Session,
   type SessionEntry,
   type UserMessage,
+  archiveSession,
   getSession,
   sendMessage,
 } from "../lib/api";
@@ -166,12 +169,18 @@ export function SessionDetail({ id }: { id: string }) {
   // Bumped to re-read the session row. Its own counter, because the log has
   // one of its own (useEntries) and either read can fail without the other.
   const [reads, setReads] = useState(0);
+  const [archiving, setArchiving] = useState(false);
+  // The api's refusal of an archive, and whether it was the ONE refusal
+  // this page can explain: 409, the session is still working. Its own
+  // state, not `failure` above — that one means the session row would not
+  // load, and this page has plenty to show while this is set.
+  const [refused, setRefused] = useState<{ message: string; running: boolean }>();
   const now = useNow(RELATIVE_TICK_MS);
 
   const archived = session?.archivedAt !== undefined;
   // Follow the log only while there is something that could still write to
   // it, and only once the row that says so has arrived.
-  const { state, live, reload } = useEntries(id, session !== undefined && !archived);
+  const { state, live, reload, refresh } = useEntries(id, session !== undefined && !archived);
 
   const log = useRef<HTMLDivElement>(null);
   const box = useRef<HTMLTextAreaElement>(null);
@@ -197,6 +206,43 @@ export function SessionDetail({ id }: { id: string }) {
     setFailure(undefined);
     setReads((n) => n + 1);
     reload();
+  }
+
+  /**
+   * Retire the session. Terminal, taken on the click — the red label is the
+   * whole of the warning, as it is in the config dialogs — but unlike a
+   * config's archive this one can be REFUSED: the api takes the transition
+   * only while the session is idle, and answers 409 while a worker still
+   * has an item open.
+   *
+   * Which is why there is no disabled state for it. Nothing this console
+   * can read says whether a session is running — funky derives that from
+   * its work items rather than storing it on the row — so a button greyed
+   * out on a guess would be wrong in both directions. The api's answer is
+   * the only one there is, so it is asked, and its refusal is reported.
+   */
+  async function archive() {
+    if (archiving || archived) return;
+    setRefused(undefined);
+    setArchiving(true);
+    try {
+      setSession(await archiveSession(id));
+      // The same transaction drains a message parked behind a cancelled run
+      // into the log, and the row above has just closed the tail that would
+      // have carried it — an archived session is one this page stops
+      // following. One more read, so what is on screen is the whole of a log
+      // that can no longer change.
+      refresh();
+    } catch (err) {
+      setRefused({
+        message: messageOf(err),
+        running: err instanceof ApiError && err.status === 409,
+      });
+    } finally {
+      // Unconditional: a refusal has to leave the button pressable again,
+      // and a success has already taken it off the page.
+      setArchiving(false);
+    }
   }
 
   const entries = state.status === "ready" ? state.entries : EMPTY;
@@ -270,7 +316,13 @@ export function SessionDetail({ id }: { id: string }) {
   async function submit(event: FormEvent) {
     event.preventDefault();
     const text = draft.trim();
-    if (text === "" || archived) return;
+    // `archiving` gates this as firmly as `archived` does. A message sent
+    // while the transition is in flight races it, and BOTH outcomes are
+    // wrong: intake opens a work item, so a message that wins refuses the
+    // archive the reader just asked for (409, idle only) — and one that
+    // loses is refused BY the archive and then hidden with the composer
+    // its bubble was drawn in, taking the text with it.
+    if (text === "" || archived || archiving) return;
 
     // Sent at the tail as this client last saw it. Anything at or behind
     // this seq was already in the log, so it cannot be this message.
@@ -298,8 +350,11 @@ export function SessionDetail({ id }: { id: string }) {
 
   /** Send a refused message again. Offered only where the api refused it —
    *  an unconfirmed one has no retry, because nothing this console can read
-   *  would say whether it needs one (see deliver). */
+   *  would say whether it needs one (see deliver). Held back while an
+   *  archive is in flight for the same reason a first send is (see
+   *  submit) — this is a send like any other, just of an older message. */
   function retry(message: Sent) {
+    if (archiving || archived) return;
     setSent((prev) =>
       prev.map((row) =>
         row.id === message.id
@@ -336,14 +391,44 @@ export function SessionDetail({ id }: { id: string }) {
           <>
             <Status archivedAt={session.archivedAt} meaning={SESSION_STATUS} />
             {archived ? null : (
-              <span className={live ? "live live-on" : "live"}>
-                <span className="live-dot" aria-hidden="true" />
-                {live ? "Live" : "Reconnecting…"}
-              </span>
+              <>
+                <span className={live ? "live live-on" : "live"}>
+                  <span className="live-dot" aria-hidden="true" />
+                  {live ? "Live" : "Reconnecting…"}
+                </span>
+                {/* At the far end, away from the back link and the two
+                    marks beside it that only report: this is the one
+                    control in the head that changes the session, and the
+                    one with nothing on the other side of it. */}
+                <button
+                  className="btn btn-archive chat-archive"
+                  type="button"
+                  onClick={archive}
+                  disabled={archiving}
+                >
+                  {archiving ? "Archiving…" : "Archive"}
+                </button>
+              </>
             )}
           </>
         )}
       </header>
+
+      {refused === undefined ? null : (
+        <p className="chat-refused" role="alert">
+          {/* The api's own words first, as everywhere else in this console,
+              and this page's reading of them on a line of its own — the
+              messages end without punctuation, so a clause appended to one
+              would run into it as a single sentence. */}
+          {refused.message}
+          {refused.running ? (
+            <span className="chat-refused-why">
+              Archive takes an idle session, and this one still has a run open — it can be taken
+              once that turn ends.
+            </span>
+          ) : null}
+        </p>
+      )}
 
       <p className="chat-id">{id}</p>
 
@@ -453,7 +538,11 @@ export function SessionDetail({ id }: { id: string }) {
                         <span className="chat-queued-actions">
                           {/* Only a refusal may be sent again: see deliver. */}
                           {message.state === "failed" ? (
-                            <button type="button" onClick={() => retry(message)}>
+                            <button
+                              type="button"
+                              onClick={() => retry(message)}
+                              disabled={archiving}
+                            >
                               Retry
                             </button>
                           ) : null}
@@ -484,14 +573,14 @@ export function SessionDetail({ id }: { id: string }) {
                 rows={1}
                 value={draft}
                 placeholder="Send a message…"
-                disabled={session === undefined}
+                disabled={session === undefined || archiving}
                 onChange={(event) => setDraft(event.target.value)}
                 onKeyDown={keyDown}
               />
               <button
                 className="btn btn-primary compose-send"
                 type="submit"
-                disabled={draft.trim() === "" || session === undefined}
+                disabled={draft.trim() === "" || session === undefined || archiving}
               >
                 <SendIcon />
                 Send


### PR DESCRIPTION
The session detail page gains Archive at the end of its head — terminal, taken on the click, the red label being the whole of the warning, as in the two config dialogs. Unlike a config's archive it can be refused: the api takes the transition only from an idle session, and nothing on the wire says which a session is, so the button asks rather than guessing and reports the 409 under the head with this page's reading of it on a line of its own. Message writes are held back while it is in flight, since a send that raced the transition either refuses the archive the reader just asked for or is refused by it and then hidden along with the composer, taking the text with it. `useEntries` gains `refresh()` beside `reload()` — archive drains a parked message into the log and closes the tail in the same move, and `/stream` polls, so those last entries would otherwise be written just after the only thing watching for them went away — and `.btn-archive` splits, the red label moving to `index.css` and only the footer placement staying in `Modal.css`, scoped to `.modal-foot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)