### PR TITLE
Serve the web console from docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
-# Dockerfile (repo root) — ONE image for the whole workspace, in two
-# stages: compile the three entries with the full toolchain, then lay the
-# bundles beside a pruned production install. Runs the api by default;
-# the migrate one-shot and the worker are the SAME image with a different
-# command (ratified: one image, two commands).
+# Dockerfile (repo root) — ONE image for the api, the migrator and the
+# worker, in two stages: compile the three entries with the full toolchain,
+# then lay the bundles beside a pruned production install. Runs the api by
+# default; the migrate one-shot and the worker are the SAME image with a
+# different command (ratified: one image, two commands).
 #
 # The bundles carry the workspace source (@funky/* is bundled in); npm
 # dependencies stay external and come from the prod install — so the
 # runtime image ships no TypeScript, no tsx, no dev toolchain.
+#
+# The console (`--target web`) is the one process that can't live in that
+# image — vite serves it, and vite is a dev dependency — so it gets a stage
+# of its own. That stage sits in the MIDDLE deliberately: the default target
+# is whichever stage comes last, and the default has to stay the api's.
 
 FROM node:22-slim AS build
 ENV PNPM_HOME=/pnpm
@@ -27,6 +32,29 @@ COPY packages/adapters/package.json packages/adapters/
 RUN pnpm install --frozen-lockfile
 COPY . .
 RUN pnpm build
+
+# The console (apps/web), served by `vite preview`: the built bundle plus
+# the dev server's /v1 proxy, which preview reuses as-is (vite resolves
+# `preview.proxy ?? server.proxy`). That proxy is why this is a server and
+# not a folder of static files — the api has no CORS and is bearer-authed,
+# so the console never calls it directly. The token is attached HERE and
+# never enters the browser, exactly as in dev (apps/web/vite.config.ts).
+#
+# The stage IS the build stage: vite is a dev dependency, so there is no
+# pruned install to lay a bundle beside. Those layers are already built for
+# the stage above, so this target adds nothing to the build — it is a fat
+# image by the standard of the two below, and it is a dev console.
+#
+# `pnpm build` again at START, rather than shipping the bundle the stage
+# above already made: WHICH providers the console offers is compiled into
+# the bundle from the keys in the environment, and those are runtime
+# values. Building here is what lets a key added to .env show up on a plain
+# `docker compose up`, with no --build. It costs about three seconds of
+# boot — `tsc -b` finds the buildinfo from the image build and no-ops,
+# leaving vite's second-long pass.
+FROM build AS web
+EXPOSE 5173
+CMD ["sh", "-c", "pnpm --filter web run build && exec pnpm --filter web run preview --host --port 5173"]
 
 FROM node:22-slim
 ENV NODE_ENV=production

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ lost and no side effect run twice.
 
 Requires Docker, an [E2B](https://e2b.dev) API key, and a key for at least one model
 provider: [Anthropic](https://console.anthropic.com), [OpenAI](https://platform.openai.com),
-[Google](https://aistudio.google.com/apikey), or [Together AI](https://api.together.ai). A
-config's `inference.provider` names which one runs it; see [Model providers](#model-providers).
+[Google](https://aistudio.google.com/apikey), or [Together AI](https://api.together.ai).
 
 ```bash
 git clone https://github.com/funkyhq/funky && cd funky
@@ -22,8 +21,16 @@ cp .env.example .env        # the auth token, a model-provider key, and the E2B 
 docker compose up --build
 ```
 
-The stack is postgres → a one-shot migration → the api (`:3000`) + a worker; it's up when
-the `api` service reports healthy. Then:
+You can interact with the Funky service through Web UI or CURL.
+
+**The console**, at <http://localhost:5173>. Define an agent, give it an environment, start a
+session, and watch the log stream live — all in the browser. It proxies the api and attaches
+the token itself, so no credential ever reaches the page.
+
+<!-- TODO: replace this comment with the console screenshot, e.g.
+     <img alt="The Funky Console" src="PASTE_GITHUB_ATTACHMENT_URL_HERE"> -->
+
+**The api**, at `localhost:3000` — bearer-authed, and the same five steps with curl:
 
 ```bash
 export TOKEN=<your FUNKY_AUTH_TOKEN>
@@ -130,6 +137,7 @@ in-flight work dies with it. Funky decouples them:
 | `packages/adapters` | The port implementations: Postgres store (drizzle), AI SDK inference, E2B sandboxes              |
 | `apps/api`          | The HTTP surface (Hono): configs, sessions, intake, cancel, inspection, the SSE stream           |
 | `apps/worker`       | The runDriver host — the process a container runs                                                |
+| `apps/web`          | The browser console over the api (React + Vite); compose serves it on `:5173`                    |
 
 ## Development
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -33,8 +33,11 @@ file `docker compose up` reads, so there is no second copy to keep in sync, and 
 never enters the client bundle. Point it elsewhere with `FUNKY_API_URL` (default
 `http://localhost:3000`).
 
-So: start the stack (`docker compose up`), then `pnpm -F web dev`. With the api down, the
-proxy answers 502 and the console says it can't reach it.
+`docker compose up` serves exactly this on `:5173`, with `vite preview` over a built bundle
+in place of the dev server — `preview.proxy` falls back to `server.proxy`, so it is the same
+proxy, reading the same variables out of the container's environment. Run `pnpm -F web dev`
+against the stack when you want hot reload. With the api down, the proxy answers 502 and the
+console says it can't reach it.
 
 ## Brand
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 # docker-compose.yml (repo root) — the funky stack: postgres + migrate +
-# api + worker, all four from the topology the harness was designed around.
+# api + worker, all four from the topology the harness was designed around,
+# with the browser console in front of the api.
 #
 # Bring up:   FUNKY_AUTH_TOKEN=... E2B_API_KEY=... ANTHROPIC_API_KEY=... \
 #             docker compose up --build   (or put them in .env; any model-provider
@@ -80,6 +81,47 @@ services:
     depends_on:
       migrate:
         condition: service_completed_successfully
+    restart: unless-stopped
+
+  # The browser console (apps/web), on http://localhost:5173. It is a client
+  # of the api like curl is — no database, no share of the work — so it can
+  # be stopped without touching a run: `docker compose up -d --scale web=0`.
+  #
+  # `vite preview` serves it, which is a dev server serving a production
+  # bundle, and that is the point: it carries the /v1 proxy that attaches
+  # FUNKY_AUTH_TOKEN to every request. The api has no CORS and is
+  # bearer-authed, so the console never calls it directly and the token
+  # never enters the browser (apps/web/vite.config.ts).
+  web:
+    build:
+      context: .
+      # NOT the default stage — the console needs vite, which the pruned
+      # runtime image the other three share does not carry.
+      target: web
+    ports:
+      # Loopback only, where the api publishes wide — and the asymmetry is
+      # the point. The api on 0.0.0.0 is still bearer-authed; this proxy on
+      # 0.0.0.0 HANDS OUT the bearer token, so anyone who could reach the
+      # port would have the api without one. Vite's allowedHosts doesn't
+      # cover it either: IP-literal Host headers pass by default, so it
+      # stops DNS rebinding, not a request to 192.168.x.x. Reach a remote
+      # stack's console through an SSH tunnel rather than widening this.
+      - "127.0.0.1:5173:5173"
+    environment:
+      FUNKY_API_URL: http://api:3000 # ← service name, not localhost
+      FUNKY_AUTH_TOKEN: ${FUNKY_AUTH_TOKEN:?set FUNKY_AUTH_TOKEN in .env — any random string, ≥16 chars}
+      # The same keys the worker takes, and for the same reason — but only
+      # their PRESENCE is read here. The console offers a provider when the
+      # stack has a key for it, and compiles the ids into the bundle at
+      # container start; no key VALUE reaches the browser, same rule as
+      # FUNKY_AUTH_TOKEN above.
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      GOOGLE_GENERATIVE_AI_API_KEY: ${GOOGLE_GENERATIVE_AI_API_KEY:-}
+      TOGETHER_API_KEY: ${TOGETHER_API_KEY:-}
+    depends_on:
+      api:
+        condition: service_healthy
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
`docker compose up` now brings up the browser console too — a fifth service on <http://localhost:5173>, with no application code changed; the Quickstart names both ways in (console or curl) and carries a commented-out slot for a screenshot still to be added.

`vite preview` serves it from a new `web` Dockerfile stage: vite resolves `preview.proxy ?? server.proxy`, so preview reuses the dev server's `/v1` proxy verbatim — token injection included — which is why the console is a server here rather than static files behind nginx (the api has no CORS and is bearer-authed).

The bundle is rebuilt at container start (~3s; `tsc -b` no-ops off the image build) rather than baked in, so a provider key added to `.env` shows up without a `--build`.

It publishes on `127.0.0.1` where the api publishes wide, because the api on `0.0.0.0` is still bearer-authed while this proxy *hands that token out* — measured before that fix, from the machine's LAN address `:5173/v1/agent-configs` answered 200 where `:3000/v1/agent-configs` answered 401.

Also verified live: SSE streams unbuffered through the preview proxy, and the served bundle compiled exactly the providers whose keys were set on the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)