### PR TITLE
Offer Gemini 3.8 Flash in the console's Google list

### DIFF
--- a/apps/web/src/lib/providers.ts
+++ b/apps/web/src/lib/providers.ts
@@ -60,7 +60,7 @@ export const KNOWN_PROVIDERS: Provider[] = [
     envKey: "GOOGLE_GENERATIVE_AI_API_KEY",
     models: [
       { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro (preview)" },
-      { id: "gemini-3.7-flash", label: "Gemini 3.7 Flash" },
+      { id: "gemini-3.8-flash", label: "Gemini 3.8 Flash" },
       { id: "gemini-3.5-flash-lite", label: "Gemini 3.5 Flash-Lite" },
     ],
   },


### PR DESCRIPTION
Google shipped `gemini-3.8-flash` GA on 2026-09-02, so the console's Google entry now offers it. The table holds the newest of each tier, so this replaces the 3.7 Flash entry rather than adding a fourth beside Pro and Flash-Lite.

One line is the whole change because the worker's `VENDORS` table maps a provider id to an env var and an SDK factory, not to models — model ids pass through per request, so the worker could already serve this one. Configs still pinned to `gemini-3.7-flash` keep working: `EditAgentConfig` runs the saved model through `withCurrent`, which keeps a model the console can't enumerate in the dropdown instead of switching it. `pnpm -F web typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)