### PR TITLE
Offer Claude Fable 5.1 in the console's model list

### DIFF
--- a/apps/web/src/lib/providers.ts
+++ b/apps/web/src/lib/providers.ts
@@ -28,7 +28,9 @@ export type Provider = {
   label: string;
   /** The env var the stack reads its key from; mirrored in vite.config.ts. */
   envKey: string;
-  /** Newest of each tier. Ids are complete as written — no date suffix. */
+  /** Newest of each tier. Ids are complete as written — no date suffix.
+   *  The FIRST is where a new config starts (lib/agent.ts), so the order
+   *  is a claim about what to reach for by default, not just a list. */
   models: ProviderModel[];
 };
 
@@ -39,7 +41,13 @@ export const KNOWN_PROVIDERS: Provider[] = [
     label: "Anthropic",
     envKey: "ANTHROPIC_API_KEY",
     models: [
+      // Opus 5 leads because it is the default, not because the list is
+      // sorted: strongest general-purpose model of the four, and what a
+      // first agent should meet a sandbox with. The rest follow it
+      // strongest-first, Fable included — a tier above Opus and priced
+      // above it, so it is chosen by name rather than landed on.
       { id: "claude-opus-5", label: "Claude Opus 5" },
+      { id: "claude-fable-5-1", label: "Claude Fable 5.1" },
       { id: "claude-sonnet-5", label: "Claude Sonnet 5" },
       { id: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
     ],


### PR DESCRIPTION
Anthropic shipped Fable 5.1, so `claude-fable-5-1` joins the Anthropic entry in the console's model dropdown — the one place in the repo that enumerates models at all, since everywhere else an id is a pass-through string (the worker's table is per-vendor, and the AI SDK's Anthropic model-id type ends in `(string & {})`, so nothing needed a version bump to route it).

Position in that list is load-bearing, which is what the new comment is for: `lib/agent.ts` starts a new config on `models[0]`, in the create dialog and the Quick Start alike. So the list is ordered default-first rather than by price — Opus 5 keeps the lead as the strongest general-purpose model to hand a fresh sandbox with a bash tool, and Fable follows it as the tier above, chosen by name rather than landed on at twice Opus's per-token price.

Worth knowing and deliberately not fixed: Fable rejects `temperature`, `top_p` and `top_k` with a 400, and while the console never writes `inference.temperature`, a config created through the api with both a temperature and this model will fail at inference time — a check there would be the first model-specific rule in a deliberately vendor-neutral port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)