### PR TITLE
Drop Active from the session head, and Live unless it drops

### DIFF
--- a/apps/web/src/pages/SessionDetail.css
+++ b/apps/web/src/pages/SessionDetail.css
@@ -66,8 +66,11 @@
   text-decoration: none;
 }
 
-/* Whether the tail is connected. Dimmed until it is — a reconnect is
-   ordinary, so this reports rather than warns. */
+/* The tail, off. There is no mark for the other side of it — a stream
+   that is keeping up has nothing to report — so this appears only when
+   the log has stopped following, and its absence is the good news.
+   Dimmed even so: EventSource retries by itself, so a reconnect is
+   ordinary and this reports rather than warns. */
 .live {
   display: inline-flex;
   align-items: center;
@@ -84,15 +87,11 @@
   opacity: 0.55;
 }
 
-.live-on .live-dot {
-  background: var(--ok);
-  box-shadow: 0 0 0 3px var(--ok-glow);
-  opacity: 1;
-}
-
 /* Pushed to the far end, so the head reads left to right as identity then
-   action: back, state, tail, and the one thing that ends it. On a wrapped
-   row it takes a line of its own, still right-aligned. */
+   action: back, whatever the marks above have to report, and the one thing
+   that ends the session. Margin rather than a spacer, because on a head
+   with nothing to report it is the only thing after the back link. On a
+   wrapped row it takes a line of its own, still right-aligned. */
 .chat-archive {
   margin-left: auto;
 }

--- a/apps/web/src/pages/SessionDetail.tsx
+++ b/apps/web/src/pages/SessionDetail.tsx
@@ -387,29 +387,40 @@ export function SessionDetail({ id }: { id: string }) {
           <ArrowLeftIcon />
           Sessions
         </a>
-        {session === undefined ? null : (
+        {session === undefined ? null : archived ? (
+          // Only the ARCHIVED half of the lifecycle is marked here. The
+          // list needs both, because a row there has nothing else to say
+          // which it is — but this page IS the active state: it has a
+          // composer taking messages and an Archive button to end it with.
+          // A pill repeating that said nothing, and said it in the same
+          // green dot as the mark below, which is about something else
+          // entirely.
+          <Status archivedAt={session.archivedAt} meaning={SESSION_STATUS} />
+        ) : (
           <>
-            <Status archivedAt={session.archivedAt} meaning={SESSION_STATUS} />
-            {archived ? null : (
-              <>
-                <span className={live ? "live live-on" : "live"}>
-                  <span className="live-dot" aria-hidden="true" />
-                  {live ? "Live" : "Reconnecting…"}
-                </span>
-                {/* At the far end, away from the back link and the two
-                    marks beside it that only report: this is the one
-                    control in the head that changes the session, and the
-                    one with nothing on the other side of it. */}
-                <button
-                  className="btn btn-archive chat-archive"
-                  type="button"
-                  onClick={archive}
-                  disabled={archiving}
-                >
-                  {archiving ? "Archiving…" : "Archive"}
-                </button>
-              </>
-            )}
+            {/* Not the session's state — THIS CLIENT'S. The log follows a
+                stream, and this is shown only where that has come off:
+                while it is attached the transcript keeps itself current,
+                and a mark saying so is a green light that is always on.
+                Held back until the log has loaded, too, since a tail not
+                opened yet is not a tail that dropped. */}
+            {state.status === "ready" && !live ? (
+              <span className="live">
+                <span className="live-dot" aria-hidden="true" />
+                Reconnecting…
+              </span>
+            ) : null}
+            {/* At the far end, away from the back link: this is the one
+                control in the head that changes the session, and the one
+                with nothing on the other side of it. */}
+            <button
+              className="btn btn-archive chat-archive"
+              type="button"
+              onClick={archive}
+              disabled={archiving}
+            >
+              {archiving ? "Archiving…" : "Archive"}
+            </button>
           </>
         )}
       </header>


### PR DESCRIPTION
The session page's head carried two green dots side by side that meant different things — "Active" was the row's lifecycle, "Live" was this client's connection to the log — with nothing saying which was which, and both lit whenever nothing was wrong.

"Active" goes: this page *is* the active state, with a composer taking messages and an Archive button to end it with, so the pill now draws only its ARCHIVED half. "Live" is shown only where it isn't, as "Reconnecting…" alone, held until the log has loaded — which also fixes the old head claiming to reconnect a tail it had never opened. `.live-on` and a stale placement comment go with it.

What neither mark ever said, and still doesn't, is whether the agent is working right now: nothing on the wire carries it, the same reason Archive has no disabled state. Verified with `tsc -b` and `oxlint`; not checked in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)