### PR TITLE
Add xAI to the vendor table

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,8 @@ OPENAI_API_KEY=
 GOOGLE_GENERATIVE_AI_API_KEY=
 # "togetherai" — https://api.together.ai
 TOGETHER_API_KEY=
+# "xai" — https://console.x.ai
+XAI_API_KEY=
 
 # The worker's sandbox provider (E2B) — https://e2b.dev
 E2B_API_KEY=

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ lost and no side effect run twice.
 
 Requires Docker, an [E2B](https://e2b.dev) API key, and a key for at least one model
 provider: [Anthropic](https://console.anthropic.com), [OpenAI](https://platform.openai.com),
-[Google](https://aistudio.google.com/apikey), or [Together AI](https://api.together.ai).
+[Google](https://aistudio.google.com/apikey), [Together AI](https://api.together.ai), or
+[xAI](https://console.x.ai).
 
 ```bash
 git clone https://github.com/funkyhq/funky && cd funky
@@ -101,6 +102,7 @@ the session's config names, so one stack runs sessions on different vendors side
 | `openai`             | `OPENAI_API_KEY`               |
 | `google`             | `GOOGLE_GENERATIVE_AI_API_KEY` |
 | `togetherai`         | `TOGETHER_API_KEY`             |
+| `xai`                | `XAI_API_KEY`                  |
 
 Inference goes through the [Vercel AI SDK](https://ai-sdk.dev) behind a vendor-neutral
 port.

--- a/apps/web/src/lib/providers.ts
+++ b/apps/web/src/lib/providers.ts
@@ -76,6 +76,14 @@ export const KNOWN_PROVIDERS: Provider[] = [
       { id: "moonshotai/Kimi-K3", label: "Kimi K3" },
     ],
   },
+  {
+    // One release line rather than tiers, so only the newest is listed.
+    // Any xAI model id works through the api.
+    id: "xai",
+    label: "xAI",
+    envKey: "XAI_API_KEY",
+    models: [{ id: "grok-4.6", label: "Grok 4.6" }],
+  },
 ];
 
 // Replaced at build time by vite.config.ts (`define`), so this is a literal

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -21,6 +21,7 @@ const PROVIDER_ENV_KEYS: Record<string, string> = {
   openai: "OPENAI_API_KEY",
   google: "GOOGLE_GENERATIVE_AI_API_KEY",
   togetherai: "TOGETHER_API_KEY",
+  xai: "XAI_API_KEY",
 };
 
 export default defineConfig(({ mode }) => {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -13,6 +13,7 @@
     "@ai-sdk/google": "^4.0.0",
     "@ai-sdk/openai": "^4.0.0",
     "@ai-sdk/togetherai": "^3.0.0",
+    "@ai-sdk/xai": "^4.0.0",
     "@funky/adapters": "workspace:*",
     "@funky/agent": "workspace:*",
     "@funky/core": "workspace:*",

--- a/apps/worker/src/providers.ts
+++ b/apps/worker/src/providers.ts
@@ -15,6 +15,7 @@ import { createAnthropic } from "@ai-sdk/anthropic";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOpenAI } from "@ai-sdk/openai";
 import { createTogetherAI } from "@ai-sdk/togetherai";
+import { createXai } from "@ai-sdk/xai";
 import type { LanguageModel } from "ai";
 import { createAiSdkProvider } from "@funky/adapters";
 import type { InferenceProvider } from "@funky/agent";
@@ -52,6 +53,11 @@ export const VENDORS: readonly Vendor[] = [
     id: "togetherai",
     envKey: "TOGETHER_API_KEY",
     languageModel: (apiKey) => createTogetherAI({ apiKey }),
+  },
+  {
+    id: "xai",
+    envKey: "XAI_API_KEY",
+    languageModel: (apiKey) => createXai({ apiKey }),
   },
 ];
 

--- a/apps/worker/test/config.test.ts
+++ b/apps/worker/test/config.test.ts
@@ -58,6 +58,7 @@ describe("loadConfig — model provider keys", () => {
       OPENAI_API_KEY: "test-openai-key",
       GOOGLE_GENERATIVE_AI_API_KEY: "test-google-key",
       TOGETHER_API_KEY: "test-together-key",
+      XAI_API_KEY: "test-xai-key",
     });
     expect(cfg.providerKeys).toEqual(
       new Map([
@@ -65,6 +66,7 @@ describe("loadConfig — model provider keys", () => {
         ["openai", "test-openai-key"],
         ["google", "test-google-key"],
         ["togetherai", "test-together-key"],
+        ["xai", "test-xai-key"],
       ]),
     );
   });
@@ -88,7 +90,7 @@ describe("loadConfig — model provider keys", () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining(
-        "ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY, TOGETHER_API_KEY",
+        "ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY, TOGETHER_API_KEY, XAI_API_KEY",
       ),
     );
   });

--- a/apps/worker/test/providers.test.ts
+++ b/apps/worker/test/providers.test.ts
@@ -5,6 +5,7 @@ import { createAnthropic } from "@ai-sdk/anthropic";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOpenAI } from "@ai-sdk/openai";
 import { createTogetherAI } from "@ai-sdk/togetherai";
+import { createXai } from "@ai-sdk/xai";
 import { VENDORS, wireProviders } from "../src/providers";
 
 vi.mock("@ai-sdk/anthropic", () => ({ createAnthropic: vi.fn(() => () => "anthropic-model") }));
@@ -13,12 +14,14 @@ vi.mock("@ai-sdk/google", () => ({
 }));
 vi.mock("@ai-sdk/openai", () => ({ createOpenAI: vi.fn(() => () => "openai-model") }));
 vi.mock("@ai-sdk/togetherai", () => ({ createTogetherAI: vi.fn(() => () => "together-model") }));
+vi.mock("@ai-sdk/xai", () => ({ createXai: vi.fn(() => () => "xai-model") }));
 
 const ALL_KEYS = new Map([
   ["anthropic", "k-anthropic"],
   ["openai", "k-openai"],
   ["google", "k-google"],
   ["togetherai", "k-together"],
+  ["xai", "k-xai"],
 ]);
 
 describe("VENDORS", () => {
@@ -33,7 +36,13 @@ describe("VENDORS", () => {
 describe("wireProviders", () => {
   it("wires one adapter per key, under the vendor's id", () => {
     const providers = wireProviders(ALL_KEYS);
-    expect([...providers.keys()].sort()).toEqual(["anthropic", "google", "openai", "togetherai"]);
+    expect([...providers.keys()].sort()).toEqual([
+      "anthropic",
+      "google",
+      "openai",
+      "togetherai",
+      "xai",
+    ]);
     for (const provider of providers.values()) expect(typeof provider.stream).toBe("function");
   });
 
@@ -43,6 +52,7 @@ describe("wireProviders", () => {
     expect(createOpenAI).toHaveBeenCalledWith({ apiKey: "k-openai" });
     expect(createGoogleGenerativeAI).toHaveBeenCalledWith({ apiKey: "k-google" });
     expect(createTogetherAI).toHaveBeenCalledWith({ apiKey: "k-together" });
+    expect(createXai).toHaveBeenCalledWith({ apiKey: "k-xai" });
   });
 
   it("wires nothing for a vendor without a key, and nothing for an id off the table", () => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,7 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       GOOGLE_GENERATIVE_AI_API_KEY: ${GOOGLE_GENERATIVE_AI_API_KEY:-}
       TOGETHER_API_KEY: ${TOGETHER_API_KEY:-}
+      XAI_API_KEY: ${XAI_API_KEY:-}
       E2B_API_KEY: ${E2B_API_KEY:?set E2B_API_KEY in .env}
     depends_on:
       migrate:
@@ -119,6 +120,7 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       GOOGLE_GENERATIVE_AI_API_KEY: ${GOOGLE_GENERATIVE_AI_API_KEY:-}
       TOGETHER_API_KEY: ${TOGETHER_API_KEY:-}
+      XAI_API_KEY: ${XAI_API_KEY:-}
     depends_on:
       api:
         condition: service_healthy

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
       '@ai-sdk/togetherai':
         specifier: ^3.0.0
         version: 3.0.8(zod@4.4.3)
+      '@ai-sdk/xai':
+        specifier: ^4.0.0
+        version: 4.0.54(zod@4.4.3)
       '@funky/adapters':
         specifier: workspace:*
         version: link:../../packages/adapters
@@ -263,11 +266,21 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@5.0.36':
+    resolution: {integrity: sha512-MFXBn6XDyf37PNQAge/HTatPJE8Vmg/g/w4WPtjSV53jq8FKAzoaN5+43hsdQa9bqgN+/13jxug9ChvsG+godQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@5.0.7':
     resolution: {integrity: sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.10':
+    resolution: {integrity: sha512-fX2ENAc7iDpZ+Wp4+Rk06Usn/Ys7dI9uAkGv0jlF6XVrW13NkRWx5Ou+U6lIM2E1fTLkCs16GGrUAaVvroag7A==}
+    engines: {node: '>=22'}
 
   '@ai-sdk/provider@4.0.3':
     resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
@@ -275,6 +288,12 @@ packages:
 
   '@ai-sdk/togetherai@3.0.8':
     resolution: {integrity: sha512-Z1pioqTBQ27/ZoRHgrB397alftlqovdqBEDACvD29dNqWotkFaJPWBRjWzosvM0hrXDYIdw9IZHkDD3L5cKYPA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/xai@4.0.54':
+    resolution: {integrity: sha512-SYw8087hDU0PxTlkRrBz/Xj1zy3FUK8RA4tuxm32TqktTXsENYTG4XqyqRO3E4Pc3HhXcBJNqPjkyz8nsbpjKA==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1697,6 +1716,10 @@ packages:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
+  undici@7.29.1:
+    resolution: {integrity: sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==}
+    engines: {node: '>=20.18.1'}
+
   update-browserslist-db@1.3.2:
     resolution: {integrity: sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==}
     hasBin: true
@@ -1872,6 +1895,15 @@ snapshots:
       '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
       zod: 4.4.3
 
+  '@ai-sdk/provider-utils@5.0.36(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.10
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      undici: 7.29.1
+      zod: 4.4.3
+
   '@ai-sdk/provider-utils@5.0.7(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.3
@@ -1879,6 +1911,10 @@ snapshots:
       '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
       zod: 4.4.3
+
+  '@ai-sdk/provider@4.0.10':
+    dependencies:
+      json-schema: 0.4.0
 
   '@ai-sdk/provider@4.0.3':
     dependencies:
@@ -1889,6 +1925,12 @@ snapshots:
       '@ai-sdk/openai-compatible': 3.0.7(zod@4.4.3)
       '@ai-sdk/provider': 4.0.3
       '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/xai@4.0.54(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.10
+      '@ai-sdk/provider-utils': 5.0.36(zod@4.4.3)
       zod: 4.4.3
 
   '@babel/code-frame@7.29.7':
@@ -2919,6 +2961,8 @@ snapshots:
   undici-types@7.18.2: {}
 
   undici@7.28.0: {}
+
+  undici@7.29.1: {}
 
   update-browserslist-db@1.3.2(browserslist@4.28.8):
     dependencies:


### PR DESCRIPTION
Adds xAI as a fifth model provider: one row in the worker's `VENDORS` table and one in the console's `KNOWN_PROVIDERS`, which is exactly what `providers.ts`'s own header says adding a vendor should cost. The id is `xai` (the `@ai-sdk/xai` package suffix) and the key is `XAI_API_KEY` (the variable that SDK reads by default), so a key already exported for it works unchanged — `.env.example`, both compose services and the README table follow. No adapter change was needed: `createXai` fits the `languageModel` factory type directly, and `aisdk.ts` already closes a tool call on the assembled `tool-call` part, which covers a vendor that streams no input parts. The console offers Grok 4.6 alone, since xAI's ids are one release line rather than capability tiers, and any xAI model id still works through the api as with Together.

Not smoke-tested against the real API — there is no xAI key on this machine — but typecheck, the full suite and both builds pass, and the built artifacts were checked rather than assumed (the worker bundle keeps `@ai-sdk/xai` external for the Dockerfile's prod install; the web bundle's provider filter carries `xai` when a key is present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)